### PR TITLE
feat(layout): Easily identify a flexbox area on page so that can start…

### DIFF
--- a/packages/bodiless-layouts-ui/src/ComponentSelector.tsx
+++ b/packages/bodiless-layouts-ui/src/ComponentSelector.tsx
@@ -25,6 +25,9 @@ import { ComponentSelector as CleanComponentSelector, ComponentSelectorUI, Compo
 export const ui: ComponentSelectorUI = {
   MasterWrapper: addClasses('bl-flex bl-form-wrapper')(Div),
   FlexSection: addClasses('bl-pt-grid-16')(Div),
+  FlexboxEmpty: addClasses(
+    'bl-border-2 bl-border-dashed bl-text-gray-600',
+  )(Div),
   ItemBoxWrapper: addClasses('bl-p-grid-2')(Div),
   ItemBox: addClasses(
     'bl-bg-grey-200 bl-flex bl-flex-col bl-items-center bl-justify-center bl-p-grid-2 bl-h-full bl-w-full bl-relative bl-overflow-hidden bl-cursor-pointer',

--- a/packages/bodiless-layouts/src/ComponentSelector/types.tsx
+++ b/packages/bodiless-layouts/src/ComponentSelector/types.tsx
@@ -65,6 +65,8 @@ export type FinalUI = {
   MasterWrapper: ComponentType<HTMLProps<HTMLDivElement>> | string;
   // A div that can be configured as column or row
   FlexSection: ComponentType<HTMLProps<HTMLDivElement>> | string;
+  // A div wraps an empty flexbox
+  FlexboxEmpty: ComponentType<HTMLProps<HTMLDivElement>> | string;
   // A div that will wrap the entirety of the Accordions and Accordion Checkboxes
   ComponentSelectorWrapper: ComponentType<HTMLProps<HTMLDivElement>> | string;
   // A input that will wrap the close menu icon

--- a/packages/bodiless-layouts/src/ComponentSelector/uiContext.tsx
+++ b/packages/bodiless-layouts/src/ComponentSelector/uiContext.tsx
@@ -19,6 +19,7 @@ import { FinalUI } from './types';
 export const defaultUI: FinalUI = {
   MasterWrapper: 'div',
   FlexSection: 'div',
+  FlexboxEmpty: 'div',
   ComponentSelectorWrapper: 'div',
   SubmitButton: 'button',
   AllCheckboxWrapper: 'div',

--- a/packages/bodiless-layouts/src/FlexboxGrid/EditFlexbox.tsx
+++ b/packages/bodiless-layouts/src/FlexboxGrid/EditFlexbox.tsx
@@ -17,8 +17,9 @@ import { arrayMove, SortEnd } from 'react-sortable-hoc';
 import { observer } from 'mobx-react-lite';
 import { flowRight } from 'lodash';
 import {
-  withActivateOnEffect, withNode, withMenuOptions,
+  withActivateOnEffect, withNode, withMenuOptions, useEditContext,
 } from '@bodiless/core';
+import { addClasses, removeClasses } from '@bodiless/fclasses';
 import SortableChild from './SortableChild';
 import SortableContainer from './SortableContainer';
 import { useItemHandlers, useFlexboxDataHandlers } from './model';
@@ -26,7 +27,6 @@ import useGetMenuOptions from './useGetMenuOptions';
 import { EditFlexboxProps, FlexboxItem } from './types';
 
 const ChildNodeProvider = withNode<PropsWithChildren<{}>, any>(React.Fragment);
-
 
 /**
  * An editable version of the Flexbox container.
@@ -38,6 +38,18 @@ const EditFlexbox: FC<EditFlexboxProps> = (props:EditFlexboxProps) => {
     onFlexboxItemResize,
     setFlexboxItems,
   } = useFlexboxDataHandlers();
+
+  if (ui && ui.FlexboxEmpty) {
+    const { isActive } = useEditContext();
+    const className = 'bl-border-orange-400';
+    const classNameHover = 'hover:bl-border-orange-400';
+
+    if (isActive) {
+      ui.FlexboxEmpty = addClasses(className).removeClasses(classNameHover)(ui.FlexboxEmpty);
+    } else {
+      ui.FlexboxEmpty = removeClasses(className).addClasses(classNameHover)(ui.FlexboxEmpty);
+    }
+  }
 
   return (
     <SortableContainer

--- a/packages/bodiless-layouts/src/FlexboxGrid/EditFlexbox.tsx
+++ b/packages/bodiless-layouts/src/FlexboxGrid/EditFlexbox.tsx
@@ -45,6 +45,7 @@ const EditFlexbox: FC<EditFlexboxProps> = (props:EditFlexboxProps) => {
         const { oldIndex, newIndex } = sort;
         setFlexboxItems(arrayMove(items, oldIndex, newIndex));
       }}
+      ui={ui}
     >
       {items.map(
         (flexboxItem: FlexboxItem, index: number): React.ReactNode => {

--- a/packages/bodiless-layouts/src/FlexboxGrid/SortableContainer.tsx
+++ b/packages/bodiless-layouts/src/FlexboxGrid/SortableContainer.tsx
@@ -15,25 +15,44 @@
 import * as React from 'react';
 import { SortableContainer, SortEndHandler } from 'react-sortable-hoc';
 import { useContextActivator } from '@bodiless/core';
+import { UI } from './types';
 
 type SortableListProps = {
   children: React.ReactNode;
   onSortEnd: SortEndHandler;
+  ui?: UI;
 };
 
+const defaultUI: Partial<UI> = {
+  FlexboxEmpty: 'div',
+};
+
+const getUI = (ui: UI = {}) => ({ ...defaultUI, ...ui });
+
 const SortableListWrapper = SortableContainer(
-  ({ children }: SortableListProps): React.ReactElement<SortableListProps> => (
-    <section className="bl-flex bl-flex-wrap bl-py-grid-3" {...useContextActivator()}>{children}</section>
-  ),
+  ({ children, ui }: SortableListProps): React.ReactElement<SortableListProps> => {
+    if (!children || !children.length) {
+      const { FlexboxEmpty } = getUI(ui);
+      return (
+        <FlexboxEmpty>
+          <section className="bl-flex bl-justify-center bl-flex-wrap bl-py-grid-3" {...useContextActivator()}>Empty Flexbox</section>
+        </FlexboxEmpty>
+      );
+    }
+    return (
+      <section className="bl-flex bl-flex-wrap bl-py-grid-3" {...useContextActivator()}>{children}</section>
+    );
+  },
 );
 SortableListWrapper.displayName = 'SortableListWrapper';
 
-const EditListView = ({ onSortEnd, children }: SortableListProps) => (
+const EditListView = ({ onSortEnd, ui, children }: SortableListProps) => (
   <SortableListWrapper
     axis="xy"
     useDragHandle
     transitionDuration={0}
     onSortEnd={onSortEnd}
+    ui={ui}
   >
     {children}
   </SortableListWrapper>

--- a/packages/bodiless-layouts/src/FlexboxGrid/SortableContainer.tsx
+++ b/packages/bodiless-layouts/src/FlexboxGrid/SortableContainer.tsx
@@ -12,10 +12,15 @@
  * limitations under the License.
  */
 
-import * as React from 'react';
+import React, { ComponentType, HTMLProps } from 'react';
 import { SortableContainer, SortEndHandler } from 'react-sortable-hoc';
 import { useContextActivator } from '@bodiless/core';
-import { UI } from './types';
+
+type FinalUI = {
+  FlexboxEmpty: ComponentType<HTMLProps<HTMLDivElement>> | string,
+};
+
+export type UI = Partial<FinalUI>;
 
 type SortableListProps = {
   children: React.ReactNode[];
@@ -23,7 +28,8 @@ type SortableListProps = {
   ui?: UI;
 };
 
-const defaultUI: Partial<UI> = {
+
+const defaultUI: FinalUI = {
   FlexboxEmpty: 'div',
 };
 

--- a/packages/bodiless-layouts/src/FlexboxGrid/SortableContainer.tsx
+++ b/packages/bodiless-layouts/src/FlexboxGrid/SortableContainer.tsx
@@ -18,7 +18,7 @@ import { useContextActivator } from '@bodiless/core';
 import { UI } from './types';
 
 type SortableListProps = {
-  children: React.ReactNode;
+  children: React.ReactNode[];
   onSortEnd: SortEndHandler;
   ui?: UI;
 };

--- a/packages/bodiless-layouts/src/FlexboxGrid/SortableContainer.tsx
+++ b/packages/bodiless-layouts/src/FlexboxGrid/SortableContainer.tsx
@@ -28,7 +28,6 @@ type SortableListProps = {
   ui?: UI;
 };
 
-
 const defaultUI: FinalUI = {
   FlexboxEmpty: 'div',
 };


### PR DESCRIPTION
… adding components.

<!--
  Before issuing a pull request:

  - Please read our contribution guidelines (https://github.com/johnsonandjohnson/Bodiless-JS/blob/master/packages/bodiless-documentation/doc/Development/Contributing.md), especially the section on Pull Requests.
  - Please first create an issue (https://github.com/johnsonandjohnson/Bodiless-JS/issues/new). All pull requests must be linked to an issue.
-->

<!--
  IMPORTANT
  
  The pull request title will become the commit message title at merge, and
  should adhere to Angular Commit Message Conventions. Please see (https://github.com/johnsonandjohnson/Bodiless-JS/blob/master/packages/bodiless-documentation/doc/Development/Contributing.md) for details and examples.
-->

## Changes
<!-- Brief description of the changes introduced by this PR -->

This feature adds visual representation indicating what area can be worked via the Flexbox. When the user clicks in the outlined flexbox area then the + is added to the menu bar and works as before

## Test Instructions
<!-- Detailed description of how this feature was (and should be) tested
  - Setup instructions (if any)?
  - List of test cases, with steps and expected results?
  - List
-->

### Test 1.
- Check if no items inside Flexbox container, there are design updates applied.

### Test 2.
- The behavior is kept the same if there are items added.

### Test 3.
- Static site does not render the design updates nor placeholder.


## Related Issues
<!--
  Link to the issue that is fixed or resolved by this PR (if there is one)
  e.g. Fixes #1234, Closes #4567

  Link to an issue that is partially addressed by this PR (if there are any)
-->

Fixes #37

<!-- IF THIS PR INTRODUCES A BREAKING CHANGE

BREAKING CHANGE: Describe the nature of the breaking change here.

More Details about the breaking change.
-->

