### PR TITLE
fix(bodiless-migration-tool): do not create a page when an internal url is redirected to an external

### DIFF
--- a/packages/bodiless-migration-tool/src/page-creator.ts
+++ b/packages/bodiless-migration-tool/src/page-creator.ts
@@ -23,6 +23,7 @@ import {
   ensureDirectoryExistence,
   isUrlExternal,
   mapUrlToFilePath,
+  trimQueryParamsFromUrl,
 } from './helpers';
 import Downloader from './downloader';
 import {
@@ -86,6 +87,7 @@ export class PageCreator {
       return '';
     }
     filePath = this.removeExtension(filePath);
+    filePath = trimQueryParamsFromUrl(filePath);
     return filePath === '/' ? fileName : (`${filePath}/${fileName}`);
   }
 

--- a/packages/bodiless-migration-tool/src/scraper.ts
+++ b/packages/bodiless-migration-tool/src/scraper.ts
@@ -18,7 +18,10 @@ import url from 'url';
 import { Request } from '@bodiless/headless-chrome-crawler/lib/puppeteer';
 // @ts-ignore - ignoring as it contains functions that invoked in browser
 import evaluatePage from './evaluate-page';
-import { trimQueryParamsFromUrl } from './helpers';
+import {
+  isUrlExternal,
+  trimQueryParamsFromUrl,
+} from './helpers';
 import debug from './debug';
 // require due to ES6 modules cannot directly export class objects.
 import HCCrawler = require('@bodiless/headless-chrome-crawler');
@@ -89,6 +92,11 @@ export class Scraper extends EE<Events> {
       onSuccess: (async successResult => {
         try {
           const { result } = successResult;
+          // we can get an external url here
+          // when an internal url is redirected to the external
+          if (isUrlExternal(this.params.pageUrl, successResult.response.url)) {
+            return;
+          }
           result.pageUrl = successResult.response.url;
           // @ts-ignore
           result.rawHtml = await successResult.rawHtml;


### PR DESCRIPTION
## Changes
given source site has an internal url that is redirected to an external url
when the crawler follows this internal url
then the crawler returns sources of external url to migration tool
then the migration tool should not create a page for this kind of url


