### PR TITLE
feat(core): Sidecar Node API

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -38,6 +38,7 @@
   ],
   "spellright.documentTypes": [
     "markdown",
+    "md",
     "latex",
     "plaintext"
   ],

--- a/cypress/integration/link_menu.spec.js
+++ b/cypress/integration/link_menu.spec.js
@@ -1,3 +1,17 @@
+/**
+ * Copyright © 2020 Johnson & Johnson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /* eslint-disable jest/valid-expect */
 /* eslint-disable no-undef */
 // <reference types="Cypress" />

--- a/cypress/integration/smokeTest/editorMenu_spec.js
+++ b/cypress/integration/smokeTest/editorMenu_spec.js
@@ -1,3 +1,17 @@
+/**
+ * Copyright © 2020 Johnson & Johnson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 describe('Editor Menu (left and right)', function () {
 
    before(function () {

--- a/cypress/integration/smokeTest/linkToggle_spec.js
+++ b/cypress/integration/smokeTest/linkToggle_spec.js
@@ -1,3 +1,17 @@
+/**
+ * Copyright © 2020 Johnson & Johnson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 describe('Link Toggle smoke tests', function () {
 
   before(function () {

--- a/cypress/integration/smokeTest/singleAccordion_spec.js
+++ b/cypress/integration/smokeTest/singleAccordion_spec.js
@@ -1,3 +1,17 @@
+/**
+ * Copyright © 2020 Johnson & Johnson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 describe('Single Accordion smoke tests', function () {
 
   before(function () {

--- a/cypress/integration/smokeTest/touts_spec.js
+++ b/cypress/integration/smokeTest/touts_spec.js
@@ -1,3 +1,17 @@
+/**
+ * Copyright © 2020 Johnson & Johnson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 describe('Tout testing', function () {
 
   before(function () {

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -1,3 +1,17 @@
+/**
+ * Copyright © 2020 Johnson & Johnson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // ***********************************************************
 // This example plugins/index.js can be used to load plugins
 //

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,3 +1,17 @@
+/**
+ * Copyright © 2020 Johnson & Johnson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // ***********************************************
 // This example commands.js shows you how to
 // create various custom commands and overwrite

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,3 +1,17 @@
+/**
+ * Copyright © 2020 Johnson & Johnson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // ***********************************************************
 // This example support/index.js is processed and
 // loaded automatically before your test files.

--- a/examples/test-site/src/components/FlowContainer/token.tsx
+++ b/examples/test-site/src/components/FlowContainer/token.tsx
@@ -1,3 +1,17 @@
+/**
+ * Copyright © 2020 Johnson & Johnson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {
   addClasses,
   withDesign,

--- a/packages/bodiless-backend/__tests__/getChanges.test.ts
+++ b/packages/bodiless-backend/__tests__/getChanges.test.ts
@@ -1,3 +1,17 @@
+/**
+ * Copyright © 2020 Johnson & Johnson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import path from 'path';
 import { mkdirSync } from 'fs';
 

--- a/packages/bodiless-components/__tests__/Image.test.tsx
+++ b/packages/bodiless-components/__tests__/Image.test.tsx
@@ -1,3 +1,17 @@
+/**
+ * Copyright © 2020 Johnson & Johnson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { mount, ReactWrapper } from 'enzyme';

--- a/packages/bodiless-components/__tests__/Link.test.tsx
+++ b/packages/bodiless-components/__tests__/Link.test.tsx
@@ -1,3 +1,17 @@
+/**
+ * Copyright © 2020 Johnson & Johnson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { mount, ReactWrapper } from 'enzyme';

--- a/packages/bodiless-core-ui/src/ReactTags.tsx
+++ b/packages/bodiless-core-ui/src/ReactTags.tsx
@@ -1,3 +1,17 @@
+/**
+ * Copyright © 2020 Johnson & Johnson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { ComponentType } from 'react';
 import { ReactTagsField as ReactTagsFieldClean, ReactTagsFieldProps } from '@bodiless/core';
 

--- a/packages/bodiless-core/__tests__/hoc.test.tsx
+++ b/packages/bodiless-core/__tests__/hoc.test.tsx
@@ -1,3 +1,17 @@
+/**
+ * Copyright © 2020 Johnson & Johnson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { shallow, mount } from 'enzyme';
 import { observable } from 'mobx';

--- a/packages/bodiless-core/__tests__/withSidecarNodes.test.tsx
+++ b/packages/bodiless-core/__tests__/withSidecarNodes.test.tsx
@@ -1,0 +1,62 @@
+import React, { ComponentType } from 'react';
+import { flowRight } from 'lodash';
+import { mount } from 'enzyme';
+import withNode, { withNodeKey } from '../src/withNode';
+import { useNode } from '../src/NodeProvider';
+
+const withEnhancement = (id: string) => (Component: ComponentType<any>) => (props: any) => {
+  const { node } = useNode();
+  const enhancement = {
+    [`data-enh-${id}`]: node.path.join('$'),
+  };
+  return (
+    <Component {...props} {...enhancement} />
+  );
+};
+
+const withSidecarNodes = flowRight;
+
+const NodePathPrinter = (props: any) => (<span {...props}>{useNode().node.path.join('$')}</span>);
+
+const asBodilessComponent = (nodeKey?: string) => flowRight(
+  withNodeKey(nodeKey),
+  withNode,
+);
+
+const withCompoundEnhancement = (nodeKey?: string) => flowRight(
+  asBodilessComponent(nodeKey),
+  withEnhancement('foo'),
+  asBodilessComponent('bar'),
+  withEnhancement('bar'),
+);
+
+const asTestWithoutEnhancement = flowRight(
+  asBodilessComponent('test'),
+);
+
+const asTestWithEnhancement = flowRight(
+  withNodeKey('test'),
+  withSidecarNodes(
+    withCompoundEnhancement('foo'),
+  ),
+  asBodilessComponent(),
+);
+
+describe('withSidecarNodes', () => {
+  it('restores the original node', () => {
+    let Test;
+    let wrapper;
+    Test = asTestWithoutEnhancement(NodePathPrinter);
+    wrapper = mount(<Test id="test" />);
+    expect(wrapper.find('span#test').text()).toBe('root$test');
+    Test = asTestWithEnhancement(NodePathPrinter);
+    wrapper = mount(<Test id="test" />);
+    const span = wrapper.find('span#test');
+    expect(span.text()).toBe('root$test');
+    expect(span.prop('data-enh-foo')).toBe('root$test$foo');
+    expect(span.prop('data-enh-bar')).toBe('root$test$foo$bar');
+    console.log(wrapper.debug());
+  });
+});
+
+export default withCompoundEnhancement;

--- a/packages/bodiless-core/__tests__/withSidecarNodes.test.tsx
+++ b/packages/bodiless-core/__tests__/withSidecarNodes.test.tsx
@@ -1,3 +1,17 @@
+/**
+ * Copyright © 2020 Johnson & Johnson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { ComponentType } from 'react';
 import { flowRight } from 'lodash';
 import { mount } from 'enzyme';

--- a/packages/bodiless-core/__tests__/withSidecarNodes.test.tsx
+++ b/packages/bodiless-core/__tests__/withSidecarNodes.test.tsx
@@ -8,34 +8,49 @@ import withSidecarNodes from '../src/withSidecarNodes';
 type HOC = (C: ComponentType<any>) => ComponentType<any>;
 type Bodiless = (key?: string) => HOC;
 
-const withEnhancement = (id: string) => (Component: ComponentType<any>) => (props: any) => {
-  const { node } = useNode();
-  const enhancement = {
-    [`data-enh-${id}`]: node.path.join('$'),
-  };
-  return (
-    <Component {...props} {...enhancement} />
-  );
-};
-
-const NodePathPrinter = (props: any) => (<span {...props}>{useNode().node.path.join('$')}</span>);
-
-const asBodilessComponent: Bodiless = (nodeKey?: string) => flowRight(
-  withNodeKey(nodeKey),
-  withNode,
+const withEnhancement = (id: string) => (Component: ComponentType<any>) => withNode(
+  (props: any) => {
+    const { node } = useNode();
+    const enhancement = {
+      [`data-enh-${id}`]: node.path.join('$'),
+    };
+    return (
+      <Component {...props} {...enhancement} />
+    );
+  },
 );
 
-const withCompoundEnhancement: Bodiless = (nodeKey?: string) => flowRight(
-  asBodilessComponent(nodeKey),
+// const withId: (id: string) => HOC = id => Component => props => (
+//   <Component {...props} id={id} />
+// );
+
+const NodePathPrinter = withNode(
+  (props: any) => (<span {...props}>{useNode().node.path.join('$')}</span>),
+);
+
+const CompoundPrinter = withNode(
+  ({ printer: Printer, ...rest }: any) => (
+    <span {...rest}>
+      <Printer nodeKey="baz" id="baz" />
+    </span>
+  ),
+);
+
+const withFoo: Bodiless = (nodeKey?: string) => flowRight(
+  withNodeKey(nodeKey),
   withEnhancement('foo'),
-  asBodilessComponent('bar'),
+);
+
+const withBar: Bodiless = (nodeKey?: string) => flowRight(
+  withNodeKey(nodeKey),
   withEnhancement('bar'),
 );
+
 
 describe('withSidecarNodes', () => {
   it('is tested against the correct baseline', () => {
     const asTestWithoutEnhancement: HOC = flowRight(
-      asBodilessComponent('test'),
+      withNodeKey('test'),
     );
     const Test = asTestWithoutEnhancement(NodePathPrinter);
     const wrapper = mount(<Test id="test" />);
@@ -46,9 +61,9 @@ describe('withSidecarNodes', () => {
     const asTestWithEnhancement: HOC = flowRight(
       withNodeKey('test'),
       withSidecarNodes(
-        withCompoundEnhancement('foo'),
+        withFoo('foo'),
+        withBar('bar'),
       ),
-      asBodilessComponent(),
     );
     const Test = asTestWithEnhancement(NodePathPrinter);
     const wrapper = mount(<Test id="test" />);
@@ -58,12 +73,55 @@ describe('withSidecarNodes', () => {
     expect(span.prop('data-enh-bar')).toBe('root$test$foo$bar');
   });
 
+
+  it('can create multiple sidecars', () => {
+    const asTest: HOC = flowRight(
+      withNodeKey('test'),
+      withSidecarNodes(
+        withFoo('foo'),
+      ),
+      withSidecarNodes(
+        withBar('bar'),
+      ),
+    );
+    const Test = asTest(NodePathPrinter);
+    const wrapper = mount(<Test id="test" />);
+    const span = wrapper.find('span#test');
+    expect(span.text()).toBe('root$test');
+    expect(span.prop('data-enh-foo')).toBe('root$test$foo');
+    expect(span.prop('data-enh-bar')).toBe('root$test$bar');
+  });
+
+  it('is tested against the correct baseline for nested sidecars', () => {
+    const wrapper = mount(<CompoundPrinter
+      printer={NodePathPrinter}
+      id="test"
+      nodeKey="test"
+    />);
+    const span = wrapper.find('span#baz');
+    expect(span.text()).toBe('root$test$baz');
+  });
+
+  it.only('supports nested sidecars', () => {
+    const EnhancedCompoundPrinter = withSidecarNodes(withFoo('foo'))(CompoundPrinter);
+    const EnhancedPrinter = withSidecarNodes(withBar('bar'))(NodePathPrinter);
+    const wrapper = mount(<EnhancedCompoundPrinter
+      printer={EnhancedPrinter}
+      id="test"
+      nodeKey="test"
+    />);
+    console.log(wrapper.debug());
+    const span = wrapper.find('span#baz');
+    expect(span.text()).toBe('root$test$baz');
+  });
+
   it('adds new peers and restores original node', () => {
     const asTestWithEnhancement: HOC = flowRight(
       withSidecarNodes(
-        withCompoundEnhancement('foo'),
+        withFoo('foo'),
+        withBar('bar'),
       ),
-      asBodilessComponent('test'),
+      withNodeKey('test'),
     );
     const Test = asTestWithEnhancement(NodePathPrinter);
     const wrapper = mount(<Test id="test" />);
@@ -73,5 +131,3 @@ describe('withSidecarNodes', () => {
     expect(span.prop('data-enh-bar')).toBe('root$foo$bar');
   });
 });
-
-export default withCompoundEnhancement;

--- a/packages/bodiless-core/__tests__/withSidecarNodes.test.tsx
+++ b/packages/bodiless-core/__tests__/withSidecarNodes.test.tsx
@@ -3,6 +3,10 @@ import { flowRight } from 'lodash';
 import { mount } from 'enzyme';
 import withNode, { withNodeKey } from '../src/withNode';
 import { useNode } from '../src/NodeProvider';
+import withSidecarNodes from '../src/withSidecarNodes';
+
+type HOC = (C: ComponentType<any>) => ComponentType<any>;
+type Bodiless = (key?: string) => HOC;
 
 const withEnhancement = (id: string) => (Component: ComponentType<any>) => (props: any) => {
   const { node } = useNode();
@@ -14,48 +18,59 @@ const withEnhancement = (id: string) => (Component: ComponentType<any>) => (prop
   );
 };
 
-const withSidecarNodes = flowRight;
-
 const NodePathPrinter = (props: any) => (<span {...props}>{useNode().node.path.join('$')}</span>);
 
-const asBodilessComponent = (nodeKey?: string) => flowRight(
+const asBodilessComponent: Bodiless = (nodeKey?: string) => flowRight(
   withNodeKey(nodeKey),
   withNode,
 );
 
-const withCompoundEnhancement = (nodeKey?: string) => flowRight(
+const withCompoundEnhancement: Bodiless = (nodeKey?: string) => flowRight(
   asBodilessComponent(nodeKey),
   withEnhancement('foo'),
   asBodilessComponent('bar'),
   withEnhancement('bar'),
 );
 
-const asTestWithoutEnhancement = flowRight(
-  asBodilessComponent('test'),
-);
-
-const asTestWithEnhancement = flowRight(
-  withNodeKey('test'),
-  withSidecarNodes(
-    withCompoundEnhancement('foo'),
-  ),
-  asBodilessComponent(),
-);
-
 describe('withSidecarNodes', () => {
-  it('restores the original node', () => {
-    let Test;
-    let wrapper;
-    Test = asTestWithoutEnhancement(NodePathPrinter);
-    wrapper = mount(<Test id="test" />);
+  it('is tested against the correct baseline', () => {
+    const asTestWithoutEnhancement: HOC = flowRight(
+      asBodilessComponent('test'),
+    );
+    const Test = asTestWithoutEnhancement(NodePathPrinter);
+    const wrapper = mount(<Test id="test" />);
     expect(wrapper.find('span#test').text()).toBe('root$test');
-    Test = asTestWithEnhancement(NodePathPrinter);
-    wrapper = mount(<Test id="test" />);
+  });
+
+  it('adds new children and restores original node', () => {
+    const asTestWithEnhancement: HOC = flowRight(
+      withNodeKey('test'),
+      withSidecarNodes(
+        withCompoundEnhancement('foo'),
+      ),
+      asBodilessComponent(),
+    );
+    const Test = asTestWithEnhancement(NodePathPrinter);
+    const wrapper = mount(<Test id="test" />);
     const span = wrapper.find('span#test');
     expect(span.text()).toBe('root$test');
     expect(span.prop('data-enh-foo')).toBe('root$test$foo');
     expect(span.prop('data-enh-bar')).toBe('root$test$foo$bar');
-    console.log(wrapper.debug());
+  });
+
+  it('adds new peers and restores original node', () => {
+    const asTestWithEnhancement: HOC = flowRight(
+      withSidecarNodes(
+        withCompoundEnhancement('foo'),
+      ),
+      asBodilessComponent('test'),
+    );
+    const Test = asTestWithEnhancement(NodePathPrinter);
+    const wrapper = mount(<Test id="test" />);
+    const span = wrapper.find('span#test');
+    expect(span.text()).toBe('root$test');
+    expect(span.prop('data-enh-foo')).toBe('root$foo');
+    expect(span.prop('data-enh-bar')).toBe('root$foo$bar');
   });
 });
 

--- a/packages/bodiless-core/__tests__/withSidecarNodes.test.tsx
+++ b/packages/bodiless-core/__tests__/withSidecarNodes.test.tsx
@@ -102,7 +102,7 @@ describe('withSidecarNodes', () => {
     expect(span.text()).toBe('root$test$baz');
   });
 
-  it.only('supports nested sidecars', () => {
+  it('supports nested sidecars', () => {
     const EnhancedCompoundPrinter = withSidecarNodes(withFoo('foo'))(CompoundPrinter);
     const EnhancedPrinter = withSidecarNodes(withBar('bar'))(NodePathPrinter);
     const wrapper = mount(<EnhancedCompoundPrinter
@@ -110,9 +110,11 @@ describe('withSidecarNodes', () => {
       id="test"
       nodeKey="test"
     />);
-    console.log(wrapper.debug());
-    const span = wrapper.find('span#baz');
-    expect(span.text()).toBe('root$test$baz');
+    const innerSpan = wrapper.find('span#baz');
+    expect(innerSpan.text()).toBe('root$test$baz');
+    expect(innerSpan.prop('data-enh-bar')).toBe('root$test$baz$bar');
+    const outerSpan = wrapper.find('span#test');
+    expect(outerSpan.prop('data-enh-foo')).toBe('root$test$foo');
   });
 
   it('adds new peers and restores original node', () => {

--- a/packages/bodiless-core/__tests__/withSidecarNodes.test.tsx
+++ b/packages/bodiless-core/__tests__/withSidecarNodes.test.tsx
@@ -1,14 +1,20 @@
 import React, { ComponentType } from 'react';
 import { flowRight } from 'lodash';
-import { mount, render } from 'enzyme';
+import { mount } from 'enzyme';
 import withNode, { withNodeKey } from '../src/withNode';
 import { useNode } from '../src/NodeProvider';
-import withSidecarNodes from '../src/withSidecarNodes';
+import withSidecarNodes, { endSidecarNodes } from '../src/withSidecarNodes';
+import { ifToggledOn } from '../src/withFlowToggle';
 
 type HOC = (C: ComponentType<any>) => ComponentType<any>;
 type Bodiless = (key?: string) => HOC;
 
-const withEnhancement = (id: string) => (Component: ComponentType<any>) => withNode(
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const withProps: (propsToAdd: any) => HOC = propsToAdd => Component => props => (
+  <Component {...propsToAdd} {...props} />
+);
+
+const withPropEnhancement = (id: string) => (Component: ComponentType<any>) => (
   (props: any) => {
     const { node } = useNode();
     const enhancement = {
@@ -17,121 +23,201 @@ const withEnhancement = (id: string) => (Component: ComponentType<any>) => withN
     return (
       <Component {...props} {...enhancement} />
     );
-  },
-);
-
-// const withId: (id: string) => HOC = id => Component => props => (
-//   <Component {...props} id={id} />
-// );
-
-const NodePathPrinter = withNode(
-  (props: any) => (<span {...props}>{useNode().node.path.join('$')}</span>),
-);
-
-const CompoundPrinter = withNode(
-  ({ printer: Printer, ...rest }: any) => (
-    <span {...rest}>
-      <Printer id="baz" />
-    </span>
-  ),
+  }
 );
 
 const withFoo: Bodiless = (nodeKey?: string) => flowRight(
   withNodeKey(nodeKey),
-  withEnhancement('foo'),
+  withNode,
+  withPropEnhancement('foo'),
 );
 
 const withBar: Bodiless = (nodeKey?: string) => flowRight(
   withNodeKey(nodeKey),
-  withEnhancement('bar'),
+  withNode,
+  withPropEnhancement('bar'),
 );
 
+const withBaz: Bodiless = (nodeKey?: string) => flowRight(
+  withNodeKey(nodeKey),
+  withNode,
+  withPropEnhancement('baz'),
+);
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const withWrapperEnhancement = (id: string) => (Component: ComponentType<any>) => (
+  (props: any) => {
+    const { node } = useNode();
+    const enhancement = {
+      [`data-enh-${id}`]: node.path.join('$'),
+    };
+    return (
+      <span {...enhancement} id={`enh-${id}`}>
+        <Component {...props} />
+      </span>
+    );
+  }
+);
+
+const spanWithId = (id: string) => (props: any) => <span {...props} id={id} />;
+
+describe('Sidecar Node Use Cases', () => {
+  describe('Adding a toggle', () => {
+    const mockNodeData = jest.fn();
+    const useDataToggle = () => mockNodeData(useNode<any>().node.path.join('$'));
+    const withToggleTo = (ToComponent: ComponentType<any>) => (nodeKey?: string) => flowRight(
+      withNodeKey(nodeKey),
+      withNode,
+      ifToggledOn(useDataToggle)(
+        () => ToComponent,
+      ),
+    );
+    const Span = spanWithId('test');
+    it('has the correct baseline', () => {
+      const Test = withFoo('foo')(Span);
+      const wrapper = mount(<Test />);
+      expect(wrapper.find('span#test').prop('data-enh-foo')).toBe('root$foo');
+    });
+    describe('Without sidecar', () => {
+      const Bar = withBar('foo')(spanWithId('bar'));
+      const Test = flowRight(
+        withToggleTo(Bar)('toggle'),
+        withFoo('foo'),
+      )(Span);
+      it('modifies the child nodekey when toggled off', () => {
+        mockNodeData.mockReset();
+        mockNodeData.mockReturnValueOnce(false);
+        const wrapper = mount(<Test />);
+        expect(mockNodeData.mock.calls[0][0]).toBe('root$toggle');
+        expect(wrapper.find('span#bar')).toHaveLength(0);
+        expect(wrapper.find('span#test').prop('data-enh-foo')).toBe('root$toggle$foo');
+      });
+      it('modifies the child nodekey when toggled on', () => {
+        mockNodeData.mockReset();
+        mockNodeData.mockReturnValueOnce(true);
+        const wrapper = mount(<Test />);
+        expect(mockNodeData.mock.calls[0][0]).toBe('root$toggle');
+        expect(wrapper.find('span#test')).toHaveLength(0);
+        expect(wrapper.find('span#bar').prop('data-enh-bar')).toBe('root$toggle$foo');
+      });
+    });
+    describe('With sidecar', () => {
+      const Bar = withBar('foo')(spanWithId('bar'));
+      const Test = flowRight(
+        withSidecarNodes(
+          withToggleTo(endSidecarNodes(Bar))('toggle'),
+        ),
+        withFoo('foo'),
+      )(Span);
+      it('does not change the child nodekey when toggled off', () => {
+        mockNodeData.mockReset();
+        mockNodeData.mockReturnValueOnce(false);
+        const wrapper = mount(<Test />);
+        expect(mockNodeData.mock.calls[0][0]).toBe('root$toggle');
+        expect(wrapper.find('span#bar')).toHaveLength(0);
+        expect(wrapper.find('span#test').prop('data-enh-foo')).toBe('root$foo');
+      });
+      it('does not modify the child nodekey when toggled on', () => {
+        mockNodeData.mockReset();
+        mockNodeData.mockReturnValueOnce(true);
+        const wrapper = mount(<Test />);
+        expect(mockNodeData.mock.calls[0][0]).toBe('root$toggle');
+        expect(wrapper.find('span#test')).toHaveLength(0);
+        expect(wrapper.find('span#bar').prop('data-enh-bar')).toBe('root$foo');
+      });
+    });
+  });
+  describe('Enhancing a flow container item wrapper without changing data', () => {
+    const ChildNodeProvider:any = withNode(React.Fragment);
+    const Item:any = withFoo()(spanWithId('item'));
+    const BasicWrapper:any = spanWithId('wrapper');
+    const asFlowContainerItem = (Wrapper: any) => (
+      <ChildNodeProvider nodeKey="child">
+        <Wrapper>
+          <Item />
+        </Wrapper>
+      </ChildNodeProvider>
+    );
+    it('has a correct baseline', () => {
+      const baseline = asFlowContainerItem(BasicWrapper);
+      const wrapper = mount(baseline);
+      expect(wrapper.find('span#item').prop('data-enh-foo')).toBe('root$child');
+    });
+    it('leaves original nodekey unchanged when enhancement is in sidecar', () => {
+      const EnhancedWrapper = withSidecarNodes(withBar('barkey'))(BasicWrapper);
+      const test = asFlowContainerItem(EnhancedWrapper);
+      const wrapper = mount(test);
+      expect(wrapper.find('span#item').prop('data-enh-foo')).toBe('root$child');
+      expect(wrapper.find('span#wrapper').prop('data-enh-bar')).toBe('root$child$barkey');
+    });
+    it('changes the original nodekey when enhancement is not in sidecar', () => {
+      const EnhancedWrapper = withBar('barkey')(BasicWrapper);
+      const test = asFlowContainerItem(EnhancedWrapper);
+      const wrapper = mount(test);
+      expect(wrapper.find('span#item').prop('data-enh-foo')).toBe('root$child$barkey');
+      expect(wrapper.find('span#wrapper').prop('data-enh-bar')).toBe('root$child$barkey');
+    });
+  });
+});
 
 describe('withSidecarNodes', () => {
-  it('is tested against the correct baseline', () => {
-    const asTestWithoutEnhancement: HOC = flowRight(
-      withNodeKey('test'),
-    );
-    const Test = asTestWithoutEnhancement(NodePathPrinter);
-    const wrapper = mount(<Test id="test" />);
-    expect(wrapper.find('span#test').text()).toBe('root$test');
-  });
-
-  it('adds new children and restores original node', () => {
-    const asTestWithEnhancement: HOC = flowRight(
-      withNodeKey('test'),
-      withSidecarNodes(
-        withFoo('foo'),
-        withBar('bar'),
-      ),
-    );
-    const Test = asTestWithEnhancement(NodePathPrinter);
-    const wrapper = mount(<Test id="test" />);
-    const span = wrapper.find('span#test');
-    expect(span.text()).toBe('root$test');
-    expect(span.prop('data-enh-foo')).toBe('root$test$foo');
-    expect(span.prop('data-enh-bar')).toBe('root$test$foo$bar');
-  });
-
-
-  it('can create multiple sidecars', () => {
-    const asTest: HOC = flowRight(
-      withNodeKey('test'),
+  it('Preserves the original nodeKey when an HOC is applied outside.', () => {
+    const Test = flowRight(
       withSidecarNodes(
         withFoo('foo'),
       ),
-      withSidecarNodes(
-        withBar('bar'),
-      ),
-    );
-    const Test = asTest(NodePathPrinter);
-    const wrapper = mount(<Test id="test" />);
-    const span = wrapper.find('span#test');
-    expect(span.text()).toBe('root$test');
-    expect(span.prop('data-enh-foo')).toBe('root$test$foo');
-    expect(span.prop('data-enh-bar')).toBe('root$test$bar');
+      withBar('bar'),
+    )(spanWithId('test'));
+    const wrapper = mount(<Test />);
+    expect(wrapper.find('span#test').prop('data-enh-foo')).toBe('root$foo');
+    expect(wrapper.find('span#test').prop('data-enh-bar')).toBe('root$bar');
   });
-
-  const nestedBaseline: { Printer: ComponentType<any>, Compound: ComponentType<any> } = {
-    Printer: withNodeKey('baz')(NodePathPrinter),
-    Compound: withNodeKey('test')(CompoundPrinter),
-  };
-
-  const mountNested = ({ Printer, Compound }: any) => render(<Compound printer={Printer} id="test" />);
-
-  it('is tested against the correct baseline for nested sidecars', () => {
-    const wrapper = mountNested(nestedBaseline);
-    const span = wrapper.find('span#baz');
-    expect(span.text()).toBe('root$test$baz');
-  });
-
-
-  it.only('supports nested sidecars', () => {
-    const { Printer: BaselinePrinter, Compound: BaselineCompound } = nestedBaseline;
-    const Compound = withSidecarNodes(withFoo('foo'))(BaselineCompound);
-    const Printer = withSidecarNodes(withBar('bar'))(BaselinePrinter);
-    const wrapper = mountNested({ Printer, Compound });
-    console.log(wrapper.parent().html());
-    const innerSpan = wrapper.find('span#baz');
-    expect(innerSpan.text()).toBe('root$test$baz');
-    expect(innerSpan.prop('data-enh-bar')).toBe('root$test$baz$bar');
-    const outerSpan = wrapper.find('span#test');
-    expect(outerSpan.prop('data-enh-foo')).toBe('root$test$foo');
-  });
-
-  it('adds new peers and restores original node', () => {
-    const asTestWithEnhancement: HOC = flowRight(
+  it('Preserves the original nodeKey when wrapping a component.', () => {
+    const Bar = withBar('bar')(spanWithId('test'));
+    const baseline = mount(<Bar />);
+    const Test = flowRight(
       withSidecarNodes(
         withFoo('foo'),
+      ),
+    )(Bar);
+    const wrapper = mount(<Test />);
+    expect(wrapper.find('span#test').prop('data-enh-foo')).toBe('root$foo');
+    expect(wrapper.find('span#test').prop('data-enh-bar')).toBe('root$bar');
+    expect(baseline.find('span#test').prop('data-enh-bar')).toBe('root$bar');
+  });
+  it('Supports multiple sidecars', () => {
+    const Test = flowRight(
+      withFoo('foo'),
+      withSidecarNodes(
         withBar('bar'),
       ),
-      withNodeKey('test'),
-    );
-    const Test = asTestWithEnhancement(NodePathPrinter);
-    const wrapper = mount(<Test id="test" />);
+      withSidecarNodes(
+        withBaz('baz'),
+      ),
+    )(spanWithId('test'));
+    const wrapper = mount(<Test />);
+    expect(wrapper.find('span#test').prop('data-enh-foo')).toBe('root$foo');
+    expect(wrapper.find('span#test').prop('data-enh-bar')).toBe('root$foo$bar');
+    expect(wrapper.find('span#test').prop('data-enh-baz')).toBe('root$foo$baz');
+  });
+  it('Supports nested sidecars', () => {
+    const Test = flowRight(
+      withSidecarNodes(
+        withNodeKey('foobar'),
+        withNode,
+        withSidecarNodes(
+          withSidecarNodes(
+            withBar('bar'),
+          ),
+          withFoo('foo'),
+        ),
+      ),
+      withBaz('baz'),
+    )(spanWithId('test'));
+    const wrapper = mount(<Test />);
     const span = wrapper.find('span#test');
-    expect(span.text()).toBe('root$test');
-    expect(span.prop('data-enh-foo')).toBe('root$foo');
-    expect(span.prop('data-enh-bar')).toBe('root$foo$bar');
+    expect(span.prop('data-enh-foo')).toBe('root$foobar$foo');
+    expect(span.prop('data-enh-bar')).toBe('root$foobar$bar');
+    expect(span.prop('data-enh-baz')).toBe('root$baz');
   });
 });

--- a/packages/bodiless-core/__tests__/withSidecarNodes.test.tsx
+++ b/packages/bodiless-core/__tests__/withSidecarNodes.test.tsx
@@ -23,11 +23,6 @@ import { ifToggledOn } from '../src/withFlowToggle';
 type HOC = (C: ComponentType<any>) => ComponentType<any>;
 type Bodiless = (key?: string) => HOC;
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const withProps: (propsToAdd: any) => HOC = propsToAdd => Component => props => (
-  <Component {...propsToAdd} {...props} />
-);
-
 const withPropEnhancement = (id: string) => (Component: ComponentType<any>) => (
   (props: any) => {
     const { node } = useNode();
@@ -56,21 +51,6 @@ const withBaz: Bodiless = (nodeKey?: string) => flowRight(
   withNodeKey(nodeKey),
   withNode,
   withPropEnhancement('baz'),
-);
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const withWrapperEnhancement = (id: string) => (Component: ComponentType<any>) => (
-  (props: any) => {
-    const { node } = useNode();
-    const enhancement = {
-      [`data-enh-${id}`]: node.path.join('$'),
-    };
-    return (
-      <span {...enhancement} id={`enh-${id}`}>
-        <Component {...props} />
-      </span>
-    );
-  }
 );
 
 const spanWithId = (id: string) => (props: any) => <span {...props} id={id} />;

--- a/packages/bodiless-core/src/index.ts
+++ b/packages/bodiless-core/src/index.ts
@@ -18,6 +18,7 @@ import PageEditContext from './PageEditContext';
 import asStatic from './asStatic';
 import { useEditContext, useUUID, useContextActivator } from './hooks';
 import withNode, { withNodeKey } from './withNode';
+import withSidecarNodes, { startSidecarNodes, endSidecarNodes } from './withSidecarNodes';
 import {
   withDefaultContent,
   withResetButton,
@@ -73,6 +74,9 @@ export {
   EditButtonOptions,
   withNode,
   withNodeKey,
+  withSidecarNodes,
+  startSidecarNodes,
+  endSidecarNodes,
   contextMenuForm,
   withData,
   NodeProvider,

--- a/packages/bodiless-core/src/withSidecarNodes.tsx
+++ b/packages/bodiless-core/src/withSidecarNodes.tsx
@@ -1,3 +1,17 @@
+/**
+ * Copyright © 2020 Johnson & Johnson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 
 import React, { createContext, useContext, ComponentType } from 'react';
 import { flowRight } from 'lodash';

--- a/packages/bodiless-core/src/withSidecarNodes.tsx
+++ b/packages/bodiless-core/src/withSidecarNodes.tsx
@@ -2,30 +2,90 @@
 import React, { createContext, useContext, ComponentType } from 'react';
 import { flowRight } from 'lodash';
 import NodeProvider, { useNode } from './NodeProvider';
-import { ContentNode, DefaultContentNode } from './ContentNode';
-import withNode from './withNode';
+import { ContentNode } from './ContentNode';
 
-const SidecarNodeContext = createContext<ContentNode<any>>(DefaultContentNode.dummy());
+const SidecarNodeContext = createContext<ContentNode<any>[]>([]);
 
-const startSidecarNodes = <P extends object>(Component: ComponentType<P>) => (props: P) => (
-  <SidecarNodeContext.Provider value={useNode().node}>
-    <Component {...props} />
-  </SidecarNodeContext.Provider>
-);
+/**
+ * `startSidecarNodes` is an HOC which records the current ContentNode so that
+ * it can later be restored.
+ *
+ * @see `withSidecarNodes`
+ *
+ * @param Component Any component which uses the Bodiless ContentNode system.
+ */
+const startSidecarNodes = <P extends object>(Component: ComponentType<P>) => {
+  const StartSidecarNodes = (props: P) => {
+    const oldValue = useContext(SidecarNodeContext);
+    const newValue = [...oldValue, useNode().node];
+    return (
+      <SidecarNodeContext.Provider value={newValue}>
+        <Component {...props} />
+      </SidecarNodeContext.Provider>
+    );
+  };
+  StartSidecarNodes.displayName = 'StartSidecarNodes';
+  return StartSidecarNodes;
+};
 
