### PR TITLE
feat(bodiless-core): edit ui should start in preview mode

### DIFF
--- a/cypress/integration/link_menu.spec.js
+++ b/cypress/integration/link_menu.spec.js
@@ -8,6 +8,7 @@ context('Link Context Menu', () => {
 
   beforeEach(() => {
     cy.visit('/context');
+    cy.clickEdit();
   });
 
   it('should retain submitted value when reopened', () => {

--- a/cypress/integration/link_menu.spec.js
+++ b/cypress/integration/link_menu.spec.js
@@ -8,10 +8,11 @@ context('Link Context Menu', () => {
 
   beforeEach(() => {
     cy.visit('/context');
-    cy.clickEdit();
   });
 
   it('should retain submitted value when reopened', () => {
+    // activate edit mode
+    cy.clickEdit();
     cy.get('div.flex-1')
       .find('a')
       .first()

--- a/cypress/integration/smokeTest/touts_spec.js
+++ b/cypress/integration/smokeTest/touts_spec.js
@@ -2,6 +2,7 @@ describe('Tout testing', function () {
 
   before(function () {
     cy.visit('/touts/')
+    cy.clickEdit()
   })
 
   after(function () {

--- a/packages/bodiless-components/__tests__/Image.test.tsx
+++ b/packages/bodiless-components/__tests__/Image.test.tsx
@@ -1,6 +1,15 @@
 import React from 'react';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { mount, ReactWrapper } from 'enzyme';
+
+const setEditMode = (isEdit: boolean) => {
+  // @TODO bodiless-core internals should not be touched
+  // bodiless-core should be refactored to allow injecting of default edit mode
+  window.sessionStorage.isEdit = isEdit;
+};
+setEditMode(true);
+
+// eslint-disable-next-line import/first
 import Image from '../src/Image';
 
 let wrapper: ReactWrapper;

--- a/packages/bodiless-components/__tests__/Link.test.tsx
+++ b/packages/bodiless-components/__tests__/Link.test.tsx
@@ -1,6 +1,15 @@
 import React from 'react';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { mount, ReactWrapper } from 'enzyme';
+
+const setEditMode = (isEdit: boolean) => {
+  // @TODO bodiless-core internals should not be touched
+  // bodiless-core should be refactored to allow injecting of default edit mode
+  window.sessionStorage.isEdit = isEdit;
+};
+setEditMode(true);
+
+// eslint-disable-next-line import/first
 import Link from '../src/Link';
 
 let wrapper: ReactWrapper;

--- a/packages/bodiless-core/__tests__/StaticPage.test.tsx
+++ b/packages/bodiless-core/__tests__/StaticPage.test.tsx
@@ -131,10 +131,10 @@ describe('StaticPage', () => {
       );
     };
     let wrapper = mount(<Baseline force="foo" />);
-    expect(wrapper.find('#isEdit').text()).toBe('true');
+    expect(wrapper.find('#isEdit').text()).toBe('false');
     wrapper.find('#toggle').simulate('click', event);
     wrapper.setProps({ force: 'bar' });
-    expect(wrapper.find('#isEdit').text()).toBe('false');
+    expect(wrapper.find('#isEdit').text()).toBe('true');
 
     const Test: FC<FP> = ({ force }) => (
       <StaticPage>

--- a/packages/bodiless-core/src/PageEditContext/index.tsx
+++ b/packages/bodiless-core/src/PageEditContext/index.tsx
@@ -65,7 +65,7 @@ export class PageEditStore implements PageEditStoreInterface {
 
   @observable contextMenuOptions: TMenuOption[] = [];
 
-  @observable isEdit = getFromSessionStorage('isEdit', true);
+  @observable isEdit = getFromSessionStorage('isEdit', false);
 
   @observable isPositionToggled = getFromSessionStorage('isPositionToggled', false);
 

--- a/packages/bodiless-richtext/__tests__/RichText.test.tsx
+++ b/packages/bodiless-richtext/__tests__/RichText.test.tsx
@@ -15,12 +15,21 @@
 import React from 'react';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { mount } from 'enzyme';
-import { PageEditContext } from '@bodiless/core';
 import {
   Value as SlateEditorValue,
   ValueJSON as SlateEditorValueJSON,
 } from 'slate';
 import { Editor } from 'slate-react';
+
+const setEditMode = (isEdit: boolean) => {
+  // @TODO bodiless-core internals should not be touched
+  // bodiless-core should be refactored to allow injecting of default edit mode
+  window.sessionStorage.isEdit = isEdit;
+};
+setEditMode(true);
+// eslint-disable-next-line import/first
+import { PageEditContext } from '@bodiless/core';
+// eslint-disable-next-line import/first
 import defaultValue from '../src/default-value';
 
 const getDefaultRichTextItems = () => ({});


### PR DESCRIPTION
## Changes
* edit ui starts in preview mode
* the flag containing edit ui mode is stored in browser sessions storage

## Test Instructions
* see #160

## Related Issues
* closes #160