### PR TITLE
fix(bodiless-backend): do not require morgan when it is disabled

### DIFF
--- a/packages/bodiless-backend/README.md
+++ b/packages/bodiless-backend/README.md
@@ -10,6 +10,6 @@ You can start backend server by running `node ./path/to/server.js`. Backend serv
 * `BODILESS_BACKEND_DATA_FILE_PATH` - Where to write the content json files. Defaults to `./src/data`.
 * `BODILESS_BACKEND_STATIC_PATH` - Where to write uploaded static assets. Defaults to `./static`.
 * `BODILESS_BACKEND_COMMIT_ENABLED` - Whether or not commits are enabled. Defaults to `0` for `production` and `development` environments and `1` for `test/*` and `changeset/*` branches.
-* `BODILESS_BACKEND_EXTENDED_LOGGING_ENABLED` - Whether or not extended logging is enabled. Defaults to `0`. Please not that this feature requires `morgan` and `morgan-body` packages. If you plan to use this feature outside of monorepo, please ensure those dependencies are installed.
+* `BODILESS_BACKEND_EXTENDED_LOGGING_ENABLED` - Whether or not extended logging is enabled. Defaults to `0`. Please note that this feature requires `morgan` and `morgan-body` packages. If you plan to use this feature outside of monorepo, please ensure those dependencies are installed.
 
 Please note that `BODILESS_BACKEND_DATA_FILE_PATH`, `BODILESS_BACKEND_STATIC_PATH` and `BODILESS_BACKEND_COMMIT_ENABLED` are defined in `@bodiless/gatsby-theme-bodiless` by default.

--- a/packages/bodiless-backend/README.md
+++ b/packages/bodiless-backend/README.md
@@ -10,6 +10,6 @@ You can start backend server by running `node ./path/to/server.js`. Backend serv
 * `BODILESS_BACKEND_DATA_FILE_PATH` - Where to write the content json files. Defaults to `./src/data`.
 * `BODILESS_BACKEND_STATIC_PATH` - Where to write uploaded static assets. Defaults to `./static`.
 * `BODILESS_BACKEND_COMMIT_ENABLED` - Whether or not commits are enabled. Defaults to `0` for `production` and `development` environments and `1` for `test/*` and `changeset/*` branches.
-* `BODILESS_BACKEND_EXTENDED_LOGGING_ENABLED` - Whether or not extended logging is enabled. Defaults to `0`.
+* `BODILESS_BACKEND_EXTENDED_LOGGING_ENABLED` - Whether or not extended logging is enabled. Defaults to `0`. Please not that this feature requires `morgan` and `morgan-body` packages. If you plan to use this feature outside of monorepo, please ensure those dependencies are installed.
 
 Please note that `BODILESS_BACKEND_DATA_FILE_PATH`, `BODILESS_BACKEND_STATIC_PATH` and `BODILESS_BACKEND_COMMIT_ENABLED` are defined in `@bodiless/gatsby-theme-bodiless` by default.

--- a/packages/bodiless-backend/src/backend.js
+++ b/packages/bodiless-backend/src/backend.js
@@ -13,13 +13,12 @@
  */
 
 /* eslint no-console: 0 */
+/* eslint global-require: 0 */
 const express = require('express');
 const fs = require('fs');
 const bodyParser = require('body-parser');
 const { spawn } = require('child_process');
 const formidable = require('formidable');
-const morgan = require('morgan');
-const morganBody = require('morgan-body');
 const tmp = require('tmp');
 const path = require('path');
 const Page = require('./page');
@@ -312,6 +311,8 @@ class Backend {
     this.app = express();
     this.app.use(bodyParser.json());
     if (isMorganEnabled()) {
+      const morgan = require('morgan');
+      const morganBody = require('morgan-body');
       this.app.use(morgan(':method :url :status :res[content-length] - :response-time ms'));
       morganBody(this.app);
     }


### PR DESCRIPTION
## Changes
* adjusted bodiless-backend so that it does not fail when development packages morgan and morgan-body are not installed

## Test Instructions
1. npm i @bodiless/backend@0.0.40
2. node ./node_modules/@bodiless/backend/src/server.js

**AR:** Error: Cannot find module 'morgan'
**ER:** The server started without errors