### PR TITLE
feat(bv) inline ratings widget

### DIFF
--- a/packages/bodiless-bv/__tests__/BVInlineRatings.test.tsx
+++ b/packages/bodiless-bv/__tests__/BVInlineRatings.test.tsx
@@ -18,29 +18,25 @@ import { shallow } from 'enzyme';
 
 jest.mock('../src/components/BVLoader');
 jest.mock('../src/components/asBVComponent', () => ({
-  asDesignableBVComponent: () => (Component: CT) => (props: any) => (
-    <Component {...props} />
-  ),
+  asDesignableBVComponent: () => (Component: CT) => (props: any) => <Component {...props} />,
 }));
 jest.mock('../src/components/asEditableBV');
 
-const creatBVReviews = () => {
-  let BVReviews;
+const creatBVInlineRatings = () => {
+  let BVInlineRatings;
   // @ts-ignore no types defined for jest.isolateModules
   jest.isolateModules(() => {
     // eslint-disable-next-line global-require,prefer-destructuring
-    BVReviews = require('../src/components/v2/BVReviews').BVReviewsBase;
+    BVInlineRatings = require('../src/components/v2/BVInlineRatings').BVInlineRatingsBase;
   });
-  return BVReviews;
+  return BVInlineRatings;
 };
 
-describe('bv reviews', () => {
+describe('bv inline ratings', () => {
   it('renders according to BV specification', () => {
-    const BVReviews = creatBVReviews();
+    const BVInlineRatings = creatBVInlineRatings();
     // @ts-ignore
-    const wrapper = shallow(<BVReviews productId="123" />);
-    expect(wrapper.html()).toBe(
-      '<div data-bv-show="reviews" data-bv-product-id="123"></div>',
-    );
+    const wrapper = shallow(<BVInlineRatings productId="123" />);
+    expect(wrapper.html()).toBe('<div data-bv-show="inline_rating" data-bv-product-id="123"></div>');
   });
 });

--- a/packages/bodiless-bv/__tests__/BVReviewsV1.test.tsx
+++ b/packages/bodiless-bv/__tests__/BVReviewsV1.test.tsx
@@ -14,13 +14,22 @@
 
 import React, { ComponentType as CT } from 'react';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
+
+type BVProps = {
+  productId: string | number;
+};
 
 jest.mock('../src/components/BVLoader');
 jest.mock('../src/components/asBVComponent', () => ({
-  asDesignableBVComponent: () => (Component: CT) => (props: any) => (
-    <Component {...props} />
-  ),
+  asDesignableBVComponent: (
+    name: string,
+    onLoaded: (bvprops: BVProps) => void,
+  ) => (Component: CT) => (props: any) => {
+    const { productId } = props;
+    onLoaded({ productId });
+    return <Component {...props} />;
+  },
 }));
 jest.mock('../src/components/asEditableBV');
 
@@ -29,7 +38,7 @@ const creatBVReviews = () => {
   // @ts-ignore no types defined for jest.isolateModules
   jest.isolateModules(() => {
     // eslint-disable-next-line global-require,prefer-destructuring
-    BVReviews = require('../src/components/v2/BVReviews').BVReviewsBase;
+    BVReviews = require('../src/components/v1/BVReviews').BVReviewsBase;
   });
   return BVReviews;
 };
@@ -39,8 +48,19 @@ describe('bv reviews', () => {
     const BVReviews = creatBVReviews();
     // @ts-ignore
     const wrapper = shallow(<BVReviews productId="123" />);
-    expect(wrapper.html()).toBe(
-      '<div data-bv-show="reviews" data-bv-product-id="123"></div>',
-    );
+    expect(wrapper.html()).toBe('<div id="BVRRContainer"></div>');
+  });
+  it('triggers $BV.ui method once $BV is initialized', () => {
+    // @ts-ignore
+    window.$BV = {};
+    // @ts-ignore
+    const BVMock = window.$BV.ui = jest.fn(); // eslint-disable-line no-multi-assign
+    const BVReviews = creatBVReviews();
+    const testProductId = 123;
+    // @ts-ignore
+    mount(<BVReviews productId={testProductId} />);
+    expect(BVMock.mock.calls[0][0]).toBe('rr');
+    expect(BVMock.mock.calls[0][1]).toBe('show_reviews');
+    expect(BVMock.mock.calls[0][2]).toStrictEqual({ productId: testProductId });
   });
 });

--- a/packages/bodiless-bv/__tests__/asBVComponent.test.tsx
+++ b/packages/bodiless-bv/__tests__/asBVComponent.test.tsx
@@ -14,7 +14,7 @@
 
 import React from 'react';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { shallow, mount } from 'enzyme';
+import { mount } from 'enzyme';
 import BVProductIsNotMapped from '../src/components/BVErrors';
 import BVPlaceholder from '../src/components/BVPlaceholder';
 import BVLoading from '../src/components/BVLoading';
@@ -40,7 +40,7 @@ const creatAsBVComponent = () => {
   // @ts-ignore no types defined for jest.isolateModules
   jest.isolateModules(() => {
     // eslint-disable-next-line global-require,prefer-destructuring
-    asBVComponent = require('../src/components/asBVComponent').default;
+    asBVComponent = require('../src/components/asBVComponent').asDesignableBVComponent;
   });
   return asBVComponent;
 };
@@ -52,8 +52,8 @@ describe('asBVComponent', () => {
     const asBVComponent = creatAsBVComponent();
     // @ts-ignore
     const BVComponent = asBVComponent()(() => <TestComponent />);
-    const wrapper = shallow(<BVComponent productId="" />);
-    expect(wrapper.equals(<BVProductIsNotMapped />)).toBe(true);
+    const wrapper = mount(<BVComponent productId="" />);
+    expect(wrapper.find(BVProductIsNotMapped).length).toBe(1);
   });
   describe('when on edit mode', () => {
     it('renders BVPlaceholder ', () => {
@@ -64,8 +64,10 @@ describe('asBVComponent', () => {
       const asBVComponent = creatAsBVComponent();
       // @ts-ignore
       const BVComponent = asBVComponent(componentName)(() => <TestComponent />);
-      const wrapper = shallow(<BVComponent productId="123" />);
-      expect(wrapper.equals(<BVPlaceholder productId="123" componentName={componentName} />)).toBe(true);
+      const wrapper = mount(<BVComponent productId="123" />);
+      expect(wrapper.find(BVPlaceholder).length).toBe(1);
+      expect(wrapper.find(BVPlaceholder).prop('productId')).toBe('123');
+      expect(wrapper.find(BVPlaceholder).prop('componentName')).toBe(componentName);
     });
   });
   describe('when on preview mode', () => {
@@ -85,11 +87,11 @@ describe('asBVComponent', () => {
       it('renders BVLoading', () => {
         mockBodilessCore(false);
         mockBVLoader(false);
-        const asBVComponent = creatAsBVComponent();
         const TestComponent = () => <></>;
+        const asBVComponent = creatAsBVComponent();
         // @ts-ignore
         const BVComponent = asBVComponent()(() => <TestComponent />);
-        const wrapper = shallow(<BVComponent productId="123" />);
+        const wrapper = mount(<BVComponent productId="123" />);
         expect(wrapper.find(BVLoading).length).toBe(1);
       });
     });

--- a/packages/bodiless-bv/bodiless.docs.json
+++ b/packages/bodiless-bv/bodiless.docs.json
@@ -4,14 +4,26 @@
       "Configuration.md": "./doc/Configuration.md",
       "Components": {
         "BVLoaderProvider.md": "./doc/Components/BVLoaderProvider.md",
-        "BVRatingsSummary.md": "./doc/Components/BVRatingsSummary.md",
-        "BVRatingsSummaryBase.md": "./doc/Components/BVRatingsSummaryBase.md",
-        "BVReviews.md": "./doc/Components/BVReviews.md",
-        "BVReviewsBase.md": "./doc/Components/BVReviewsBase.md"
+        "v1": {
+          "BVRatingsSummary.md": "./doc/Components/v1/BVRatingsSummary.md",
+          "BVRatingsSummaryBase.md": "./doc/Components/v1/BVRatingsSummaryBase.md",
+          "BVReviews.md": "./doc/Components/v1/BVReviews.md",
+          "BVReviewsBase.md": "./doc/Components/v1/BVReviewsBase.md",
+          "BVInlineRatings.md": "./doc/Components/v1/BVInlineRatings.md",
+          "BVInlineRatingsBase.md": "./doc/Components/v1/BVInlineRatingsBase.md"
+        },
+        "v2": {
+          "BVRatingsSummary.md": "./doc/Components/v2/BVRatingsSummary.md",
+          "BVRatingsSummaryBase.md": "./doc/Components/v2/BVRatingsSummaryBase.md",
+          "BVReviews.md": "./doc/Components/v2/BVReviews.md",
+          "BVReviewsBase.md": "./doc/Components/v2/BVReviewsBase.md",
+          "BVInlineRatings.md": "./doc/Components/v2/BVInlineRatings.md",
+          "BVInlineRatingsBase.md": "./doc/Components/v2/BVInlineRatingsBase.md"
+        }
       },
       "HOCs": {
         "asBodilessBV.md": "./doc/HOCs/asBodilessBV.md",
-        "asBVComponent.md": "./doc/HOCs/asBVComponent.md",
+        "asDesignableBVComponent.md": "./doc/HOCs/asDesignableBVComponent.md",
         "asEditableBV.md": "./doc/HOCs/asEditableBV.md",
         "withBVLoader.md": "./doc/HOCs/withBVLoader.md"
       }

--- a/packages/bodiless-bv/doc/Configuration.md
+++ b/packages/bodiless-bv/doc/Configuration.md
@@ -6,7 +6,7 @@ This section describes configuration steps required in order to use BV Component
 
 In order to use BV components, you need to know:
 
-* URL of main Baazarvoice script. Example: https://display.ugc.bazaarvoice.com/bvstaging/static/clientid/main_site/en_US/bvapi.js, or
+* URL of main Baazarvoice script. Example: https://apps.bazaarvoice.com/deployments/<client_name>/<site_ID>/<environment>/<locale>/bv.js, or
 * client_name, site_ID, environment and locale of your Baazarvoice account.
 
 ## How to configure
@@ -14,7 +14,7 @@ In order to use BV components, you need to know:
 In order to connect your BV components to BV service, you need to set BV_SCRIPT environment variable to main BV main script url:
 
 ``` bash
-BV_SCRIPT="https://display.ugc.bazaarvoice.com/bvstaging/static/clientid/main_site/en_US/bvapi.js"
+BV_SCRIPT="https://apps.bazaarvoice.com/deployments/<client_name>/<site_ID>/<environment>/<locale>/bv.js"
 ```
 
 Altenatively, you can set the following environment variables
@@ -24,4 +24,18 @@ BV_CLIENT_NAME='clientid'
 BV_SITE_ID='main_site'
 BV_ENVIRONMENT='staging'
 BV_LOCALE='en_US'
+```
+
+By default, [Display integration V2](https://knowledge.bazaarvoice.com/wp-content/conversations/en_US/Display/display_integration.html) is enabled.
+
+## How to enable Display Integration V1
+
+If you want to enable [Display Intergration V1](https://knowledge.bazaarvoice.com/wp-content/conversations/en_US/Display/display_integration_v1.html)
+
+If you configure the connection by setting BV_SCRIPT in environment variable, then no additional settings is required, just ensure the script you set ends with bvapi.js.
+
+If you configure the connection by setting BV_CLIENT_NAME, BV_SITE_ID, BV_ENVIRONMENT, BV_LOCALE, you need to set the following environment variable
+
+``` bash
+BV_API_VERSION=1
 ```

--- a/packages/bodiless-bv/doc/components/BVLoaderProvider.md
+++ b/packages/bodiless-bv/doc/components/BVLoaderProvider.md
@@ -4,7 +4,7 @@ One can use this component in order to add main Baazarvoice script to the page h
 
 ## Usage
 
-First, you need to compose our custom BV components.
+First, you need to compose your custom BV components.
 
 ``` js
 import { BVRatingsSummaryBase, BVReviewsBase, asBodilessBV } from '@bodiless/bv';

--- a/packages/bodiless-bv/doc/components/v1/BVInlineRatings.md
+++ b/packages/bodiless-bv/doc/components/v1/BVInlineRatings.md
@@ -1,0 +1,17 @@
+# BVInlineRatings
+
+One can use this component in order to add baazarvoice inline ratings widget to the page. The component encapsulates logic to load main baazarvoice script to the page. The component provides ability for content editors to configure BV product mapping via UI.
+
+## Usage
+
+You need to import the component
+
+``` js
+import { BVInlineRatingsV1 } from '@bodiless/bv';
+```
+
+And then you can place the component on a page
+
+``` js
+<BVInlineRatingsV1 />
+```

--- a/packages/bodiless-bv/doc/components/v1/BVInlineRatingsBase.md
+++ b/packages/bodiless-bv/doc/components/v1/BVInlineRatingsBase.md
@@ -1,0 +1,27 @@
+# BVInlineRatingsBase
+
+One can use this component as base component in order to compose his/her custom BV component for rendering BV Inline Ratings widget.
+
+## Usage
+
+You need to import the base component and the list of HOCs to compose your custom BV component
+
+``` js
+import { BVInlineRatingsBaseV1, withBVLoader, asBodilessBV } from '@bodiless/bv';
+import { flowRight } from 'lodash';
+```
+
+Then you need to compose the custom component
+
+``` js
+const CustomBVComponent = flowRight(
+  withBVLoader,
+  asBodilessBV
+)(BVInlineRatingsBaseV1);
+```
+
+Then you can place the custom component on a page
+
+``` js
+<CustomBVComponent />
+```

--- a/packages/bodiless-bv/doc/components/v1/BVRatingsSummary.md
+++ b/packages/bodiless-bv/doc/components/v1/BVRatingsSummary.md
@@ -1,0 +1,17 @@
+# BVRatingsSummary
+
+One can use this component in order to add baazarvoice ratings summary widget to the page. The component encapsulates logic to load main baazarvoice script to the page. The component provides ability for content editors to configure BV product mapping via UI.
+
+## Usage
+
+You need to import the component
+
+``` js
+import { BVRatingsSummaryV1 } from '@bodiless/bv';
+```
+
+And then you can place the component on a page
+
+``` js
+<BVRatingsSummaryV1 />
+```

--- a/packages/bodiless-bv/doc/components/v1/BVRatingsSummaryBase.md
+++ b/packages/bodiless-bv/doc/components/v1/BVRatingsSummaryBase.md
@@ -1,0 +1,27 @@
+# BVRatingsSummaryBase
+
+One can use this component as base component in order to compose his/her custom BV component for rendering BV Ratings Summary widget.
+
+## Usage
+
+You need to import the base component and the list of HOCs to compose your custom BV component
+
+``` js
+import { BVRatingsSummaryBaseV1, withBVLoader, asBodilessBV } from '@bodiless/bv';
+import { flowRight } from 'lodash';
+```
+
+Then you need to compose the custom component
+
+``` js
+const CustomBVComponent = flowRight(
+  withBVLoader,
+  asBodilessBV
+)(BVRatingsSummaryBaseV1);
+```
+
+Then you can place the custom component on a page
+
+``` js
+<CustomBVComponent />
+```

--- a/packages/bodiless-bv/doc/components/v1/BVReviews.md
+++ b/packages/bodiless-bv/doc/components/v1/BVReviews.md
@@ -1,0 +1,17 @@
+# BVReviews
+
+One can use this component in order to add baazarvoice reviews widget to the page. The component encapsulates logic to load main baazarvoice script to the page. The component provides ability for content editors to configure BV product mapping via UI.
+
+## Usage
+
+You need to import the component
+
+``` js
+import { BVReviewsV1 } from '@bodiless/bv';
+```
+
+And then you can place the component on a page
+
+``` js
+<BVReviewsV1 />
+```

--- a/packages/bodiless-bv/doc/components/v1/BVReviewsBase.md
+++ b/packages/bodiless-bv/doc/components/v1/BVReviewsBase.md
@@ -1,0 +1,27 @@
+# BVReviewsBase
+
+One can use this component as base component in order to compose his/her custom BV component for rendering BV Reviews widget.
+
+## Usage
+
+You need to import the base component and the list of HOCs to compose your custom BV component
+
+``` js
+import { BVReviewsBaseV1, withBVLoader, asBodilessBV } from '@bodiless/bv';
+import { flowRight } from 'lodash';
+```
+
+Then you need to compose the custom component
+
+``` js
+const CustomBVComponent = flowRight(
+  withBVLoader,
+  asBodilessBV
+)(BVReviewsBaseV1);
+```
+
+Then you can place the custom component on a page
+
+``` js
+<CustomBVComponent />
+```

--- a/packages/bodiless-bv/doc/components/v2/BVInlineRatings.md
+++ b/packages/bodiless-bv/doc/components/v2/BVInlineRatings.md
@@ -1,0 +1,45 @@
+# BVInlineRatings
+
+One can use this component in order to add baazarvoice inline ratings widget to the page. The component encapsulates logic to load main baazarvoice script to the page. The component provides ability for content editors to configure BV product mapping via UI.
+
+## Usage
+
+You need to import the component
+
+``` js
+import { BVInlineRatings } from '@bodiless/bv';
+```
+
+And then you can place the component on a page
+
+``` js
+const redirectUrl = "http://localhost/testUrl"; // set it you want to include a hyperlink in an inline rating
+const seo = false; // set it if you want to enable/disable rendering of schema.org metadata
+<BVInlineRatings redirectUrl={redirectUrl} seo={seo} />
+```
+
+## Customization
+
+It is possible to customize the component by using Design API. The component exposes:
+
+* BVProductIsNotMapped - component is displayed when BV External ID is not set
+* BVLoading - component is displayed while BV main script is loading
+* BVPlaceholder - component is displayed on edit mode
+
+For instance, you can add some styles to the exposed components
+
+``` js
+const asBVInlineRatingsBlue = withDesign({
+  BVProductIsNotMapped: addClasses('bg-blue text-white p-2 border border-red'),
+  BVPlaceholder: addClasses('bg-blue text-white p-2 border border-red'),
+  BVLoading: addClasses('bg-blue text-white p-2 border border-red'),
+});
+
+const BlueBVInlineRatings = asBVInlineRatingsBlue(BVInlineRatings);
+```
+
+And then you can add your customized component on a page
+
+``` js
+<BlueBVInlineRatings />
+```

--- a/packages/bodiless-bv/doc/components/v2/BVInlineRatingsBase.md
+++ b/packages/bodiless-bv/doc/components/v2/BVInlineRatingsBase.md
@@ -1,0 +1,27 @@
+# BVInlineRatingsBase
+
+One can use this component as base component in order to compose his/her custom BV component for rendering BV Inline Ratings widget.
+
+## Usage
+
+You need to import the base component and the list of HOCs to compose your custom BV component
+
+``` js
+import { BVInlineRatingsBase, withBVLoader, asBodilessBV } from '@bodiless/bv';
+import { flowRight } from 'lodash';
+```
+
+Then you need to compose the custom component
+
+``` js
+const CustomBVComponent = flowRight(
+  withBVLoader,
+  asBodilessBV
+)(BVInlineRatingsBase);
+```
+
+Then you can place the custom component on a page
+
+``` js
+<CustomBVComponent />
+```

--- a/packages/bodiless-bv/doc/components/v2/BVRatingsSummary.md
+++ b/packages/bodiless-bv/doc/components/v2/BVRatingsSummary.md
@@ -1,0 +1,43 @@
+# BVRatingsSummary
+
+One can use this component in order to add baazarvoice ratings summary widget to the page. The component encapsulates logic to load main baazarvoice script to the page. The component provides ability for content editors to configure BV product mapping via UI.
+
+## Usage
+
+You need to import the component
+
+``` js
+import { BVRatingsSummary } from '@bodiless/bv';
+```
+
+And then you can place the component on a page
+
+``` js
+<BVRatingsSummary />
+```
+
+## Customization
+
+It is possible to customize the component by using Design API. The component exposes:
+
+* BVProductIsNotMapped - component is displayed when BV External ID is not set
+* BVLoading - component is displayed while BV main script is loading
+* BVPlaceholder - component is displayed on edit mode
+
+For instance, you can add some styles to the exposed components
+
+``` js
+const asBVRatingsSummaryBlue = withDesign({
+  BVProductIsNotMapped: addClasses('bg-blue text-white p-2 border border-red'),
+  BVPlaceholder: addClasses('bg-blue text-white p-2 border border-red'),
+  BVLoading: addClasses('bg-blue text-white p-2 border border-red'),
+});
+
+const BlueBVRatingsSummary = asBVRatingsSummaryBlue(BVRatingsSummary);
+```
+
+And then you can add your customized component on a page
+
+``` js
+<BlueBVRatingsSummary />
+```

--- a/packages/bodiless-bv/doc/components/v2/BVRatingsSummaryBase.md
+++ b/packages/bodiless-bv/doc/components/v2/BVRatingsSummaryBase.md
@@ -1,0 +1,27 @@
+# BVRatingsSummaryBase
+
+One can use this component as base component in order to compose his/her custom BV component for rendering BV Ratings Summary widget.
+
+## Usage
+
+You need to import the base component and the list of HOCs to compose your custom BV component
+
+``` js
+import { BVRatingsSummaryBase, withBVLoader, asBodilessBV } from '@bodiless/bv';
+import { flowRight } from 'lodash';
+```
+
+Then you need to compose the custom component
+
+``` js
+const CustomBVComponent = flowRight(
+  withBVLoader,
+  asBodilessBV
+)(BVRatingsSummaryBase);
+```
+
+Then you can place the custom component on a page
+
+``` js
+<CustomBVComponent />
+```

--- a/packages/bodiless-bv/doc/components/v2/BVReviews.md
+++ b/packages/bodiless-bv/doc/components/v2/BVReviews.md
@@ -1,0 +1,43 @@
+# BVReviews
+
+One can use this component in order to add baazarvoice reviews widget to the page. The component encapsulates logic to load main baazarvoice script to the page. The component provides ability for content editors to configure BV product mapping via UI.
+
+## Usage
+
+You need to import the component
+
+``` js
+import { BVReviews } from '@bodiless/bv';
+```
+
+And then you can place the component on a page
+
+``` js
+<BVReviews />
+```
+
+## Customization
+
+It is possible to customize the component by using Design API. The component exposes:
+
+* BVProductIsNotMapped - component is displayed when BV External ID is not set
+* BVLoading - component is displayed while BV main script is loading
+* BVPlaceholder - component is displayed on edit mode
+
+For instance, you can add some styles to the exposed components
+
+``` js
+const asBVReviewsBlue = withDesign({
+  BVProductIsNotMapped: addClasses('bg-blue text-white p-2 border border-red'),
+  BVPlaceholder: addClasses('bg-blue text-white p-2 border border-red'),
+  BVLoading: addClasses('bg-blue text-white p-2 border border-red'),
+});
+
+const BlueBVReviews = asBVReviewsBlue(BlueBVReviews);
+```
+
+And then you can add your customized component on a page
+
+``` js
+<BlueBVReviews />
+```

--- a/packages/bodiless-bv/doc/components/v2/BVReviewsBase.md
+++ b/packages/bodiless-bv/doc/components/v2/BVReviewsBase.md
@@ -1,0 +1,27 @@
+# BVReviewsBase
+
+One can use this component as base component in order to compose his/her custom BV component for rendering BV Reviews widget.
+
+## Usage
+
+You need to import the base component and the list of HOCs to compose your custom BV component
+
+``` js
+import { BVReviewsBase, withBVLoader, asBodilessBV } from '@bodiless/bv';
+import { flowRight } from 'lodash';
+```
+
+Then you need to compose the custom component
+
+``` js
+const CustomBVComponent = flowRight(
+  withBVLoader,
+  asBodilessBV
+)(BVReviewsBase);
+```
+
+Then you can place the custom component on a page
+
+``` js
+<CustomBVComponent />
+```

--- a/packages/bodiless-bv/doc/hocs/asDesignableBVComponent.md
+++ b/packages/bodiless-bv/doc/hocs/asDesignableBVComponent.md
@@ -1,0 +1,21 @@
+# asDesignableBVComponent
+
+One can use this HOC in order to compose his/her own BV component. asDesignableBVComponent provides error handling and allows to subscribe to event when main BV script is loaded and $BV object is initialized.
+
+## Usage
+
+You need to import the HOC and compose your component
+
+``` js
+import { asDesignableBVComponent } from '@bodiless/bv';
+
+const MyBVContainer = props => <div id="BVContainer" {...props}></div>;
+const MyBVComponent = asDesignableBVComponent('BV Ratings Summary', () => $BV.ui('rr', 'show_reviews', {productId: 'product_id'}))(MyBVContainer);
+)
+```
+
+Then you can add your component on a page
+
+``` js
+<MyBVComponent />
+```

--- a/packages/bodiless-bv/package.json
+++ b/packages/bodiless-bv/package.json
@@ -22,10 +22,8 @@
   "dependencies": {
     "@bodiless/components": "^0.0.36",
     "@bodiless/core": "^0.0.36",
+    "@bodiless/fclasses": "^0.0.36",
     "lodash": "^4.17.15"
-  },
-  "devDependencies": {
-    "typescript": "^3.5.3"
   },
   "peerDependencies": {
     "react": "^16.11.0",

--- a/packages/bodiless-bv/src/components/BVLoader.tsx
+++ b/packages/bodiless-bv/src/components/BVLoader.tsx
@@ -73,8 +73,8 @@ export const BVLoaderProvider: FC<Props> = ({ children, scriptUrl }) => {
 
 export const useBVLoader = () => useContext(BVLoaderContext);
 
-export const withBVLoader = (Component: CT) => () => (
+export const withBVLoader = <P extends object>(Component: CT<P>) => (props: P) => (
   <BVLoaderProvider>
-    <Component />
+    <Component {...props} />
   </BVLoaderProvider>
 );

--- a/packages/bodiless-bv/src/components/BVLoading.tsx
+++ b/packages/bodiless-bv/src/components/BVLoading.tsx
@@ -13,11 +13,16 @@
  */
 
 import React, { FC, HTMLProps } from 'react';
+import { Div } from '@bodiless/fclasses';
+import { BVProps, withoutBVProps } from './BVProps';
 
-type Props = HTMLProps<HTMLDivElement>;
+type DivProps = HTMLProps<HTMLDivElement>;
 
-const BVLoading: FC<Props> = props => (
-  <div {...props}>Loading BV Widget</div>
-);
+export type Props = DivProps & BVProps;
+
+const BVLoading: FC<Props> = props => {
+  const props$1 = withoutBVProps(props);
+  return <Div {...props$1}>Loading BV Widget </Div>;
+};
 
 export default BVLoading;

--- a/packages/bodiless-bv/src/components/BVPlaceholder.tsx
+++ b/packages/bodiless-bv/src/components/BVPlaceholder.tsx
@@ -13,21 +13,24 @@
  */
 
 import React, { FC, HTMLProps } from 'react';
-import { BVProps } from './BVProps';
+import { Div } from '@bodiless/fclasses';
+import { BVProps, withoutBVProps } from './BVProps';
 
 type DivProps = HTMLProps<HTMLDivElement>;
 
-type Props = DivProps & BVProps;
+export type Props = DivProps & BVProps;
 
-const BVPlaceholder: FC<Props> = ({ componentName, productId, ...rest }) => {
+const BVPlaceholder: FC<Props> = props => {
+  const { componentName, productId } = props;
   const BVWidgetName = componentName || 'BV widget';
+  const props$1 = withoutBVProps(props);
   return (
-    <div {...rest}>
+    <Div {...props$1}>
       {`
       ${BVWidgetName} with Product External Id: "${productId}" will be rendered here.
       If your domain is whitelisted, you will see BV generated widget in preview mode.
     `}
-    </div>
+    </Div>
   );
 };
 

--- a/packages/bodiless-bv/src/components/BVProps.ts
+++ b/packages/bodiless-bv/src/components/BVProps.ts
@@ -12,8 +12,13 @@
  * limitations under the License.
  */
 
-// eslint-disable-next-line import/prefer-default-export
+import { omit } from 'lodash';
+
 export type BVProps = {
   productId: string | number,
   componentName?: string,
+  redirectUrl?: string,
+  seo?: boolean,
 };
+
+export const withoutBVProps = <P extends BVProps>(props: P) => omit(props, ['productId', 'componentName', 'redirectUrl', 'seo']);

--- a/packages/bodiless-bv/src/components/v1/BVInlineRatings.tsx
+++ b/packages/bodiless-bv/src/components/v1/BVInlineRatings.tsx
@@ -1,0 +1,43 @@
+/**
+ * Copyright © 2019 Johnson & Johnson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { FC, HTMLProps } from 'react';
+import { flowRight } from 'lodash';
+import { withBVLoader } from '../BVLoader';
+import { asDesignableBVComponent } from '../asBVComponent';
+import { BVProps } from '../BVProps';
+import { asEditableBV } from '../asEditableBV';
+
+type DivProps = HTMLProps<HTMLDivElement>;
+
+type Props = DivProps & BVProps;
+
+const onLoaded = ({ productId }: BVProps) => {
+  // @ts-ignore since $BV variable is defined in external script
+  if (typeof $BV !== 'undefined') {
+    // @ts-ignore
+    $BV.ui('rr', 'inline_ratings', { productIds: productId }); // eslint-disable-line no-undef
+  }
+};
+
+const BVPlainInlineRatings: FC<Props> = () => <div id="BVRRSummaryContainer" />;
+
+export const BVInlineRatingsBase = asDesignableBVComponent('BV Inline Ratings', onLoaded)(BVPlainInlineRatings);
+
+const BVInlineRating = flowRight(
+  withBVLoader,
+  asEditableBV,
+)(BVInlineRatingsBase);
+
+export default BVInlineRating;

--- a/packages/bodiless-bv/src/components/v1/BVRatingsSummary.tsx
+++ b/packages/bodiless-bv/src/components/v1/BVRatingsSummary.tsx
@@ -1,0 +1,43 @@
+/**
+ * Copyright © 2019 Johnson & Johnson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { FC, HTMLProps } from 'react';
+import { flowRight } from 'lodash';
+import { withBVLoader } from '../BVLoader';
+import { asDesignableBVComponent } from '../asBVComponent';
+import { BVProps } from '../BVProps';
+import { asEditableBV } from '../asEditableBV';
+
+type DivProps = HTMLProps<HTMLDivElement>;
+
+type Props = DivProps & BVProps;
+
+const onLoaded = ({ productId }: BVProps) => {
+  // @ts-ignore since $BV variable is defined in external script
+  if (typeof $BV !== 'undefined') {
+    // @ts-ignore
+    $BV.ui('rr', 'show_reviews', { productId }); // eslint-disable-line no-undef
+  }
+};
+
+const BVPlainRatingsSummary: FC<Props> = () => <div id="BVRRSummaryContainer" />;
+
+export const BVRatingsSummaryBase = asDesignableBVComponent('BV Ratings Summary', onLoaded)(BVPlainRatingsSummary);
+
+const BVRatingsSummary = flowRight(
+  withBVLoader,
+  asEditableBV,
+)(BVRatingsSummaryBase);
+
+export default BVRatingsSummary;

--- a/packages/bodiless-bv/src/components/v1/BVReviews.tsx
+++ b/packages/bodiless-bv/src/components/v1/BVReviews.tsx
@@ -1,0 +1,43 @@
+/**
+ * Copyright © 2019 Johnson & Johnson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { FC, HTMLProps } from 'react';
+import { flowRight } from 'lodash';
+import { withBVLoader } from '../BVLoader';
+import { asDesignableBVComponent } from '../asBVComponent';
+import { BVProps } from '../BVProps';
+import { asEditableBV } from '../asEditableBV';
+
+type DivProps = HTMLProps<HTMLDivElement>;
+
+type Props = DivProps & BVProps;
+
+const onLoaded = ({ productId }: BVProps) => {
+  // @ts-ignore since $BV variable is defined in external script
+  if (typeof $BV !== 'undefined') {
+    // @ts-ignore
+    $BV.ui('rr', 'show_reviews', { productId }); // eslint-disable-line no-undef
+  }
+};
+
+const BVPlainReviews: FC<Props> = ({ productId, ...rest }) => <div id="BVRRContainer" {...rest} />;
+
+export const BVReviewsBase = asDesignableBVComponent('BV Reviews', onLoaded)(BVPlainReviews);
+
+const BVReviews = flowRight(
+  withBVLoader,
+  asEditableBV,
+)(BVReviewsBase);
+
+export default BVReviews;

--- a/packages/bodiless-bv/src/components/v2/BVInlineRatings.tsx
+++ b/packages/bodiless-bv/src/components/v2/BVInlineRatings.tsx
@@ -1,0 +1,42 @@
+/**
+ * Copyright © 2019 Johnson & Johnson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { HTMLProps, FC } from 'react';
+import { flowRight } from 'lodash';
+import { withBVLoader } from '../BVLoader';
+import { asDesignableBVComponent } from '../asBVComponent';
+import { BVProps } from '../BVProps';
+import { asEditableBV } from '../asEditableBV';
+
+type DivProps = HTMLProps<HTMLDivElement>;
+
+type Props = DivProps & BVProps;
+
+export const BVPlainInlineRatings: FC<Props> = ({ productId, redirectUrl, seo }) => {
+  const props: any = {
+    'data-bv-product-id': productId,
+    'data-bv-redirect-url': redirectUrl,
+    'data-bv-seo': seo,
+  };
+  return <div data-bv-show="inline_rating" {...props} />;
+};
+
+export const BVInlineRatingsBase = asDesignableBVComponent('BV Inline Ratings')(BVPlainInlineRatings);
+
+const BVInlineRatings = flowRight(
+  withBVLoader,
+  asEditableBV,
+)(BVInlineRatingsBase);
+
+export default BVInlineRatings;

--- a/packages/bodiless-bv/src/components/v2/BVRatingsSummary.tsx
+++ b/packages/bodiless-bv/src/components/v2/BVRatingsSummary.tsx
@@ -13,16 +13,25 @@
  */
 
 import React, { FC, HTMLProps } from 'react';
-import { Div } from '@bodiless/fclasses';
-import { BVProps, withoutBVProps } from './BVProps';
+import { flowRight } from 'lodash';
+import { withBVLoader } from '../BVLoader';
+import { asDesignableBVComponent } from '../asBVComponent';
+import { BVProps } from '../BVProps';
+import { asEditableBV } from '../asEditableBV';
 
 type DivProps = HTMLProps<HTMLDivElement>;
 
-export type Props = DivProps & BVProps;
+type Props = DivProps & BVProps;
 
-const BVProductIsNotMapped: FC<Props> = props => {
-  const props$1 = withoutBVProps(props);
-  return <Div {...props$1}>Please hover and click to enter Bazaarvoice Product External ID: </Div>;
-};
+export const BVPlainRatingsSummary: FC<Props> = ({ productId }) => (
+  <div data-bv-show="rating_summary" data-bv-product-id={productId} />
+);
 
-export default BVProductIsNotMapped;
+export const BVRatingsSummaryBase = asDesignableBVComponent('BV Ratings Summary')(BVPlainRatingsSummary);
+
+const BVRatingsSummary = flowRight(
+  withBVLoader,
+  asEditableBV,
+)(BVRatingsSummaryBase);
+
+export default BVRatingsSummary;

--- a/packages/bodiless-bv/src/components/v2/BVReviews.tsx
+++ b/packages/bodiless-bv/src/components/v2/BVReviews.tsx
@@ -13,16 +13,25 @@
  */
 
 import React, { FC, HTMLProps } from 'react';
-import { Div } from '@bodiless/fclasses';
-import { BVProps, withoutBVProps } from './BVProps';
+import { flowRight } from 'lodash';
+import { withBVLoader } from '../BVLoader';
+import { asDesignableBVComponent } from '../asBVComponent';
+import { BVProps } from '../BVProps';
+import { asEditableBV } from '../asEditableBV';
 
 type DivProps = HTMLProps<HTMLDivElement>;
 
-export type Props = DivProps & BVProps;
+type Props = DivProps & BVProps;
 
-const BVProductIsNotMapped: FC<Props> = props => {
-  const props$1 = withoutBVProps(props);
-  return <Div {...props$1}>Please hover and click to enter Bazaarvoice Product External ID: </Div>;
-};
+export const BVPlainReviews: FC<Props> = ({ productId }) => (
+  <div data-bv-show="reviews" data-bv-product-id={productId} />
+);
 
-export default BVProductIsNotMapped;
+export const BVReviewsBase = asDesignableBVComponent('BV Reviews')(BVPlainReviews);
+
+const BVReviews = flowRight(
+  withBVLoader,
+  asEditableBV,
+)(BVReviewsBase);
+
+export default BVReviews;

--- a/packages/bodiless-bv/src/getBVScriptUrl.ts
+++ b/packages/bodiless-bv/src/getBVScriptUrl.ts
@@ -15,8 +15,12 @@
 import { defaultBVConfig, BVConfig } from './BVConfig';
 
 const getBVScriptUrlFromConfig = (conf: BVConfig) => {
-  const bvHost = process.env.BV_HOST || 'https://display.ugc.bazaarvoice.com';
-  return `${bvHost}/${conf.environment}/static/${conf.client_name}/${conf.site_ID}/${conf.locale}/bvapi.js`;
+  if (process.env.BV_API_VERSION === '1') {
+    const bvHost = process.env.BV_HOST || 'https://display.ugc.bazaarvoice.com';
+    return `${bvHost}/${conf.environment}/static/${conf.client_name}/${conf.site_ID}/${conf.locale}/bvapi.js`;
+  }
+  const bvHost = process.env.BV_HOST || 'https://apps.bazaarvoice.com';
+  return `${bvHost}/deployments/${conf.client_name}/${conf.site_ID}/${conf.environment}/${conf.locale}/bv.js`;
 };
 
 const isBVConfigValid = (conf: BVConfig): boolean => {

--- a/packages/bodiless-bv/src/index.ts
+++ b/packages/bodiless-bv/src/index.ts
@@ -12,25 +12,46 @@
  * limitations under the License.
  */
 
-import asBVComponent from './components/asBVComponent';
+import asBVComponent, { asDesignableBVComponent } from './components/asBVComponent';
 import { BVLoaderProvider, withBVLoader } from './components/BVLoader';
 import { asBodilessBV } from './components/asBodilessBV';
 import { asEditableBV } from './components/asEditableBV';
+import BVRatingsSummaryV1, {
+  BVRatingsSummaryBase as BVRatingsSummaryBaseV1,
+} from './components/v1/BVRatingsSummary';
+import BVReviewsV1, {
+  BVReviewsBase as BVReviewsBaseV1,
+} from './components/v1/BVReviews';
+import BVInlineRatingsV1, {
+  BVInlineRatingsBase as BVInlineRatingsBaseV1,
+} from './components/v1/BVInlineRatings';
 import BVRatingsSummary, {
   BVRatingsSummaryBase,
-} from './components/BVRatingsSummary';
+} from './components/v2/BVRatingsSummary';
+import BVInlineRatings, {
+  BVInlineRatingsBase,
+} from './components/v2/BVInlineRatings';
 import BVReviews, {
   BVReviewsBase,
-} from './components/BVReviews';
+} from './components/v2/BVReviews';
 
 export {
   asBodilessBV,
   asBVComponent,
+  asDesignableBVComponent,
   asEditableBV,
   BVLoaderProvider,
   withBVLoader,
+  BVRatingsSummaryV1,
+  BVRatingsSummaryBaseV1,
+  BVReviewsV1,
+  BVReviewsBaseV1,
+  BVInlineRatingsV1,
+  BVInlineRatingsBaseV1,
   BVRatingsSummary,
   BVRatingsSummaryBase,
   BVReviews,
   BVReviewsBase,
+  BVInlineRatings,
+  BVInlineRatingsBase,
 };


### PR DESCRIPTION
## Changes
* implemented BV inline ratings component
* added support for display integration v2 (https://knowledge.bazaarvoice.com/wp-content/conversations/en_US/Display/display_integration.html)
* added a toggle to switch between v1 and v2
* made v2 activated by default


## References
* https://knowledge.bazaarvoice.com/wp-content/conversations/en_US/Display/display_integration.html
* https://knowledge.bazaarvoice.com/wp-content/conversations/en_US/Display/display_integration_v1.html
