### PR TITLE
fix(bodiless-migration-tool): allow to migrate a site with bareroot domain specified

### DIFF
--- a/packages/bodiless-migration-tool/src/helpers.ts
+++ b/packages/bodiless-migration-tool/src/helpers.ts
@@ -44,10 +44,10 @@ export function getUrlToLocalDirectoryMapper(targetDir: string): Function {
 }
 
 export function isUrlExternal(baseUrl: string, targetUrl: string) {
-  const hasHost = url.parse(baseUrl, true, true).host !== null;
+  const hasTargetUrlHost = url.parse(targetUrl, true, true).host !== null;
   const baseUrlHost = url.parse(baseUrl).host || '';
   const targetUrlHost = url.parse(targetUrl).host || '';
-  return hasHost
+  return hasTargetUrlHost
     && stripWWW(baseUrlHost) !== stripWWW(targetUrlHost);
 }
 
@@ -68,7 +68,7 @@ function stripWWW(host: string): string {
   return host.replace(/^www\./, '');
 }
 
-function getHostNameWithoutWWW(host: string): string {
+export function getHostNameWithoutWWW(host: string): string {
   const hostName = url.parse(host).hostname || '';
   return stripWWW(hostName);
 }
@@ -177,4 +177,11 @@ export function cfDecodeEmail(encodedString: string) {
     email += String.fromCharCode(i);
   }
   return email;
+}
+
+export function prependProtocolToBareUrl(url$: string, protocol = 'https://') {
+  if (!url$.match(/^[a-zA-Z]+:\/\//)) {
+    return protocol + url$;
+  }
+  return url$;
 }

--- a/packages/bodiless-migration-tool/src/helpers.ts
+++ b/packages/bodiless-migration-tool/src/helpers.ts
@@ -43,10 +43,12 @@ export function getUrlToLocalDirectoryMapper(targetDir: string): Function {
   };
 }
 
