### PR TITLE
fix(bodiless-richtext): improved richtext input lag on a page with multiple richtext elements

### DIFF
--- a/packages/bodiless-richtext/src/MobxStateContainer.ts
+++ b/packages/bodiless-richtext/src/MobxStateContainer.ts
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-import { observable, computed, action } from 'mobx';
+import { observable, action } from 'mobx';
 
 type NewState = {
   [index:string]: any,
@@ -22,14 +22,11 @@ class MobxStateContainer {
 
   constructor() {
     this.setState = this.setState.bind(this);
+    this.get = this.get.bind(this);
   }
 
-  @computed get state() {
-    const obj = {} as NewState;
-    this.store.forEach((v, k) => {
-      obj[k] = v;
-    });
-    return obj;
+  get(key: string) {
+    return this.store.get(key);
   }
 
   @action setState(newState:NewState) {

--- a/packages/bodiless-richtext/src/useNodeStateHandlers.ts
+++ b/packages/bodiless-richtext/src/useNodeStateHandlers.ts
@@ -40,9 +40,6 @@ type TUseNodeStateHandlers = (
   value: Value;
   onChange: TOnChange;
 };
-type MobxState = {
-  [key: string]: any;
-};
 
 const stateContainer = React.createContext<MobxStateContainer>(
   new MobxStateContainer(),
@@ -87,10 +84,10 @@ const useOnChange: TUseOnChange = ({ onChange }) => {
 
 // Create the value prop (gets current editor value from state).
 const useValue: TUseValue = ({ initialValue }) => {
-  const { state } = useStateContainer();
+  const { get: getValue } = useStateContainer();
   const { node } = useNode<Data>();
   const key = (node.path as string[]).join('$');
-  let { [key]: oldValue } = state as MobxState;
+  let oldValue = getValue(key);
   if (!oldValue) {
     oldValue = Value.fromJSON(
       node.data.document ? { document: node.data.document } : initialValue,


### PR DESCRIPTION
<!--
  Before issuing a pull request:

  - Please read our contribution guidelines (https://github.com/johnsonandjohnson/Bodiless-JS/blob/master/packages/bodiless-documentation/doc/Development/Contributing.md), especially the section on Pull Requests.
  - Please first create an issue (https://github.com/johnsonandjohnson/Bodiless-JS/issues/new). All pull requests must be linked to an issue.
-->

<!--
  IMPORTANT
  
  The pull request title will become the commit message title at merge, and
  should adhere to Angular Commit Message Conventions. Please see (https://github.com/johnsonandjohnson/Bodiless-JS/blob/master/packages/bodiless-documentation/doc/Development/Contributing.md) for details and examples.
-->

## Changes
* improved richtext input lag on a page with multiple richtext elements

## Technical notes
* bodiless richtext observes mobx richtext store (MobxStateContainer). before this fix, richtext component reacts to any changes to the store which leads to unnecessary renders of all richtext on the page when changes are made to any richtext component. after this fix, richtext observers and react to only each own key from the mobx store. 

## Test Instructions
Place many slate editors on the same page (eg on slate-api page, add >20 copies of the same editor, pointing to different nodes.

ER: Editors are as responsive to kestrokes as if there is only one.
AR: Editors exhibit significant keyboard lag.