### PR TITLE
fix(psh): Platform.sh site return 502 error instead of 404 page on non-existing pages.

### DIFF
--- a/packages/bodiless-psh/resources/static/static.platform.app.yaml
+++ b/packages/bodiless-psh/resources/static/static.platform.app.yaml
@@ -46,6 +46,7 @@ web:
             index: ['index.html']
             scripts: false
             allow: true
+            passthru: false
 
 variables:
     env:


### PR DESCRIPTION
## Changes
- Disable `passthru` for the static app on psh to display default 404 page

## Test Instructions
- On a static site open any non-existing page.
- You should see a default p.sh 404 page.

## Related Issues
<!--
  Link to the issue that is fixed or resolved by this PR (if there is one)
  e.g. Fixes #1234, Closes #4567

  Link to an issue that is partially addressed by this PR (if there are any)
-->


