### PR TITLE
Fix static Flexbox uses editor styles

### DIFF
--- a/examples/test-site/src/data/pages/flexbox/index.tsx
+++ b/examples/test-site/src/data/pages/flexbox/index.tsx
@@ -38,14 +38,14 @@ const FlexboxPage = (props: any) => (
       />
       <h3 className="text-lg font-bold">This shows the json content of the grid:</h3>
       <NodeViewer nodeKey={FLEXBOX_PAGE_PATH} />
-      <h1 className="text-3xl font-bold bl-mt-4">Flexbox grid with constrained widths</h1>
+      <h1 className="text-3xl font-bold mt-4">Flexbox grid with constrained widths</h1>
       <FlexBoxDefault
         nodeKey="constrained_widths"
         snapData={options}
       />
       <h3 className="text-lg font-bold">This shows the json content of the grid:</h3>
       <NodeViewer nodeKey="constrained_widths" />
-      <h1 className="text-3xl font-bold bl-mt-4">Flexbox restricted to 1 item</h1>
+      <h1 className="text-3xl font-bold mt-4">Flexbox restricted to 1 item</h1>
       <FlexBoxDefault
         nodeKey="restricted"
         maxComponents={1}

--- a/packages/bodiless-layouts/src/FlexboxGrid/StaticFlexbox.tsx
+++ b/packages/bodiless-layouts/src/FlexboxGrid/StaticFlexbox.tsx
@@ -22,7 +22,8 @@ const NodeProvider = withNode<PropsWithChildren<{}>, any>(React.Fragment);
 const StaticFlexbox: FC<StaticFlexboxProps> = ({ components }) => {
   const items = useItemHandlers().getItems();
   return (
-    <div className="bl-flex bl-flex-wrap">
+    // When in a static mode we don't want to use `bl-*` prefixed classes.
+    <div className="flex flex-wrap">
       {items
         .map((flexboxItem: FlexboxItem) => {
           const ChildComponent = components[flexboxItem.type];


### PR DESCRIPTION
## Changes
Remove `bl-` prefixed classes from the `StaticFlexbox`.

## Test Instructions

1. Start the edit env by running `npm run start`
2. Go to `/flexbox` page and add some tacos.
3. Build and serve a static site by running `npm run build` and `npm run serve`
4. Go to `http://localhost:9000/flexbox/` and make sure there are no HTML elements with `bl-` classes left.


## Related Issues
Fixes https://github.com/johnsonandjohnson/Bodiless-JS/issues/35
