### PR TITLE
fix(psh): Ensure cypress cache folder is writable.

### DIFF
--- a/examples/test-site/edit/.platform.app.yaml
+++ b/examples/test-site/edit/.platform.app.yaml
@@ -57,3 +57,5 @@ variables:
     env:
         APP_VOLUME: '/app/volume'
         CHOKIDAR_USEPOLLING: true
+        # Ensure cypress cache is writable
+        CYPRESS_CACHE_FOLDER: '/app/volume/.cache'

--- a/packages/bodiless-psh/resources/edit/edit.platform.app.yaml
+++ b/packages/bodiless-psh/resources/edit/edit.platform.app.yaml
@@ -57,3 +57,5 @@ variables:
     env:
         APP_VOLUME: '/app/volume'
         CHOKIDAR_USEPOLLING: true
+        # Ensure cypress cache is writable
+        CYPRESS_CACHE_FOLDER: '/app/volume/.cache'


### PR DESCRIPTION
## Changes
- Set cypress cache directory location on writable volume on p.sh

## Test Instructions
- Activate edit environment and/or run `platform ssh bash ./platform.sh fresh`.  Verify that installation completes and app starts normally.