### PR TITLE
fix(editor) Placeholder text overflows parent container

### DIFF
--- a/examples/test-site/src/components/Editors/asEditor.tsx
+++ b/examples/test-site/src/components/Editors/asEditor.tsx
@@ -15,6 +15,7 @@
 import { flow } from 'lodash';
 import React, { ComponentType } from 'react';
 import { withChild, withNodeKey } from '@bodiless/core';
+import { addClasses } from '@bodiless/fclasses';
 
 type WithInitialValue = {
   placeholder: string;
@@ -24,10 +25,14 @@ const withPlaceholder = (placeholder: string) => (
     <Component placeholder={placeholder} {...props} />
   )
 );
+
 const asEditor = (Editor:ComponentType<any>) => (nodeKey?: string, placeholder?: string) => (
-  withChild(flow(
-    withPlaceholder(placeholder),
-    withNodeKey(nodeKey),
-  )(Editor))
+  flow(
+    addClasses('overflow-hidden'),
+    withChild(flow(
+      withPlaceholder(placeholder),
+      withNodeKey(nodeKey),
+    )(Editor)),
+  )
 );
 export default asEditor;


### PR DESCRIPTION
## Changes
- hide overflowing part of editor placeholder

## Technical details
Another (and better) way to fix it would be to change the whitespace property of the placeholder itself, but it's not compatible with the current implementation where "whitespace: nowrap" is combined with "width: 0" to make the placeholder visible but not taking any space at the same time.
See this comment for more details:
https://github.com/ianstormtaylor/slate/issues/1344#issuecomment-340528377

## Test Instructions
- open any editable area, e.g. at /accordion example page
- make sure the placeholder doesn't overflow its container

## Related Issues
Fixes #21 

