### PR TITLE
chore(cypress): fixing build - added npm run build:doc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ defaults: &defaults
   script:
     - echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
     - BODILESS_DOCS_COPYFILES=1
+    - npm run build:doc
     - npm run lint
     - npm run test
     - npm run test:ci


### PR DESCRIPTION
Alex removed the npm run build from .travis.yml
so the docs aren't getting built
we didn't catch it on the branch bc the deploy of hte docs only happens on master

