### PR TITLE
[wip] feat(migration-tool): scrape assets from multiple urls

### DIFF
--- a/packages/bodiless-migration-tool/patches/html-to-react-components+1.6.6.patch
+++ b/packages/bodiless-migration-tool/patches/html-to-react-components+1.6.6.patch
@@ -199,7 +199,7 @@ index 7062916..186629d 100644
 -
  module.exports = HTMLtoJSX;
 diff --git a/node_modules/html-to-react-components/lib/jsx.js b/node_modules/html-to-react-components/lib/jsx.js
-index 1b4aa2d..fa19ae2 100644
+index 1b4aa2d..50eb185 100644
 --- a/node_modules/html-to-react-components/lib/jsx.js
 +++ b/node_modules/html-to-react-components/lib/jsx.js
 @@ -1,4 +1,4 @@
@@ -207,4 +207,31 @@ index 1b4aa2d..fa19ae2 100644
 +var parseJSX = require("@babel/parser").parse;
  var traverse = require("babel-traverse").default;
  var HTMLtoJSX = require("./html2jsx");
-
+ 
+@@ -16,7 +16,7 @@ function childrenToComponents(ast) {
+         var name;
+ 
+         var attrs = p.node.openingElement.attributes.filter(function(attr) {
+-          return attr.name.name === "data-component";
++          return attr.name.name === "data-bl-component";
+         });
+ 
+         if (attrs.length > 0) {
+diff --git a/node_modules/html-to-react-components/lib/processor.js b/node_modules/html-to-react-components/lib/processor.js
+index 1d6d661..c5577f4 100644
+--- a/node_modules/html-to-react-components/lib/processor.js
++++ b/node_modules/html-to-react-components/lib/processor.js
+@@ -7,11 +7,11 @@ var toCode = require("./code");
+ var formatCode = require("./format");
+ 
+ function getComponentName(node) {
+-  return node.attrs["data-component"];
++  return node.attrs["data-bl-component"];
+ }
+ 
+ function removeComponentName(node) {
+-  delete node.attrs["data-component"];
++  delete node.attrs["data-bl-component"];
+ 
+   return node;
+ }

--- a/packages/bodiless-migration-tool/src/downloader.ts
+++ b/packages/bodiless-migration-tool/src/downloader.ts
@@ -46,10 +46,13 @@ export default class Downloader {
 
   excludePaths: Array<string> | undefined;
 
-  constructor(pageUrl: string, downloadPath: string, excludePaths?: Array<string>) {
+  internalDomains?: Array<string>;
+
+  constructor(pageUrl: string, downloadPath: string, excludePaths?: Array<string>, internalDomains?: Array<string>) {
     this.pageUrl = pageUrl;
     this.downloadPath = downloadPath;
     this.excludePaths = excludePaths;
+    this.internalDomains = internalDomains;
   }
 
   public async downloadFiles(resources: Array<string>) {
@@ -78,7 +81,18 @@ export default class Downloader {
   private filterResources(resources: Array<string>): Array<string> {
     return resources
       // filter external resources
-      .filter(resource => resource && !isUrlExternal(this.pageUrl, resource), this)
+      .filter(resource => {
+        if (!resource) {
+          return false;
+        }
+        const internalDomains = [
+          this.pageUrl,
+          ...(this.internalDomains ? this.internalDomains : [])
+        ];
+        return internalDomains.some(
+          domain => !isUrlExternal(domain, resource)
+        );
+      } , this)
       // filter already downloaded resources
       .filter(resource => {
         const targetPath = this.getTargetPath(resource);

--- a/packages/bodiless-migration-tool/src/html-parser.ts
+++ b/packages/bodiless-migration-tool/src/html-parser.ts
@@ -42,7 +42,7 @@ interface HtmlParserInterface {
   getImages(): string
   replaceString(oldHtmlString: string, newHtmlString: string): void
   replace(selector: string, newElement: string): void
-  transformAbsoluteToRelative(pageUrl: string): void
+  transformAbsoluteToRelative(internalUrls: string[]): void
   transformRelativeToInternal(pageUrl: string): void
   removeTrailingSlash(pageUrl: string): void
   addTrailingSlash(pageUrl: string): void
@@ -169,10 +169,14 @@ export default class HtmlParser implements HtmlParserInterface {
     });
   }
 
-  transformAbsoluteToRelative(pageUrl: string) {
+  transformAbsoluteToRelative(internalUrls: string[]) {
     this.transformHtmlElementsWithReference((link: string, element: CheerioElement) => {
       if (this.shouldTransformAbsoluteToRelative(link, element)) {
-        return transformAbsoluteUrlToRelative(link, pageUrl);
+        let link$ = link;
+        internalUrls.forEach(internalUrl => {
+          link$ = transformAbsoluteUrlToRelative(link$, internalUrl)
+        });
+        return link$;
       }
       return link;
     });

--- a/packages/bodiless-migration-tool/src/html-parser.ts
+++ b/packages/bodiless-migration-tool/src/html-parser.ts
@@ -267,7 +267,7 @@ export default class HtmlParser implements HtmlParserInterface {
         const text = $(element).html();
         if (text !== null) {
           const withoutNewLine = text.replace(/\n\s+/g, '\n');
-          $(element).html(withoutNewLine);
+          $(element).text(withoutNewLine);
         }
       }
     });

--- a/packages/bodiless-migration-tool/src/html-to-components.ts
+++ b/packages/bodiless-migration-tool/src/html-to-components.ts
@@ -17,7 +17,7 @@ import path from 'path';
 // @ts-ignore
 import extractReactComponents from 'html-to-react-components';
 
-const COMPONENT_LABEL = 'data-component';
+const COMPONENT_LABEL = 'data-bl-component';
 
 export enum ComponentScope {
   Global = 'global',

--- a/packages/bodiless-migration-tool/src/index.ts
+++ b/packages/bodiless-migration-tool/src/index.ts
@@ -63,6 +63,7 @@ class MigrationTool extends Command {
     const settings = this.getDefaultSettings();
     const flattenerParams: SiteFlattenerParams = {
       websiteUrl: settings.url,
+      internalDomains: settings.internalDomains || [],
       workDir: this.getWorkDir(),
       gitRepository: this.getGitRepo(),
       reservedPaths: ['404'],

--- a/packages/bodiless-migration-tool/src/page-creator.ts
+++ b/packages/bodiless-migration-tool/src/page-creator.ts
@@ -227,9 +227,13 @@ export class PageCreator {
   }
 
   private isUrlExternal(item: string) {
+    const internalUrlsWithoutProtocol = this.params.internalDomains.map(
+      domain => domain.replace('https:', '').replace('http:', '')
+    );
     const internalUrls = [
       this.params.pageUrl,
       ...this.params.internalDomains,
+      ...internalUrlsWithoutProtocol
     ]
     return !internalUrls.some(internalUrl => {
       return !isUrlExternal(internalUrl, item);

--- a/packages/bodiless-migration-tool/src/page-creator.ts
+++ b/packages/bodiless-migration-tool/src/page-creator.ts
@@ -63,6 +63,7 @@ export interface PageCreatorParams {
   htmlToComponentsSettings?: HtmlToComponentsSettings,
   reservedPaths?: Array<string>,
   allowFallbackHtml?: boolean,
+  internalDomains: Array<string>,
 }
 
 export class PageCreator {
@@ -76,6 +77,7 @@ export class PageCreator {
       this.params.pageUrl,
       this.params.staticDir,
       this.params.reservedPaths,
+      this.params.internalDomains,
     );
   }
 
@@ -225,7 +227,13 @@ export class PageCreator {
   }
 
   private isUrlExternal(item: string) {
-    return isUrlExternal(this.params.pageUrl, item);
+    const internalUrls = [
+      this.params.pageUrl,
+      ...this.params.internalDomains,
+    ]
+    return !internalUrls.some(internalUrl => {
+      return !isUrlExternal(internalUrl, item);
+    });
   }
 
   private convertTextToAttribute(html: string) {

--- a/packages/bodiless-migration-tool/tests/html-to-components.test.ts
+++ b/packages/bodiless-migration-tool/tests/html-to-components.test.ts
@@ -40,6 +40,6 @@ describe('labeling html elements', () => {
   test('header, footer, search elements are labeled', () => {
     const inputHtml = '<header><div class="search"></div></header><footer></footer>';
     const resultHtml = htmlToComponents.label(inputHtml);
-    expect(resultHtml).toBe('<div data-component="Page"><header data-component="Header"><div class="search" data-component="Search"></div></header><footer data-component="Footer"></footer></div>');
+    expect(resultHtml).toBe('<div data-bl-component="Page"><header data-bl-component="Header"><div class="search" data-bl-component="Search"></div></header><footer data-bl-component="Footer"></footer></div>');
   });
 });


### PR DESCRIPTION
<!--
  Before issuing a pull request:

  - Please read our contribution guidelines (https://github.com/johnsonandjohnson/Bodiless-JS/blob/master/packages/bodiless-documentation/doc/Development/Contributing.md), especially the section on Pull Requests.
  - Please first create an issue (https://github.com/johnsonandjohnson/Bodiless-JS/issues/new). All pull requests must be linked to an issue.
-->

<!--
  IMPORTANT
  
  The pull request title will become the commit message title at merge, and
  should adhere to Angular Commit Message Conventions. Please see (https://github.com/johnsonandjohnson/Bodiless-JS/blob/master/packages/bodiless-documentation/doc/Development/Contributing.md) for details and examples.
-->

## Changes
* renamed an attribute reserved for extracting common components
* allow scraping assets from multiple urls

## Test Instructions
<!-- Detailed description of how this feature was (and should be) tested
  - Setup instructions (if any)?
  - List of test cases, with steps and expected results?
  - List
-->

## Related Issues
<!--
  Link to the issue that is fixed or resolved by this PR (if there is one)
  e.g. Fixes #1234, Closes #4567

  Link to an issue that is partially addressed by this PR (if there are any)
-->

<!-- IF THIS PR INTRODUCES A BREAKING CHANGE

BREAKING CHANGE: Describe the nature of the breaking change here.

More Details about the breaking change.
-->
