### PR TITLE
fix:(bodiless-backend) Fix /src is missing in package.json

### DIFF
--- a/packages/bodiless-backend/package.json
+++ b/packages/bodiless-backend/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "",
   "files": [
-    "/bodiless.docs.json"
+    "/bodiless.docs.json",
+    "/src"
   ],
   "dependencies": {
     "body-parser": "^1.18.3",


### PR DESCRIPTION
## Changes
Added `/src` to files in `/packages/bodiless-backend/package.json` so that it gets packed correctly.

## Test Instructions

1. Run `npm run sites:clone-local starter`
2. Run `npm run sites:update starter`
3. Go to `cd sites/starter`
4. Run `npm run build`
5. Run `npm run start`

ER: The app starts with no errors.

## Related Issues
Fixes: https://github.com/johnsonandjohnson/Bodiless-JS/issues/80