-const endSidecarNodes = <P extends object>(Component: ComponentType<P>) => (props: P) => (
-  <NodeProvider node={useContext(SidecarNodeContext)}>
-    <Component {...props} />
-  </NodeProvider>
-);
+
+/**
+ * `endSidecarNodes` is an HOC which restores the ContentNode preserved
+ * by `startSidecarNodes`.
+ *
+ * @see `withSidecarNodes`
+ *
+ * @param Component Any component which uses the Bodiless ContentNode system.
+ */
+const endSidecarNodes = <P extends object>(Component: ComponentType<P>) => {
+  const EndSidecarNodes = (props: P) => {
+    const oldValue = useContext(SidecarNodeContext);
+    if (oldValue.length === 0) return <Component {...props} />;
+    const newNode = oldValue[oldValue.length - 1];
+    const newValue = oldValue.slice(0, -1);
+    return (
+      <NodeProvider node={newNode}>
+        <SidecarNodeContext.Provider value={newValue}>
+          <Component {...props} />
+        </SidecarNodeContext.Provider>
+      </NodeProvider>
+    );
+  };
+  EndSidecarNodes.displayName = 'EndSidecarNodes';
+  return EndSidecarNodes;
+};
 
 type HOC = (Component: ComponentType<any>) => ComponentType<any>;
 
