### PR TITLE
fix(Backend): commit operation throws 'authentication failed' error with an exposed password.

### DIFF
--- a/packages/bodiless-backend/src/backend.js
+++ b/packages/bodiless-backend/src/backend.js
@@ -354,7 +354,7 @@ class Backend {
       res.status(500);
     }
     // End response process to prevent any further queued promises/events from responding.
-    res.send(error.message).end();
+    res.send(Backend.sanitizeOutput(error.message)).end();
   }
 
   static gitCommitsEnabled(res) {
@@ -631,6 +631,10 @@ class Backend {
           res.send({});
         });
     });
+  }
+
+  static sanitizeOutput(data) {
+    return data.replace(/(http|https):\/\/[^@]+:[^@]+@/gi, '$1://****:****@');
   }
 
   start(port) {


### PR DESCRIPTION

## Test Instructions
- Checkout the repo using https as git remote origin.
- Alter github credential so commits can not be pushed to origin successfully.
- Setup edit site
- Make some changes and commit.

## Related Issues
<!--
  Link to the issue that is fixed or resolved by this PR (if there is one)
  e.g. Fixes #1234, Closes #4567

  Link to an issue that is partially addressed by this PR (if there are any)
-->

Fixes #274 

<!-- IF THIS PR INTRODUCES A BREAKING CHANGE

BREAKING CHANGE: Describe the nature of the breaking change here.

More Details about the breaking change.
-->
