### PR TITLE
feat(components): Add withEditPlaceholder HOC to bodiless-components

### DIFF
--- a/examples/test-site/src/data/pages/index.tsx
+++ b/examples/test-site/src/data/pages/index.tsx
@@ -17,10 +17,10 @@ import { graphql } from 'gatsby';
 import { flow } from 'lodash';
 import { Page } from '@bodiless/gatsby-theme-bodiless';
 import {
-  Image, Editable, List, asEditableList, withEditPlaceholder,
+  Image, Editable, List, asEditableList,
 } from '@bodiless/components';
 import {
-  withDesign, replaceWith, addClasses, stylable, Div,
+  withDesign, replaceWith, addClasses, stylable,
 } from '@bodiless/fclasses';
 import Layout from '../../components/Layout';
 import { FlexBoxDefault } from '../../components/Flexbox';
@@ -30,18 +30,6 @@ const HOME_PAGE_PATH = 'homepage';
 const BulletPoints = (props: any) => (
   <span {...props}><Editable nodeKey="bullet" placeholder="Enter Bullet Item" /></span>
 );
-
-const TestComponent = props => (
-  <Div {...props}>Test Component</Div>
-);
-
-const PlaceholderComponent = props => (
-  <Div {...props}>Placeholder Component</Div>
-);
-
-const TestComponentWithPlaceholder = flow(
-  withEditPlaceholder(PlaceholderComponent),
-)(TestComponent);
 
 const EditableBulletPoints = flow(
   asEditableList,
@@ -67,10 +55,6 @@ const HomePage = (props: any) => (
       <FlexBoxDefault
         nodeKey={HOME_PAGE_PATH}
       />
-      <div className="py-6">
-        <TestComponent />
-        <TestComponentWithPlaceholder />
-      </div>
     </Layout>
   </Page>
 );

--- a/examples/test-site/src/data/pages/index.tsx
+++ b/examples/test-site/src/data/pages/index.tsx
@@ -17,10 +17,10 @@ import { graphql } from 'gatsby';
 import { flow } from 'lodash';
 import { Page } from '@bodiless/gatsby-theme-bodiless';
 import {
-  Image, Editable, List, asEditableList,
+  Image, Editable, List, asEditableList, withBodilessPlaceholder,
 } from '@bodiless/components';
 import {
-  withDesign, replaceWith, addClasses, stylable,
+  withDesign, replaceWith, addClasses, stylable, Div,
 } from '@bodiless/fclasses';
 import Layout from '../../components/Layout';
 import { FlexBoxDefault } from '../../components/Flexbox';
@@ -30,6 +30,18 @@ const HOME_PAGE_PATH = 'homepage';
 const BulletPoints = (props: any) => (
   <span {...props}><Editable nodeKey="bullet" placeholder="Enter Bullet Item" /></span>
 );
+
+const TestComponent = props => (
+  <Div {...props}>Test Component</Div>
+);
+
+const PlaceholderComponent = props => (
+  <Div {...props}>Placeholder Component</Div>
+);
+
+const TestComponentWithPlaceholder = flow(
+  withBodilessPlaceholder(PlaceholderComponent),
+)(TestComponent);
 
 const EditableBulletPoints = flow(
   asEditableList,
@@ -55,6 +67,10 @@ const HomePage = (props: any) => (
       <FlexBoxDefault
         nodeKey={HOME_PAGE_PATH}
       />
+      <div className="py-6">
+        <TestComponent />
+        <TestComponentWithPlaceholder />
+      </div>
     </Layout>
   </Page>
 );

--- a/examples/test-site/src/data/pages/index.tsx
+++ b/examples/test-site/src/data/pages/index.tsx
@@ -17,7 +17,7 @@ import { graphql } from 'gatsby';
 import { flow } from 'lodash';
 import { Page } from '@bodiless/gatsby-theme-bodiless';
 import {
-  Image, Editable, List, asEditableList, withBodilessPlaceholder,
+  Image, Editable, List, asEditableList, withEditPlaceholder,
 } from '@bodiless/components';
 import {
   withDesign, replaceWith, addClasses, stylable, Div,
@@ -40,7 +40,7 @@ const PlaceholderComponent = props => (
 );
 
 const TestComponentWithPlaceholder = flow(
-  withBodilessPlaceholder(PlaceholderComponent),
+  withEditPlaceholder(PlaceholderComponent),
 )(TestComponent);
 
 const EditableBulletPoints = flow(

--- a/packages/bodiless-components/src/Placeholder.tsx
+++ b/packages/bodiless-components/src/Placeholder.tsx
@@ -15,8 +15,8 @@
 import { ComponentType as CT } from 'react';
 import { withEditToggle } from '@bodiless/core';
 
-export const withBodilessPlaceholder = <P extends object>(
+export const withEditPlaceholder = <P extends object>(
   PlaceholderComponent: CT<P>,
 ) => (Component: CT<P>) => withEditToggle(Component, PlaceholderComponent);
 
-export default withBodilessPlaceholder;
+export default withEditPlaceholder;

--- a/packages/bodiless-components/src/Placeholder.tsx
+++ b/packages/bodiless-components/src/Placeholder.tsx
@@ -1,0 +1,22 @@
+/**
+ * Copyright © 2020 Johnson & Johnson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ComponentType as CT } from 'react';
+import { withEditToggle } from '@bodiless/core';
+
+export const withBodilessPlaceholder = <P extends object>(
+  PlaceholderComponent: CT<P>,
+) => (Component: CT<P>) => withEditToggle(Component, PlaceholderComponent);
+
+export default withBodilessPlaceholder;

--- a/packages/bodiless-components/src/Placeholder.tsx
+++ b/packages/bodiless-components/src/Placeholder.tsx
@@ -15,8 +15,8 @@
 import { ComponentType as CT } from 'react';
 import { withEditToggle } from '@bodiless/core';
 
-export const withEditPlaceholder = <P extends object>(
+const withEditPlaceholder = <P extends object>(
   PlaceholderComponent: CT<P>,
 ) => (Component: CT<P>) => withEditToggle(Component, PlaceholderComponent);
 
-export default withEditPlaceholder;
+export { withEditPlaceholder };

--- a/packages/bodiless-components/src/Placeholder.tsx
+++ b/packages/bodiless-components/src/Placeholder.tsx
@@ -19,4 +19,4 @@ const withEditPlaceholder = <P extends object>(
   PlaceholderComponent: CT<P>,
 ) => (Component: CT<P>) => withEditToggle(Component, PlaceholderComponent);
 
-export { withEditPlaceholder };
+export default withEditPlaceholder;

--- a/packages/bodiless-components/src/index.ts
+++ b/packages/bodiless-components/src/index.ts
@@ -30,7 +30,7 @@ import {
   withMeta, withMetaTitle, withMetaHtml, asBodilessHelmet,
 } from './Meta/Meta';
 import { withToggle, withToggleTo, withToggleButton } from './Toggle';
-import { withEditPlaceholder } from './Placeholder';
+import withEditPlaceholder from './Placeholder';
 
 export {
   Link,

--- a/packages/bodiless-components/src/index.ts
+++ b/packages/bodiless-components/src/index.ts
@@ -30,6 +30,7 @@ import {
   withMeta, withMetaTitle, withMetaHtml, asBodilessHelmet,
 } from './Meta/Meta';
 import { withToggle, withToggleTo, withToggleButton } from './Toggle';
+import { withBodilessPlaceholder } from './Placeholder';
 
 export {
   Link,
@@ -55,4 +56,5 @@ export {
   withMetaTitle,
   withMetaHtml,
   asBodilessHelmet,
+  withBodilessPlaceholder,
 };

--- a/packages/bodiless-components/src/index.ts
+++ b/packages/bodiless-components/src/index.ts
@@ -30,7 +30,7 @@ import {
   withMeta, withMetaTitle, withMetaHtml, asBodilessHelmet,
 } from './Meta/Meta';
 import { withToggle, withToggleTo, withToggleButton } from './Toggle';
-import { withBodilessPlaceholder } from './Placeholder';
+import { withEditPlaceholder } from './Placeholder';
 
 export {
   Link,
@@ -56,5 +56,5 @@ export {
   withMetaTitle,
   withMetaHtml,
   asBodilessHelmet,
-  withBodilessPlaceholder,
+  withEditPlaceholder,
 };


### PR DESCRIPTION

## Changes
- This PR adds new `withEditPlaceholder` HOC to `@bodiless/components`.
- When used this HOC rendered `PlaceholderComponent` when in `edit` mode and an original component when on `static` site or in `preview` mode.

## Test Instructions
You can create test components on any page of the `test-site`. 

- Open `Bodiless-JS/examples/test-site/src/data/pages/index.tsx` and add `withEditPlaceholder` to `@bodiless/components` imports:
```js
import {
  ..., withEditPlaceholder,
} from '@bodiless/components';
```
- In the same file ( `index.tsx` ) create 2 test components: any component and it's placeholder. For example:
```js
const TestComponent = props => (
  <div {...props}>Test Component</div>
);

const PlaceholderComponent = props => (
  <div {...props}>Placeholder Component</div>
);
```
- Use `withEditPlaceholder` to wrap `TestComponent` and pass `PlaceholderComponent`:
```js
const TestComponentWithPlaceholder = flow(
  withEditPlaceholder(PlaceholderComponent),
)(TestComponent);
```
- Add `TestComponentWithPlaceholder` to any place on the page:
```js
    <Layout>
	  ...
      <FlexBoxDefault
        nodeKey={HOME_PAGE_PATH}
      />
      <div className="py-6">
        <TestComponentWithPlaceholder />
      </div>
    </Layout>
```
- Run `npm run start`
- On the home page in `edit` environment you should see `Test Component` text closer to the buttom of the page.
- Toggle `preview` mode and this text should swich to `Placeholder Component`.

## Related Issues
<!--
  Link to the issue that is fixed or resolved by this PR (if there is one)
  e.g. Fixes #1234, Closes #4567

  Link to an issue that is partially addressed by this PR (if there are any)
-->
