### PR TITLE
Remove the Checkmark Icon from the Component Picker Window

### DIFF
--- a/packages/bodiless-core/src/contextMenuForm.tsx
+++ b/packages/bodiless-core/src/contextMenuForm.tsx
@@ -47,6 +47,7 @@ export type FormBodyRenderer<D> = (props: FormBodyProps<D>) => ReactNode;
 export type Options<D> = {
   submitValues?: (componentData: D) => void;
   initialValues?: D;
+  hasSubmit?: Boolean;
 };
 
 const contextMenuForm = <D extends object>(options: Options<D>) => (
@@ -54,7 +55,7 @@ const contextMenuForm = <D extends object>(options: Options<D>) => (
 ) => {
   const ContextMenuForm = ({ closeForm, ui }: FormProps) => {
     const { ComponentFormButton, Icon } = getUI(ui);
-    const { submitValues, initialValues } = options;
+    const { submitValues, initialValues, hasSubmit = true } = options;
     return (
       <Form
         onSubmit={(values: D) => {
@@ -78,7 +79,7 @@ const contextMenuForm = <D extends object>(options: Options<D>) => (
               formState,
               ui,
             })}
-            {!formState.invalid
+            {hasSubmit && !formState.invalid
             && (
               <div className="bl-clearfix">
                 <ComponentFormButton type="submit" className="bl-float-right">

--- a/packages/bodiless-layouts/src/FlexboxGrid/helpers.tsx
+++ b/packages/bodiless-layouts/src/FlexboxGrid/helpers.tsx
@@ -123,6 +123,7 @@ function useGetMenuOptions(props: EditFlexboxProps) {
     isDisabled: () => !context.isEdit,
     handler: () => contextMenuForm({
       initialValues: { selection: '' },
+      hasSubmit: false,
     })(
       ({ ui, closeForm }) => (
         <ComponentSelector


### PR DESCRIPTION
### Overview
Currently, we reusing `contextMenuForm` for every fly-out panel. Since we need to remove the submit button ( checkmark ) only for component picker window, I added `hasSubmit` to the `contextMenuForm` component options. `hasSubmit` defaults to `true` if not set.

### Testing notes
Go to the `/flexbox` page and open component picker. There should not be a submit checkmark at the bottom of that window.

**GitHub Issue:** https://github.com/johnsonandjohnson/Bodiless-JS/issues/32