### PR TITLE
Remove the Pull Changes Button from the Edit UI

### DIFF
--- a/packages/gatsby-theme-bodiless/src/dist/GitProvider.tsx
+++ b/packages/gatsby-theme-bodiless/src/dist/GitProvider.tsx
@@ -105,21 +105,21 @@ const formGitCommit = (client: Client) => contextMenuForm({
   },
 );
 
-const formGitPull = (client: Client) => contextMenuForm({
-  submitValues: () => handle(client.pull()),
-})(
-  ({ ui }: any) => {
-    const { ComponentFormTitle, ComponentFormLabel } = getUI(ui);
-    return (
-      <>
-        <ComponentFormTitle>Download Changes</ComponentFormTitle>
-        <ComponentFormLabel htmlFor="pull-txt">
-          Download remote changes
-        </ComponentFormLabel>
-      </>
-    );
-  },
-);
+// const formGitPull = (client: Client) => contextMenuForm({
+//   submitValues: () => handle(client.pull()),
+// })(
+//   ({ ui }: any) => {
+//     const { ComponentFormTitle, ComponentFormLabel } = getUI(ui);
+//     return (
+//       <>
+//         <ComponentFormTitle>Download Changes</ComponentFormTitle>
+//         <ComponentFormLabel htmlFor="pull-txt">
+//           Download remote changes
+//         </ComponentFormLabel>
+//       </>
+//     );
+//   },
+// );
 
 const formGitReset = (client: Client) => contextMenuForm({
   submitValues: () => handle(client.reset()),
@@ -153,11 +153,11 @@ const getMenuOptions = (client: Client = defaultClient): TMenuOption[] => {
       isDisabled: () => !canCommit,
       handler: () => saveChanges,
     },
-    {
-      name: 'pullchanges',
-      icon: 'cloud_download',
-      handler: () => formGitPull(client),
-    },
+    // {
+    //   name: 'pullchanges',
+    //   icon: 'cloud_download',
+    //   handler: () => formGitPull(client),
+    // },
     {
       name: 'resetchanges',
       icon: 'first_page',

--- a/packages/gatsby-theme-bodiless/src/dist/GitProvider.tsx
+++ b/packages/gatsby-theme-bodiless/src/dist/GitProvider.tsx
@@ -105,6 +105,9 @@ const formGitCommit = (client: Client) => contextMenuForm({
   },
 );
 
+// Currently descoping the Pull Changes Button Functionality.
+// Might use it later.
+
 // const formGitPull = (client: Client) => contextMenuForm({
 //   submitValues: () => handle(client.pull()),
 // })(
@@ -153,6 +156,8 @@ const getMenuOptions = (client: Client = defaultClient): TMenuOption[] => {
       isDisabled: () => !canCommit,
       handler: () => saveChanges,
     },
+    // Currently descoping the Pull Changes Button Functionality.
+    // Might use it later.
     // {
     //   name: 'pullchanges',
     //   icon: 'cloud_download',


### PR DESCRIPTION
### Overview
We are descoping the Pull Changes Button Functionality from the Content Edit UI in the Main Menu.

**GitHub Issue:** https://github.com/johnsonandjohnson/Bodiless-JS/issues/30