### PR TITLE
docs(examples): Add "How To" generate env vars and restructure .env.site comments.

### DIFF
--- a/examples/starter/.env.site
+++ b/examples/starter/.env.site
@@ -1,8 +1,10 @@
-# Set to string 'true' to enable Git commits. Default is 'false' if not specified.
+# Git commits are disabled by default.
+# To enable it - uncomment the following line.
 # BODILESS_BACKEND_COMMIT_ENABLED='1'
 
-# Set to string 'true' to enable save. Default is 'true' if not specified.
-# BODILESS_BACKEND_SAVE_ENABLED='1'
+# The Backend Data Save is enabled by default.
+# To disable it - uncomment the following line.
+# BODILESS_BACKEND_SAVE_ENABLED='0'
 
 # Git commit paths used by the backend, in our case @bodiless/backend/server.js.
 # APP_GIT_PATH='.'
@@ -10,21 +12,20 @@
 # BODILESS_BACKEND_STATIC_PATH='static'
 # BODILESS_BACKEND_PORT="8006"
 
-# google fonts plugin is enabled by default. To disable plugin set GOOGLE_FONTS_ENABLED to '0'.
+# The Google Fonts plugin is enabled by default.
+# To disable it - uncomment the following line.
 # GOOGLE_FONTS_ENABLED='0'
 
-# GTM is enabled on Bodiless example site by default and is rendered in the static site.
-# For GTM activation/disablement, you should set the following variables in the .env.production file that controls static site.
-
-# GTM Disablement
-# GTM is enabled by default. To disable GTM, uncomment the following line.
+# GTM is enabled by default.
+# To disable it - uncomment the following line
 # GOOGLE_TAGMANAGER_ENABLED='0'
 
 # GTM Activation
 # To set GTM ID modify line below and remove #.
 # GOOGLE_TAGMANAGER_ID='GTM-XXXXXXX'
 
-# Robots.txt plugin is enabled by default. To disable plugin set ROBOTSTXT_ENABLED to '0'.
+# Robots.txt plugin is enabled by default.
+# To disable it - uncomment the following line
 # ROBOTSTXT_ENABLED='0'
 
 # To define custom rules in robots.txt, set ROBOTSTXT_POLICIES to JSON string containing a list of policies.
@@ -33,7 +34,8 @@
 # To add sitemap.xml to robots.txt file, set ROBOTSTXT_SITEMAP env variable to your site sitemap.xml
 # ROBOTSTXT_SITEMAP='https://www.example.com/sitemap.xml'
 
-# Set to '0' to disable site tailwind theme. Enabled by default in `@bodiless/gatsby-theme-bodiless`.
+# The Site tailwind theme is enabled by default.
+# To disable it - uncomment the following line.
 # BODILESS_TAILWIND_THEME_ENABLED='0'
 
 # Location of bodiless documentation

--- a/examples/starter/.env.site
+++ b/examples/starter/.env.site
@@ -16,9 +16,9 @@
 # To disable it - uncomment the following line.
 # GOOGLE_FONTS_ENABLED='0'
 
-# GTM is enabled by default.
-# To disable it - uncomment the following line
-# GOOGLE_TAGMANAGER_ENABLED='0'
+# GTM is disabled by default.
+# To enable it - uncomment the following line
+# GOOGLE_TAGMANAGER_ENABLED='1'
 
 # GTM Activation
 # To set GTM ID modify line below and remove #.

--- a/examples/starter/README.md
+++ b/examples/starter/README.md
@@ -43,4 +43,12 @@ npm run serve
 
 Visit http://localhost:9000/ in your browser to view the site.
 
+### Handling environment variables with `.env.site`
+As part of the installation process, you may want to configure specific environment variables for the site. You may do so by adding or updating `.env.site` file in the root folder of the site. This file allows us to overwrite env variables defined in `@bodiless` packages and/or add new env variables. Make sure you regenerated env variables after you've changed it by running any of the following:
+
+* `npm run build:env-vars` - To regenerate env variables only.
+* `npm run build` - It will regenerate env vars as part of the `build` script.
+* `npm run start` - It will regenerate env vars as part of the `start` script.
+
+
 > Note: Official Gatsby Stater (installable via `gatsby new`) is coming soon!

--- a/examples/test-site/.env.site
+++ b/examples/test-site/.env.site
@@ -1,8 +1,10 @@
-# Set to string 'true' to enable Git commits. Default is 'false' if not specified.
+# Git commits are disabled by default.
+# To enable it - uncomment the following line.
 # BODILESS_BACKEND_COMMIT_ENABLED='1'
 
