### PR TITLE
fix(richtext) Format bar persists when leaving edit mode

### DIFF
--- a/packages/bodiless-organisms/src/components/SingleAccordion.tsx
+++ b/packages/bodiless-organisms/src/components/SingleAccordion.tsx
@@ -60,7 +60,7 @@ const SingleAccordionBase = ({ components, expanded, expandedStyle = null }: any
   } = components;
 
   return (
-    <Wrapper className={['zzz', accordionState]}>
+    <Wrapper className={[accordionState]}>
       <TitleWrapper
         onClick={toggleAccordionState}
         className={[

--- a/packages/bodiless-richtext/src/core/HoverMenu.tsx
+++ b/packages/bodiless-richtext/src/core/HoverMenu.tsx
@@ -17,6 +17,7 @@ import React,
   useEffect, ComponentType, HTMLProps,
 } from 'react';
 import ReactDOM from 'react-dom';
+import { useEditContext } from '@bodiless/core';
 import { useSlateContext } from './SlateEditorContext';
 import { EditorContext } from '../Type';
 
@@ -68,6 +69,7 @@ export type HoverMenuProps = {
 };
 
 const HoverMenu = (props: HoverMenuProps) => {
+  const isEditMode = useEditContext().isEdit || null;
   const editorContext: EditorContext = useSlateContext();
 
   const { ui } = props;
@@ -84,6 +86,7 @@ const HoverMenu = (props: HoverMenuProps) => {
   });
   return (
     root
+    && isEditMode
     && ReactDOM.createPortal(
       <Menu {...rest} id={elementID} className={className}>
         {children}


### PR DESCRIPTION
## Changes
- don't render hover menu if edit mode is not set

## Related Issues
Fixes #23