+/**
+ * `withSidecarNodes` allows you to establish a `ContentNode` sub-hierarchiy which should
+ * be used by a series of one or more HOC's. Any nodes created by the HOC's enclosed in this
+ * wrapper will not affect the hierarchy for subsequent HOC's *outside* the wrapper. For
+ * example:
+ * ```js
+ * flowRight(
+ *   ...
+ *   withNodeKey('foo'), withNode,  // ...$foo
+ *   withSidecarNodes(
+ *     withNodeKey('bar'), withNode,  // ...$foo$bar
+ *   ),
+ *   withNodeKey('baz'); withNode, // ...$foo$baz (otherwise would be ...$foo$bar$baz)
+ *   ...
+ * )
+ * ```
+ * This is useful, for example, if you want to apply an enhancment HOC which uses its own
+ * content node(s) without affecting the node paths of other children of the wrapped compoenent.
+ *
+ * @param hocs A list of HOC's to be applied using the parallel node hierarchy.  These will
+ *             be composed using lodash `flowRight`
+ *
+ * @return an HOC which can wrap any Component using the Bodiless `ContentNode` system.
+ */
 const withSidecarNodes = (...hocs: HOC[]) => flowRight(
-  withNode,
   startSidecarNodes,
   ...hocs,
   endSidecarNodes,
 );
 
 export default withSidecarNodes;
