### PR TITLE
fix(migration_tool): 'npm run setup' fails on Windows

### DIFF
--- a/examples/starter/package.json
+++ b/examples/starter/package.json
@@ -27,6 +27,7 @@
     "@bodiless/richtext": "^0.0.39",
     "@bodiless/richtext-ui": "^0.0.39",
     "@bodiless/ui": "^0.0.39",
+    "cross-env": "^5.2.0",
     "docsify-cli": "^4.3.0",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
@@ -48,7 +49,7 @@
   "scripts": {
     "build": "npm-run-all build:env-vars build:css build:lib build:doc",
     "build:lib": "gatsby build",
-    "build:css": "DOTENV_CONFIG_PATH=.env.production node -r dotenv/config ./scripts/build-css",
+    "build:css": "cross-env DOTENV_CONFIG_PATH=.env.production node -r dotenv/config ./scripts/build-css",
     "build:doc": "bl-docs-build",
     "build:env-vars": "generate-env-vars",
     "check": "tsc -p ./tsconfig.check.json",
@@ -59,8 +60,8 @@
     "prestart": "run-s build:env-vars build:css build:doc",
     "start": "run-p -r dev-backend dev-frontend",
     "serve": "gatsby serve",
-    "migrate": "DEBUG=migration_tool migration_tool",
-    "migrate:postbuild": "migration_tool postbuild public",
+    "migrate": "cross-env DEBUG=migration_tool migration_tool",
+    "migrate:postbuild": "cross-env DEBUG=migration_tool migration_tool postbuild public",
     "migrate:full": "npm run migrate && npm run build && npm run migrate:postbuild && npm run serve",
     "prepare": "npm run build:css"
   },

--- a/packages/bodiless-migration-tool/package.json
+++ b/packages/bodiless-migration-tool/package.json
@@ -22,6 +22,7 @@
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^2",
+    "cross-env": "^5.2.0",
     "bluebird": "^3.5.5",
     "cheerio": "^1.0.0-rc.3",
     "css-to-object": "^1.1.0",
@@ -108,8 +109,8 @@
     "test-clear": "jest --clearCache",
     "test-debug": "jest --detectOpenHandles --detectLeaks",
     "launch": "ts-node src/launch.ts",
-    "postinstall": "DEBUG=migration_tool node bin/apply-patches.js",
-    "migrate": "DEBUG=migration_tool bin/run"
+    "postinstall": "cross-env DEBUG=migration_tool node bin/apply-patches.js",
+    "migrate": "cross-env DEBUG=migration_tool bin/run"
   },
   "types": "lib/index.d.ts"
 }


### PR DESCRIPTION
## Changes
Use 'cross-env' package to pass variables in inline npm scripts on Windows.

## Related Issues
Fixes #111 