### PR TITLE
fix(psh): Provide default psh cache expiry for /__docs

### DIFF
--- a/packages/bodiless-psh/resources/.platform/platform.whitelist.yaml
+++ b/packages/bodiless-psh/resources/.platform/platform.whitelist.yaml
@@ -21,3 +21,5 @@ web:
     locations:
         '/':
             expires:
+        '/___docs':
+            expires:

--- a/packages/bodiless-psh/src/bodiless-psh-init.ts
+++ b/packages/bodiless-psh/src/bodiless-psh-init.ts
@@ -56,7 +56,6 @@ const mergeByKey = (Source: any, Destination: any, Whitelist: any) => {
             console.log(`Key '${key}' is not whitelisted and not found in '@bodiless/psh' defaults. The value of ${Destination[key]} will be used.`);
             Object.assign(result, { [key]: Destination[key] });
           } else {
-            console.log(`Key '${key}' is not whitelisted. The default value of '${Source[key]}' from '@bodiless/psh' will be used.`);
             Object.assign(result, { [key]: Source[key] });
           }
         }

--- a/packages/bodiless-psh/src/bodiless-psh-init.ts
+++ b/packages/bodiless-psh/src/bodiless-psh-init.ts
@@ -56,6 +56,9 @@ const mergeByKey = (Source: any, Destination: any, Whitelist: any) => {
             console.log(`Key '${key}' is not whitelisted and not found in '@bodiless/psh' defaults. The value of ${Destination[key]} will be used.`);
             Object.assign(result, { [key]: Destination[key] });
           } else {
+            if (Source[key] !== Destination[key]) {
+              console.log(`Key '${key}' is not whitelisted and default value of '${Source[key]}' is different from site level value '${Destination[key]}'. Default value will be used. `)
+            }
             Object.assign(result, { [key]: Source[key] });
           }
         }

--- a/packages/bodiless-psh/src/bodiless-psh-init.ts
+++ b/packages/bodiless-psh/src/bodiless-psh-init.ts
@@ -57,7 +57,7 @@ const mergeByKey = (Source: any, Destination: any, Whitelist: any) => {
             Object.assign(result, { [key]: Destination[key] });
           } else {
             if (Source[key] !== Destination[key]) {
-              console.log(`Key '${key}' is not whitelisted and default value of '${Source[key]}' is different from site level value '${Destination[key]}'. Default value will be used. `)
+              console.log(`Key '${key}' is not whitelisted and default value of '${Source[key]}' is different from site level value '${Destination[key]}'. Default value will be used. `);
             }
             Object.assign(result, { [key]: Source[key] });
           }


### PR DESCRIPTION
## Changes
- `expires` key was added for `/__docs` path.

## Test Instructions
#### Test if `expires` prop works:
- Deploy a site to p.sh using updated `@bodiless/psh` package.
- Open Docs
- Check the `network` tab in the chrome console.
- You should see the `Cache-Control` and `Expires` headers enabled.

## Related Issues
Fixes: https://github.com/johnsonandjohnson/Bodiless-JS/issues/172