+export { startSidecarNodes, endSidecarNodes };

--- a/packages/bodiless-core/src/withSidecarNodes.tsx
+++ b/packages/bodiless-core/src/withSidecarNodes.tsx
@@ -7,17 +7,30 @@ import withNode from './withNode';
 
 const SidecarNodeContext = createContext<ContentNode<any>>(DefaultContentNode.dummy());
 
-const startSidecarNodes = <P extends object>(Component: ComponentType<P>) => (props: P) => (
-  <SidecarNodeContext.Provider value={useNode().node}>
-    <Component {...props} />
+const SidecarProvider = ({ node, children }: any) => (
+  <SidecarNodeContext.Provider value={node}>
+    {children}
   </SidecarNodeContext.Provider>
 );
 
-const endSidecarNodes = <P extends object>(Component: ComponentType<P>) => (props: P) => (
-  <NodeProvider node={useContext(SidecarNodeContext)}>
-    <Component {...props} />
-  </NodeProvider>
-);
+
+const startSidecarNodes = <P extends object>(Component: ComponentType<P>) => (props: P) => {
+  const { node } = useNode();
+  return (
+    <SidecarProvider node={node}>
+      <Component {...props} />
+    </SidecarProvider>
+  );
+};
+
+const endSidecarNodes = <P extends object>(Component: ComponentType<P>) => (props: P) => {
+  const node = useContext(SidecarNodeContext);
+  return (
+    <NodeProvider node={node}>
+      <Component {...props} />
+    </NodeProvider>
+  );
+};
 
 type HOC = (Component: ComponentType<any>) => ComponentType<any>;
 

--- a/packages/bodiless-core/src/withSidecarNodes.tsx
+++ b/packages/bodiless-core/src/withSidecarNodes.tsx
@@ -1,0 +1,31 @@
+
+import React, { createContext, useContext, ComponentType } from 'react';
+import { flowRight } from 'lodash';
+import NodeProvider, { useNode } from './NodeProvider';
+import { ContentNode, DefaultContentNode } from './ContentNode';
+import withNode from './withNode';
+
+const SidecarNodeContext = createContext<ContentNode<any>>(DefaultContentNode.dummy());
+
+const startSidecarNodes = <P extends object>(Component: ComponentType<P>) => (props: P) => (
+  <SidecarNodeContext.Provider value={useNode().node}>
+    <Component {...props} />
+  </SidecarNodeContext.Provider>
+);
+
+const endSidecarNodes = <P extends object>(Component: ComponentType<P>) => (props: P) => (
+  <NodeProvider node={useContext(SidecarNodeContext)}>
+    <Component {...props} />
+  </NodeProvider>
+);
+
+type HOC = (Component: ComponentType<any>) => ComponentType<any>;
+
+const withSidecarNodes = (...hocs: HOC[]) => flowRight(
+  withNode,
+  startSidecarNodes,
+  ...hocs,
+  endSidecarNodes,
+);
+
+export default withSidecarNodes;

--- a/packages/bodiless-core/src/withSidecarNodes.tsx
+++ b/packages/bodiless-core/src/withSidecarNodes.tsx
@@ -7,30 +7,17 @@ import withNode from './withNode';
 
 const SidecarNodeContext = createContext<ContentNode<any>>(DefaultContentNode.dummy());
 
-const SidecarProvider = ({ node, children }: any) => (
-  <SidecarNodeContext.Provider value={node}>
-    {children}
+const startSidecarNodes = <P extends object>(Component: ComponentType<P>) => (props: P) => (
+  <SidecarNodeContext.Provider value={useNode().node}>
+    <Component {...props} />
   </SidecarNodeContext.Provider>
 );
 
-
-const startSidecarNodes = <P extends object>(Component: ComponentType<P>) => (props: P) => {
-  const { node } = useNode();
-  return (
-    <SidecarProvider node={node}>
-      <Component {...props} />
-    </SidecarProvider>
-  );
-};
-
-const endSidecarNodes = <P extends object>(Component: ComponentType<P>) => (props: P) => {
-  const node = useContext(SidecarNodeContext);
-  return (
-    <NodeProvider node={node}>
-      <Component {...props} />
-    </NodeProvider>
-  );
-};
+const endSidecarNodes = <P extends object>(Component: ComponentType<P>) => (props: P) => (
+  <NodeProvider node={useContext(SidecarNodeContext)}>
+    <Component {...props} />
+  </NodeProvider>
+);
 
 type HOC = (Component: ComponentType<any>) => ComponentType<any>;
 

--- a/packages/bodiless-documentation/doc/Development/Architecture/Data.md
+++ b/packages/bodiless-documentation/doc/Development/Architecture/Data.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Most components will consume and render some GG*data* (content and/or
+Most components will consume and render some *data* (content and/or
 configuration). For example, a link component might take a target href, some
 link text, etc. and render a clickable link on the page. A "where to buy"
 component might take a product ID and some credentials for an external service,
@@ -301,6 +301,9 @@ const asComponentWithData = BaseComponent => {
     <BaseComponent {...props}>
       {useNode().node.data}
     </BaseComponent>
+  );
+  ComponentWithData.displayName = 'ComponentWithData';
+  return ComponentWithData;
 };
 export default nodeKey => flowRight(
   withNodeKey(nodeKey),

--- a/packages/bodiless-documentation/doc/Development/Architecture/Data.md
+++ b/packages/bodiless-documentation/doc/Development/Architecture/Data.md
@@ -285,8 +285,9 @@ const ComponentWithAriaLabel = flowRight(
 ```
 giving
 ```
-
-
+content$aria-label.json
+content$component.json
+```
 
 ### Component Data Composition
 

--- a/packages/bodiless-documentation/doc/Development/Architecture/Data.md
+++ b/packages/bodiless-documentation/doc/Development/Architecture/Data.md
@@ -4,19 +4,20 @@
 
 Most components will consume and render some *data* (content and/or
 configuration). For example, a link component might take a target href, some
-link text, etc. and render a clickable link on the page. A "where to buy" component
-might take a product ID and some credentials for an external service, and render
-a list of online retailers. In an ordinary react app, such data might be passed
-as props to the component. In Bodiless, components usually provide an interface to
-edit the data they render, so the data are part of the application state.
+link text, etc. and render a clickable link on the page. A "where to buy"
+component might take a product ID and some credentials for an external service,
+and render a list of online retailers. In an ordinary react app, such data might
+be passed as props to the component. In Bodiless, components usually provide an
+interface to edit the data they render, so the data are part of the application
+state.
 
-Rather than requiring each component to manage its own state, Bodiless provides a
-central store and serialization mechanism. Components are allocated a slot in
+Rather than requiring each component to manage its own state, Bodiless provides
+a central store and serialization mechanism. Components are allocated a slot in
 that central store where they can read and write the data they need. Each
 component is responsible for the structure of its own data, while the store is
 responsible for:
-- serializing/deserializing data for all components to and from
-JSON files on the edit server
+- serializing/deserializing data for all components to and from JSON files on
+  the edit server
 - managing data which are shared among components,
 - tracking changes globally (for example, to allow for undo/redo).
 
@@ -32,16 +33,17 @@ THe following diagram illustrates the flow of data in the edit environment.
 
 1. Component data are stored in json files on the (local or public) edit server.
    There is a single file for each component, and all data files for a given
-   page are kept together in a single directory under `~/src/data/pages`.
-   The name of each file corresponds to a key in the store which uniquely
-   identifies the component to which the data belong.
+   page are kept together in a single directory under `~/src/data/pages`. The
+   name of each file corresponds to a key in the store which uniquely identifies
+   the component to which the data belong.
 
 2. The Gatsby development server -- or, more properly, the
    [Gatsby Filesystem Plugin](https://www.gatsbyjs.org/packages/gatsby-source-filesystem)
    -- watches the filesystem for changes in the data. When a change is detected,
-   Gatsby executes a page query and sends the results over a websocket to
-   the browser. There, they are provided as a "data" prop to the top level page
-   component. For more information, see [the Gatsby tutorial](https://www.gatsbyjs.org/tutorial/part-four/).
+   Gatsby executes a page query and sends the results over a websocket to the
+   browser. There, they are provided as a "data" prop to the top level page
+   component. For more information, see
+   [the Gatsby tutorial](https://www.gatsbyjs.org/tutorial/part-four/).
 
 3. The data provided by Gatsby consist of the contents of all json files in the
    directory which corresponds to the current page. These are processed into a
@@ -54,14 +56,14 @@ THe following diagram illustrates the flow of data in the edit environment.
    changed.
 
 4. We refer to each element in the store as a "node", and each is represented by
-   an instance of the `DefaultContentNode`
-   class. A ContentNode is placed in a context which can be access by `useNode()`. The
-   component can then read and write to the store via the node's data property.
+   an instance of the `DefaultContentNode` class. A ContentNode is placed in a
+   context which can be access by `useNode()`. The component can then read and
+   write to the store via the node's data property.
 
 5. The store also defines a Mobx _reaction_ which listens for changes. When a
-   component updates its data. The reaction invokes a `BackendClient`
-   to post the updated node to a ligthweight express server
-   which in turn serialized the data to json.
+   component updates its data. The reaction invokes a `BackendClient` to post
+   the updated node to a ligthweight express server which in turn serialized the
+   data to json.
 
 6. The backend server is also responsible for managing the git repository which
    contains all code and content for the site, and exposes endpoints to commit
@@ -72,28 +74,28 @@ THe following diagram illustrates the flow of data in the edit environment.
 
 ### Creating Pages
 
-By default, Gatsby creates a page for every component it finds in the `/src/pages/`
-directory. Bodiless extends this to create pages recursively for every directory
-located under `~/src/data/pages`. Thus, to create a new page,
+By default, Gatsby creates a page for every component it finds in the
+`/src/pages/` directory. Bodiless extends this to create pages recursively for
+every directory located under `~/src/data/pages`. Thus, to create a new page,
 simply create a new directory or subdirectory there. The URL path to your page
 will be the same as its relative path under `~/src/data/pages`. For example, a
 directory at `~/src/data/pages/foo/bar` will result in a page at
 `http://mysite.com/foo/bar/`.
 
-You can include an index.json file if you wish to specify
-templates to use for the page level components of the given page and/or its subpages, eg:
+You can include an index.json file if you wish to specify templates to use for
+the page level components of the given page and/or its subpages, eg:
 ```json
 {
     "#template": "mytemplate",
     "#subpage_template": "mysubpagetemplate",
 }
 ```
-The templates should be specified as paths relative to `~/src/templates`
-and should refer to a React page component, without the jsx extension.
-If `#template` key is omitted in the page index.json, then Bodiless will use template specified
-in `#subpage_template` of the closest ancestor of the page.
-If closest ancestor does not have `#subpage_template`, then the default template (`~/src/templates/_default.jsx`)
-will be used.
+The templates should be specified as paths relative to `~/src/templates` and
+should refer to a React page component, without the jsx extension. If
+`#template` key is omitted in the page index.json, then Bodiless will use
+template specified in `#subpage_template` of the closest ancestor of the page.
+If closest ancestor does not have `#subpage_template`, then the default template
+(`~/src/templates/_default.jsx`) will be used.
 
 Alternatively, for one-off pages, you can include an "index.jsx" file containing
 the page level component.
@@ -104,12 +106,13 @@ This can/should be customized to fit the needs of your site.
 
 ### Page Data
 
-In order to take advantage of the Bodiless data flow, your page-level component (or
-template) should use `Page`, and
-should export the default page query. the `default template`
-is a good example and can be copied to form the basis of your pages.
+In order to take advantage of the Bodiless data flow, your page-level component
+(or template) should use `Page`, and should export the default page query. the
+`default template` is a good example and can be copied to form the basis of your
+pages.
 
-Note that the Gatsby page query exported by the default template uses a GraphQL "fragment":
+Note that the Gatsby page query exported by the default template uses a GraphQL
+"fragment":
 
 ```javascript
 export const query = graphql`
@@ -120,50 +123,180 @@ export const query = graphql`
 `;
 ```
 
-The fragment is defined by Gatsby Theme Bodiless 
-and queries the contents of all json files in the directory corresponding to the
-page. This can be used as-is, or the page query could be extended in case the
-page requries additional data.
+The fragment is defined by Gatsby Theme Bodiless and queries the contents of all
+json files in the directory corresponding to the page. This can be used as-is,
+or the page query could be extended in case the page requries additional data.
 
 ### Component Data
 
 Page provides a root node to the node context which initializes the store and
-provides a base ContentNode instance in to the Context.
-Components that need a node will require a `nodeKey` prop, which will provide each of them with a 
-new ContentNode that is a child of the current one.
+provides a base ContentNode instance in to the Context. Components that need a
+node should wrap themselves in `withNode`. When supplied with a `nodeKey` prop,
+this will provide each of them with a new `ContentNode` identified by that key.
+The node can then be accessed via the `useNode` hook.
 
 ```javascript
+const ComponentWithData = withNode(
+  props => {
+    const { node } = useNode();
+    return (<span {,,,props}>{node.data}</span>);
+  }
+);
 export default (props: any) => (
   <Page {...props}>
     <Layout>
       <h1>Default Page</h1>
-      <EditorFullFeatured nodeKey="editor" />
+      <ComponentWithData nodeKey="content" />
     </Layout>
   </Page>
 );
  ```
- 
+
  Note that the ContentNode instance does not store any data; it is simply an
  interface which points to a particular "slot" in the global store. The actual
  storage and retrieval of data are handled by the store's getter and setter
  methods which are injected into the ContentNode constructor (this happens
  within `GatsbyNodeProvider::getRootNode()`).
 
- While the store itself is a flat set of key-value pairs, the ContentNode interface
- provides a mechanism for creating a hierarchy of content nodes which mirrors
- the component hierarchy. The key names are actually built as *paths*, and `ContentNode`
- provides a `child()` method which will create a new node within the namespace of
- the parent. This allows compound components to name the nodes used by their children
- uniquely on the page by using the nodeKey prop:
+ ### Node Hierarchy
+
+ While the store itself is a flat set of key-value pairs, the ContentNode
+ interface provides a mechanism for creating a hierarchy of content nodes which
+ mirrors the component hierarchy. The key names are actually built as *paths*,
+ and `ContentNode` provides a `child()` method which will create a new node
+ within the namespace of the parent. This allows compound components to name the
+ nodes used by their children uniquely on the page by using the nodeKey prop:
 
  ```javascript
-const Blurb =  ({ node }) => (
-  <div>
-    <header>
-      <h1><Editable nodeKey="title" />
-      <EditorFullFeatured nodeKey="subtitle" />
-    </header>
-    <EditorFullFeatured nodeKey="body" />
-  </div>
+const Blurb =  withNode(
+  props => (
+    <div>
+      <h2><ComponentWithData nodeKey="title" />
+      <div>
+        <ComponentWithData nodeKey="body" />
+      </div>
+    </div>
+  )
 );
 ```
+Now you can place multiple instances of your blurb on the page, each with an independent
+title and body.
+
+```javascript
+export default (props: any) => (
+  <Page {...props}>
+    <Layout>
+      <h1>Default Page</h1>
+      <Blurb nodeKey="blurb-1" />
+      <Blurb nodeKey="blurb-2" />
+    </Layout>
+  </Page>
+);
+
+### Nodes and the Filesystem
+
+As described above, Bodiless Content Nodes are backed by JSON files in your
+repository (although this is a pluggable mechanism, and you could easily build a
+store backed by some other persistant storage, like a database). Each node has
+its own file within the directory corresponding to the current page.  The filename
+is created by concatenating all segments of the node's path using the dollar sign ($).
+
+So, in the above example, there would be 4 files:
+```
+  blurb-1$title.json
+  blurb-1$body.json
+  blurb-2$title.json
+  blurb-2$body.json
+```
+
+### "Sidecar" nodes.
+
+There are some cases in which having the data model mirror the component hierarchy
+can be undesireable. For example, suppose we wanted to enhance our component above
+to add an `aria-label` attribute whose text was stored as content:
+```
+const ComponentWithAriaLabel = withNode(
+  props => <ComponentWithData {...props} aria-label={useNode().node.data} />
+);
+```
+Or, better, you could encapsulate this enahncement in a simple, reusable HOC.
+```
+const withAriaLabel = Component => withNode(
+  props => (<Component {...props} aria-label={useNode().node.data} />)
+);
+```
+And then
+```
+const ComponentWithAriaLabel = withAriaLabel(ComponentWithData);
+...
+<ComponentWithAriaLabel nodeKey="content" />
+```
+
+The problem with the above is that the component managing the `aria-label` and
+the original component end up using the same node to store their data.
+`withNode()` only creates a new node if a `nodeKey` prop is specified, and we
+are only specifying a `nodeKey` to the outer component.
+
+This could be solved by ensuring that our aria-label component provides a
+`nodeKey` to its child:
+```
+const withAriaLabel = Component => withNode(
+  props => (<Component nodeKey="component" {...props} aria-label={useNode().node.data} />)
+);
+``
+This will work, but consider the resulting node hierarchy:
+```
+content.json // This contains the aria-label data
+content$component.json // This contains the actual content of the original component.
+```
+The original component's data are now stored as a child of the aria-label, which
+seems backwards. And it's worse if the original component had already been
+placed on a site and was rendering actual data. When replaced with the enhanced
+component, it's existing data (at `content.json`) will be used forthe
+aria-label, and the actual text displayed on the screen will be lost.
+
+What we really want to to attach the aria-label data as a child of the original
+component. This will leave the original data intact and give us a more rational
+hierarchy. To achieve this, Bodiless provides the notion of a sidecar node:
+```
+const ComponentWithAriaLabel = withSidecarNodes(
+  withNodeKey('aria-label'),
+  withAriaLabel,
+);
+```
+In effect, this creates a sub-hierarchy off of the current node which is used
+for all the enclosed enhancements. The resulting hierarchy makes much more
+sense:
+```
+content.json // contains the orignial content.
+content$aria-label.json // contains the aria-label data.
+
+
+### Node Keys and the Design API
+
+Note that node keys can also be assigned using the `withNodeKey` HOC. That is
+```
+const Blurb1 = withNodeKey('blurb-1');
+...
+<Blurb1 />
+```
+is equivalent to
+```
+<Blurb nodeKey="blurb-1" />
+```
+
+This pattern becomes particularly powerful when enhancing a compound component
+using he [Design API](../FClasses). Assuming we made blurb "designable", we
+could easily create a version which added data:
+
+```javascript
+const asBlurbWithData = flow(
+  withNode, 
+  withDesign({
+    Title: withNodeKey('title'),
+    Body: withNodeKey('body'),
+  }
+);
+```
+
+

--- a/packages/bodiless-layouts/__tests__/ComponentSelector/componentSelectorForm.test.tsx
+++ b/packages/bodiless-layouts/__tests__/ComponentSelector/componentSelectorForm.test.tsx
@@ -1,3 +1,17 @@
+/**
+ * Copyright © 2020 Johnson & Johnson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { Fragment } from 'react';
 import { contextMenuForm } from '@bodiless/core';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/bodiless-layouts/__tests__/FlexboxGrid/model.test.ts
+++ b/packages/bodiless-layouts/__tests__/FlexboxGrid/model.test.ts
@@ -1,3 +1,17 @@
+/**
+ * Copyright © 2020 Johnson & Johnson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 const { useNode } = require('@bodiless/core');
 const { useItemHandlers, useFlowContainerDataHandlers } = require('../../src/FlowContainer/model');
 

--- a/packages/bodiless-layouts/__tests__/FlexboxGrid/useGetMenuOptions.test.tsx
+++ b/packages/bodiless-layouts/__tests__/FlexboxGrid/useGetMenuOptions.test.tsx
@@ -1,3 +1,17 @@
+/**
+ * Copyright © 2020 Johnson & Johnson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Fragment, FC } from 'react';
 import { useEditContext, TMenuOption } from '@bodiless/core';
 import { DesignableComponents } from '@bodiless/fclasses';

--- a/packages/bodiless-layouts/src/ComponentSelector/componentSelectorForm.tsx
+++ b/packages/bodiless-layouts/src/ComponentSelector/componentSelectorForm.tsx
@@ -1,3 +1,17 @@
+/**
+ * Copyright © 2020 Johnson & Johnson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { contextMenuForm } from '@bodiless/core';
 import { ComponentSelectorProps, ComponentSelectorUI } from './types';

--- a/packages/bodiless-layouts/src/FlowContainer/__mocks__/model.ts
+++ b/packages/bodiless-layouts/src/FlowContainer/__mocks__/model.ts
@@ -1,3 +1,17 @@
+/**
+ * Copyright © 2020 Johnson & Johnson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { v1 } from 'uuid';
 
 const itemHandlers = {

--- a/packages/bodiless-migration-tool/conf/template_dangerous_html.jsx
+++ b/packages/bodiless-migration-tool/conf/template_dangerous_html.jsx
@@ -1,3 +1,17 @@
+/**
+ * Copyright © 2020 Johnson & Johnson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from "react";
 
 class Page extends React.Component {

--- a/packages/bodiless-migration-tool/src/page404-handler.ts
+++ b/packages/bodiless-migration-tool/src/page404-handler.ts
@@ -1,3 +1,17 @@
+/**
+ * Copyright © 2020 Johnson & Johnson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { ScrapedPage } from './scraper';
 import debug from './debug';
 

--- a/packages/bodiless-migration-tool/tests/data/template_dangerous_html.jsx
+++ b/packages/bodiless-migration-tool/tests/data/template_dangerous_html.jsx
@@ -1,3 +1,17 @@
+/**
+ * Copyright © 2020 Johnson & Johnson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from "react";
 
 class Page extends React.Component {

--- a/packages/bodiless-migration-tool/tests/page404-handler.test.ts
+++ b/packages/bodiless-migration-tool/tests/page404-handler.test.ts
@@ -1,3 +1,17 @@
+/**
+ * Copyright © 2020 Johnson & Johnson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import page404Handler, {
   isCurrentPage404,
   getPage404DefaultUrl,

--- a/packages/bodiless-psh/resources/static/static.platform.sh
+++ b/packages/bodiless-psh/resources/static/static.platform.sh
@@ -1,3 +1,17 @@
+###
+ # Copyright © 2020 Johnson & Johnson
+ #
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ # http:##www.apache.org#licenses#LICENSE-2.0
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ ##
+
 if [ -f static.platform.custom.sh ]; then
   source static.platform.custom.sh
 fi

--- a/packages/bodiless-richtext/__tests__/HoverMenu.test.tsx
+++ b/packages/bodiless-richtext/__tests__/HoverMenu.test.tsx
@@ -1,3 +1,17 @@
+/**
+ * Copyright © 2020 Johnson & Johnson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { shallow, mount } from 'enzyme';


### PR DESCRIPTION
## Changes

Adds an API for creating "sidecar" node hierarchies,
effectively allowing an enhancing HOC to hang its
data off of the component it wraps without changing
the node that is passed to that component.

## Test Instructions

See docs and functional tests.

## Related Issues
#285
Closes #321 