-# Set to string 'true' to enable save. Default is 'true' if not specified.
-# BODILESS_BACKEND_SAVE_ENABLED='1'
+# The Backend Data Save is enabled by default.
+# To disable it - uncomment the following line.
+# BODILESS_BACKEND_SAVE_ENABLED='0'
 
 # Git commit paths used by the backend, in our case @bodiless/backend/server.js.
 # APP_GIT_PATH='.'
@@ -10,21 +12,20 @@
 # BODILESS_BACKEND_STATIC_PATH='static'
 # BODILESS_BACKEND_PORT="8006"
 
-# google fonts plugin is enabled by default. To disable plugin set GOOGLE_FONTS_ENABLED to '0'.
+# The Google Fonts plugin is enabled by default.
+# To disable it - uncomment the following line.
 # GOOGLE_FONTS_ENABLED='0'
 
-# GTM is enabled on Bodiless example site by default and is rendered in the static site.
-# For GTM activation/disablement, you should set the following variables in the .env.production file that controls static site.
-
-# GTM Disablement
-# GTM is enabled by default. To disable GTM, uncomment the following line.
+# GTM is enabled by default.
+# To disable it - uncomment the following line
 # GOOGLE_TAGMANAGER_ENABLED='0'
 
 # GTM Activation
 # To set GTM ID modify line below and remove #.
 # GOOGLE_TAGMANAGER_ID='GTM-XXXXXXX'
 
-# Robots.txt plugin is enabled by default. To disable plugin set ROBOTSTXT_ENABLED to '0'.
+# Robots.txt plugin is enabled by default.
+# To disable it - uncomment the following line
 # ROBOTSTXT_ENABLED='0'
 
 # To define custom rules in robots.txt, set ROBOTSTXT_POLICIES to JSON string containing a list of policies.
@@ -33,7 +34,8 @@
 # To add sitemap.xml to robots.txt file, set ROBOTSTXT_SITEMAP env variable to your site sitemap.xml
 # ROBOTSTXT_SITEMAP='https://www.example.com/sitemap.xml'
 
-# Set to '0' to disable site tailwind theme. Enabled by default in `@bodiless/gatsby-theme-bodiless`.
+# The Site tailwind theme is enabled by default.
+# To disable it - uncomment the following line.
 # BODILESS_TAILWIND_THEME_ENABLED='0'
 
 # Location of bodiless documentation

--- a/examples/test-site/.env.site
+++ b/examples/test-site/.env.site
@@ -16,9 +16,9 @@
 # To disable it - uncomment the following line.
 # GOOGLE_FONTS_ENABLED='0'
 
-# GTM is enabled by default.
-# To disable it - uncomment the following line
-# GOOGLE_TAGMANAGER_ENABLED='0'
+# GTM is disabled by default.
+# To enable it - uncomment the following line
+# GOOGLE_TAGMANAGER_ENABLED='1'
 
 # GTM Activation
 # To set GTM ID modify line below and remove #.

--- a/examples/test-site/README.md
+++ b/examples/test-site/README.md
@@ -4,8 +4,11 @@ Example site for testing bodiless.
 
 ## Installation
 
-Create a .env.development config file, see .env.development-example for example of contents to include in this file.
-By default GTM is enabled on Bodiless example site, and defaults to generic GTM-XXXXXX id.  Until the proper id is set in env files, it won't function correctly.
+As part of the installation process, you may want to configure specific environment variables for the site. You may do so by adding or updating `.env.site` file in the root folder of the site. This file allows us to overwrite env variables defined in `@bodiless` packages and/or add new env variables. Make sure you regenerated env variables after you've changed them by running any of the following:
+
+* `npm run build:env-vars` - To regenerate env variables only.
+* `npm run build` - It will regenerate env vars as part of the `build` script.
+* `npm run start` - It will regenerate env vars as part of the `start` script.
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "cross-env NODE_ENV=production lerna run build --stream",
     "build:packages": "cross-env NODE_ENV=production lerna run build --stream --no-private",
     "build:watch": "cross-env NODE_ENV=development lerna run build:watch --parallel",
+    "build:env-vars": "cross-env NODE_ENV=production lerna run build:env-vars --stream",
     "clean": "lerna run clean && rimraf .eslintcache examples/*/.env.development examples/*/.env.production",
     "copyright": "node ./scripts/add-copyright",
     "fix": "eslint --fix  --cache --ext .js,.jsx,.ts,.tsx packages examples",


### PR DESCRIPTION
## Changes
- Add documentation on how to generate env variables to the example sites.
- Restructure `.env.site` comments style to follow the same pattern.
- Added `build:env-vars` script to the root package.json which leverages lerna to run `build:env-vars` script in all packages.

## Test Instructions


## Related Issues
Relates to: https://github.com/johnsonandjohnson/Bodiless-JS/issues/50