-export function isUrlExternal(domain: string, item: string) {
-  return url.parse(item, true, true).host
-  !== null && url.parse(domain).host
-  !== url.parse(item).host;
+export function isUrlExternal(baseUrl: string, targetUrl: string) {
+  const hasHost = url.parse(baseUrl, true, true).host !== null;
+  const baseUrlHost = url.parse(baseUrl).host || '';
+  const targetUrlHost = url.parse(targetUrl).host || '';
+  return hasHost
+    && stripWWW(baseUrlHost) !== stripWWW(targetUrlHost);
 }
 
 export function isUrlRelative(path1: string) {
@@ -62,9 +64,13 @@ function isFragmentOnly(url1: string): boolean {
   return url1.match(/^#/g) !== null;
 }
 
+function stripWWW(host: string): string {
+  return host.replace(/^www\./, '');
+}
+
 function getHostNameWithoutWWW(host: string): string {
   const hostName = url.parse(host).hostname || '';
-  return hostName.replace(/^www\./, '');
+  return stripWWW(hostName);
 }
 
 export function transformRelativeUrlToInternal(relativeUrl: string, pageUrl: string): string {

--- a/packages/bodiless-migration-tool/src/helpers.ts
+++ b/packages/bodiless-migration-tool/src/helpers.ts
@@ -43,6 +43,10 @@ export function getUrlToLocalDirectoryMapper(targetDir: string): Function {
   };
 }
 
+function stripWWW(host: string): string {
+  return host.replace(/^www\./, '');
+}
+
 export function isUrlExternal(baseUrl: string, targetUrl: string) {
   const hasTargetUrlHost = url.parse(targetUrl, true, true).host !== null;
   const baseUrlHost = url.parse(baseUrl).host || '';
@@ -62,10 +66,6 @@ function isJavascriptProtocolUrl(url1: string): boolean {
 
 function isFragmentOnly(url1: string): boolean {
   return url1.match(/^#/g) !== null;
-}
-
-function stripWWW(host: string): string {
-  return host.replace(/^www\./, '');
 }
 
 export function getHostNameWithoutWWW(host: string): string {

--- a/packages/bodiless-migration-tool/src/scraper.ts
+++ b/packages/bodiless-migration-tool/src/scraper.ts
@@ -115,6 +115,7 @@ export class Scraper extends EE<Events> {
     });
     crawler.on(HCCrawler.Events.PuppeteerRequestStarted, async (request: Request) => {
       const resourceTypes = [
+        'fetch',
         'xhr',
         'other',
         'script',
@@ -128,13 +129,13 @@ export class Scraper extends EE<Events> {
     const pageHost = getHostNameWithoutWWW(this.params.pageUrl);
     const allowedDomains = [
       pageHost,
-      ... pageHost ? [`www.${pageHost}`] : [],
+      ...pageHost ? [`www.${pageHost}`] : [],
     ];
     // Queue a request
     await crawler.queue({
       url: this.params.pageUrl,
       maxDepth: this.params.maxDepth,
-      allowedDomains: allowedDomains,
+      allowedDomains,
     });
     await crawler.onIdle(); // Resolved when no queue is left
     await crawler.close(); // Close the crawler

--- a/packages/bodiless-migration-tool/src/scraper.ts
+++ b/packages/bodiless-migration-tool/src/scraper.ts
@@ -13,12 +13,12 @@
  */
 
 import { EventEmitter as EE } from 'ee-ts';
-import url from 'url';
 // eslint-disable-next-line import/no-unresolved
 import { Request } from '@bodiless/headless-chrome-crawler/lib/puppeteer';
 // @ts-ignore - ignoring as it contains functions that invoked in browser
 import evaluatePage from './evaluate-page';
 import {
+  getHostNameWithoutWWW,
   isUrlExternal,
   trimQueryParamsFromUrl,
 } from './helpers';
@@ -125,12 +125,16 @@ export class Scraper extends EE<Events> {
         this.emit('requestStarted', request.url());
       }
     });
-    const pageHost = url.parse(this.params.pageUrl).hostname;
+    const pageHost = getHostNameWithoutWWW(this.params.pageUrl);
+    const allowedDomains = [
+      pageHost,
+      ... pageHost ? [`www.${pageHost}`] : [],
+    ];
     // Queue a request
     await crawler.queue({
       url: this.params.pageUrl,
       maxDepth: this.params.maxDepth,
-      allowedDomains: pageHost !== undefined ? [pageHost] : undefined,
+      allowedDomains: allowedDomains,
     });
     await crawler.onIdle(); // Resolved when no queue is left
     await crawler.close(); // Close the crawler

--- a/packages/bodiless-migration-tool/src/site-flattener.ts
+++ b/packages/bodiless-migration-tool/src/site-flattener.ts
@@ -96,7 +96,7 @@ export class SiteFlattener {
       scraperParams: {
         ...params.scraperParams,
         pageUrl: prependProtocolToBareUrl(params.scraperParams.pageUrl),
-      }
+      },
     };
     const jamStackAppParams: JamStackAppParams = {
       gitRepository: this.params.gitRepository,

--- a/packages/bodiless-migration-tool/src/site-flattener.ts
+++ b/packages/bodiless-migration-tool/src/site-flattener.ts
@@ -17,6 +17,7 @@ import path from 'path';
 import minimatch from 'minimatch';
 import {
   getUrlToLocalDirectoryMapper,
+  prependProtocolToBareUrl,
 } from './helpers';
 import Downloader from './downloader';
 import HtmlParser from './html-parser';
@@ -90,7 +91,12 @@ export class SiteFlattener {
   constructor(params: SiteFlattenerParams) {
     this.params = {
       ...params,
+      websiteUrl: prependProtocolToBareUrl(params.websiteUrl),
       trailingSlash: params.trailingSlash || TrailingSlash.Add,
+      scraperParams: {
+        ...params.scraperParams,
+        pageUrl: prependProtocolToBareUrl(params.scraperParams.pageUrl),
+      }
     };
     const jamStackAppParams: JamStackAppParams = {
       gitRepository: this.params.gitRepository,

--- a/packages/bodiless-migration-tool/tests/helpers.test.ts
+++ b/packages/bodiless-migration-tool/tests/helpers.test.ts
@@ -16,6 +16,7 @@ import {
   isUrlExternal,
   isUrlRelative,
   cfDecodeEmail,
+  prependProtocolToBareUrl,
 } from '../src/helpers';
 
 describe('relative urls', () => {
@@ -47,5 +48,25 @@ describe('isUrlExternal', () => {
   test('different domain urls are external', () => {
     expect(isUrlExternal('https://www.example2.com', 'https://www.example.com')).toBe(true);
     expect(isUrlExternal('https://www.example2.com/test1', 'https://www.example.com/test2')).toBe(true);
+  });
+  test('target urls without domains are not external', () => {
+    expect(isUrlExternal('https://example.com', '/test')).toBe(false);
+    expect(isUrlExternal('https://example.com', 'test')).toBe(false);
+  });
+});
+
+describe('prependProtocolToBareUrl', () => {
+  test('protocol is prepended for url containing www', () => {
+    expect(prependProtocolToBareUrl('www.example.com')).toBe('https://www.example.com');
+    expect(prependProtocolToBareUrl('www.example.com/test')).toBe('https://www.example.com/test');
+  });
+  test('protocol is prepended for simple strings', () => {
+    expect(prependProtocolToBareUrl('localhost')).toBe('https://localhost');
+  });
+  test('protocol is not prepended for urls that already has protocol', () => {
+    expect(prependProtocolToBareUrl('http://example.com')).toBe('http://example.com');
+    expect(prependProtocolToBareUrl('http://www.example.com')).toBe('http://www.example.com');
+    expect(prependProtocolToBareUrl('https://example.com')).toBe('https://example.com');
+    expect(prependProtocolToBareUrl('https://www.example.com')).toBe('https://www.example.com');
   });
 });

--- a/packages/bodiless-migration-tool/tests/helpers.test.ts
+++ b/packages/bodiless-migration-tool/tests/helpers.test.ts
@@ -13,6 +13,7 @@
  */
 
 import {
+  isUrlExternal,
   isUrlRelative,
   cfDecodeEmail,
 } from '../src/helpers';
@@ -29,5 +30,22 @@ describe('Decoding Cloudflare-protected Emails', () => {
   test('decoding', () => {
     expect(cfDecodeEmail('314554424571455442451f525e5c'))
       .toBe('test@test.com');
+  });
+});
+
+describe('isUrlExternal', () => {
+  test('www and non-www urls are not external', () => {
+    expect(isUrlExternal('www.example.com', 'example.com')).toBe(false);
+    expect(isUrlExternal('www.example.com/path1', 'example.com')).toBe(false);
+    expect(isUrlExternal('www.example.com/path1', 'example.com/path2')).toBe(false);
+  });
+  test('http and https of the same domain are not external', () => {
+    expect(isUrlExternal('https://www.example.com', 'http://www.example.com')).toBe(false);
+    expect(isUrlExternal('https://example.com', 'http://www.example.com')).toBe(false);
+    expect(isUrlExternal('https://example.com', 'http://example.com')).toBe(false);
+  });
+  test('different domain urls are external', () => {
+    expect(isUrlExternal('https://www.example2.com', 'https://www.example.com')).toBe(true);
+    expect(isUrlExternal('https://www.example2.com/test1', 'https://www.example.com/test2')).toBe(true);
   });
 });

--- a/packages/bodiless-migration-tool/tests/site-flattener.test1.ts
+++ b/packages/bodiless-migration-tool/tests/site-flattener.test1.ts
@@ -99,13 +99,13 @@ jest.setTimeout(30000);
 test('flattening of the test website', async () => {
   const siteFlattener = new SiteFlattener(getDefaultFlattenedParams());
   await siteFlattener.start();
-  expect(existsInWorkDir('examples/test-site/src/data/pages/index.jsx')).toBe(true);
-  expect(existsInWorkDir('examples/test-site/static/gatsby.png')).toBe(true);
-  expect(existsInWorkDir('examples/test-site/static/test1.js')).toBe(true);
-  expect(existsInWorkDir('examples/test-site/static/test2.css')).toBe(true);
-  expect(existsInWorkDir('examples/test-site/static/non-existing-file.css')).toBe(false);
+  expect(existsInWorkDir('src/data/pages/index.jsx')).toBe(true);
+  expect(existsInWorkDir('static/gatsby.png')).toBe(true);
+  expect(existsInWorkDir('static/test1.js')).toBe(true);
+  expect(existsInWorkDir('static/test2.css')).toBe(true);
+  expect(existsInWorkDir('static/non-existing-file.css')).toBe(false);
   // asset loaded by xhr
-  expect(existsInWorkDir('examples/test-site/static/lazy-loaded.js')).toBe(true);
+  expect(existsInWorkDir('static/lazy-loaded.js')).toBe(true);
 }, 30000);
 
 test('tranforming of html during website flattening', async () => {
@@ -121,8 +121,8 @@ test('tranforming of html during website flattening', async () => {
   };
   const siteFlattener = new SiteFlattener(params);
   await siteFlattener.start();
-  const parentPath = getPathInWorkDir('examples/test-site/src/data/pages/products/index.jsx');
-  const childPath = getPathInWorkDir('examples/test-site/src/data/pages/products/shampoo/index.jsx');
+  const parentPath = getPathInWorkDir('src/data/pages/products/index.jsx');
+  const childPath = getPathInWorkDir('src/data/pages/products/shampoo/index.jsx');
   expect(fs.existsSync(parentPath)).toBe(true);
   expect(fs.existsSync(childPath)).toBe(true);
   // const parentIndexPage = require(parentPath).default
@@ -163,7 +163,7 @@ test('migration of attached files', async () => {
   const siteFlattener = new SiteFlattener(params);
   await siteFlattener.start();
   const sourcePath = path.join(__dirname, 'testserver', 'assets', 'files', 'test.pdf');
-  const targetPath = getPathInWorkDir('examples/test-site/static/files/test.pdf');
+  const targetPath = getPathInWorkDir('static/files/test.pdf');
   expect(fs.existsSync(targetPath)).toBe(true);
   // filesize of the downloaded file should be the same to the source file
   expect(fs.statSync(sourcePath).size).toBe(fs.statSync(targetPath).size);


### PR DESCRIPTION
## Changes
* when operator specifies a url without www in migration-settings.json (for instance, https://example.com), then urls with www (https://www.example.com) and without www (https://example.com) will be scraped. vice versa, when an operator specifies a url with www in migration-settings.json (for instance, https://www.example.com), then urls with www (https://www.example.com) and without www (https://example.com) will be scraped
* when operator specifies a url without protocol in migration-settings, then the protocol is automatically prepended to the url

## Test Instructions
* see #165 

## Related Issues
* Fixes #165 

<!-- IF THIS PR INTRODUCES A BREAKING CHANGE

BREAKING CHANGE: Describe the nature of the breaking change here.

More Details about the breaking change.
-->
