### PR TITLE
fix(richtext): richtext content is not reverted until page is refreshed

### DIFF
--- a/packages/bodiless-richtext/src/useNodeStateHandlers.ts
+++ b/packages/bodiless-richtext/src/useNodeStateHandlers.ts
@@ -101,7 +101,7 @@ const useValue: TUseValue = ({ initialValue }) => {
   // @see https://github.com/ianstormtaylor/slate/blob/6d8df18f016df75da0d49d6b753cecb333dca078/packages/slate/src/models/value.js#L803
   const jsonValue = oldValue.toJSON(preserveAll);
   if (isEqual(jsonValue.document, node.data.document)) return oldValue;
-  // jsonValue.document = node.data.document;
+  jsonValue.document = node.data.document;
   return Value.fromJSON(jsonValue);
 };
 


### PR DESCRIPTION
## Changes
* fixed the issue that richtext content on a contentful tout is not reverted until the page is refreshed
* enabled back the logic responsible for combining richtext mobx store data with content node data to pass value prop to slate editor component.

## Notes
* the reason the logic was commented out is to deal with performance issues in slate editor. but taking into consideration other performance optimizations were made for slate editor and commenting out the logic breaks data propagation from the server, the logic is enabled back.

## Test Instructions

Notes:
* the changes may impact richtext performance. a test should be made if the difference is noticeable to the user 

STR1 (vanilla richtext)
1. open edit app of test-site
2. open /richtext page
3. type some text to "Simple Rich Text"
4. find related json file on file system (examples/test-site/src/data/pages/richtext/simpleRTE.json)
5. update text in the json file

Actual: "Simple Rich Text" is not updated with the new text until the page is refreshed
Expected: "Simple Rich Text" is updated with the new text

STR2 (contentful component)
1. open edit app of test-site
2. open homepage
3. type some text to flexbox tout body
4. revert the changes using local revert button

Actual: tout body changes are not reverted until the page is refreshed
Expected: tout body changes are reverted without page refresh
## Related Issues
<!--
  Link to the issue that is fixed or resolved by this PR (if there is one)
  e.g. Fixes #1234, Closes #4567

  Link to an issue that is partially addressed by this PR (if there are any)
-->

<!-- IF THIS PR INTRODUCES A BREAKING CHANGE

BREAKING CHANGE: Describe the nature of the breaking change here.

More Details about the breaking change.
-->
