### PR TITLE
fix(components, core): Fix withEditPlaceholder components order

### DIFF
--- a/packages/bodiless-components/src/Placeholder.tsx
+++ b/packages/bodiless-components/src/Placeholder.tsx
@@ -17,6 +17,6 @@ import { withEditToggle } from '@bodiless/core';
 
 const withEditPlaceholder = <P extends object>(
   PlaceholderComponent: CT<P>,
-) => (Component: CT<P>) => withEditToggle(Component, PlaceholderComponent);
+) => (Component: CT<P>) => withEditToggle(PlaceholderComponent, Component);
 
 export default withEditPlaceholder;

--- a/packages/bodiless-core/src/withEditToggle.tsx
+++ b/packages/bodiless-core/src/withEditToggle.tsx
@@ -21,8 +21,8 @@ export const withEditToggle = <P extends object, Q extends object>(
   Editable: CT<P>,
   ReadOnly: CT<Q>,
 ) => observer((props: P & Q) => {
-    const { isEdit } = useEditContext();
-    return isEdit ? <Editable {...props} /> : <ReadOnly {...props} />;
+    const context = useEditContext();
+    return context.isEdit ? <Editable {...props} /> : <ReadOnly {...props} />;
   });
 
 export const ifEditable = <H extends Function>(...hocs: Function[]) => (


### PR DESCRIPTION
## Changes
- Fix withEditPlaceholder components order so that the placeholder component is displayed on edit envs instead of static.

## Test Instructions
You can create test components on any page of the `test-site`. 

- Open `Bodiless-JS/examples/test-site/src/data/pages/index.tsx` and add `withEditPlaceholder` to `@bodiless/components` imports:
```js
import {
  ..., withEditPlaceholder,
} from '@bodiless/components';
```
- In the same file ( `index.tsx` ) create 2 test components: any component and it's placeholder. For example:
```js
const TestComponent = props => (
  <div {...props}>Test Component</div>
);

const PlaceholderComponent = props => (
  <div {...props}>Placeholder Component</div>
);
```
- Use `withEditPlaceholder` to wrap `TestComponent` and pass `PlaceholderComponent`:
```js
const TestComponentWithPlaceholder = flow(
  withEditPlaceholder(PlaceholderComponent),
)(TestComponent);
```
- Add `TestComponentWithPlaceholder` to any place on the page:
```js
    <Layout>
	  ...
      <FlexBoxDefault
        nodeKey={HOME_PAGE_PATH}
      />
      <div className="py-6">
        <TestComponentWithPlaceholder />
      </div>
    </Layout>
```
- Run `npm run start`
- On the home page in `edit` environment you should see `Placeholder Component` text closer to the buttom of the page.
- Toggle `preview` mode and this text should swich to `Test Component`.
- Run `npm run build && npm run serve`.
- On static env you should see `Test Component`.

