### PR TITLE
chore(core): Fix legacy naming

### DIFF
--- a/examples/test-site/src/data/pages/context/index.tsx
+++ b/examples/test-site/src/data/pages/context/index.tsx
@@ -24,7 +24,7 @@ import {
 import { Div } from '@bodiless/ui';
 import {
   TMenuOptionGetter,
-  ContextProvider,
+  PageContextProvider,
   withNode,
   useNodeDataHandlers,
   useEditContext,
@@ -108,14 +108,14 @@ const EditableBox: React.FC<BoxProps> = ({
   children,
   className,
 }) => (
-  <ContextProvider
+  <PageContextProvider
     getMenuOptions={getMenuOptions || emptyMenuOptionsGetter}
     name={name}
   >
     <LocalContextMenu>
       <StaticBox className={className}>{children}</StaticBox>
     </LocalContextMenu>
-  </ContextProvider>
+  </PageContextProvider>
 );
 const Box: React.FC<BoxProps> = observer(props => {
   const { isEdit } = useEditContext();

--- a/packages/bodiless-core/__tests__/ContextProvider.test.tsx
+++ b/packages/bodiless-core/__tests__/ContextProvider.test.tsx
@@ -15,11 +15,11 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
 import PageContextProvider from '../src/PageContextProvider';
-import { withPageContext } from '../src/hoc';
+import { withMenuOptions } from '../src/hoc';
 import { useEditContext } from '../src/hooks';
 import { PageEditContextInterface } from '../src/PageEditContext/types';
 
-describe('withPageContext', () => {
+describe('withMenuOptions', () => {
   type Props = {
     foo: string;
   };
@@ -40,7 +40,7 @@ describe('withPageContext', () => {
 
   const WrappedComponent = ({ foo }: Props) => <span>{foo}</span>;
 
-  const Test = withPageContext({ useGetMenuOptions })(WrappedComponent);
+  const Test = withMenuOptions({ useGetMenuOptions })(WrappedComponent);
 
   it('passes props and context correctly to the getMenuOptions creator', () => {
     const ShowContextId = () => <span>{useEditContext().id}</span>;

--- a/packages/bodiless-core/src/Contentful/withResetButton.ts
+++ b/packages/bodiless-core/src/Contentful/withResetButton.ts
@@ -14,7 +14,7 @@
 
 import { flowRight } from 'lodash';
 import {
-  withPageContext as withMenuOptions,
+  withMenuOptions,
   withContextActivator,
   withLocalContextMenu,
 } from '../hoc';

--- a/packages/bodiless-core/src/hoc.tsx
+++ b/packages/bodiless-core/src/hoc.tsx
@@ -78,7 +78,7 @@ type Options<P> = {
   id?: string;
 };
 
-export const withPageContext = <P extends object>({
+export const withMenuOptions = <P extends object>({
   useGetMenuOptions,
   name,
   id,

--- a/packages/bodiless-core/src/index.ts
+++ b/packages/bodiless-core/src/index.ts
@@ -58,7 +58,7 @@ export {
   withNodeAndHandlers,
   withNodeDataHandlers,
   withLocalContextMenu,
-  PageContextProvider as ContextProvider,
+  PageContextProvider,
   withMenuOptions,
   PageEditContext,
   useEditContext,

--- a/packages/bodiless-core/src/index.ts
+++ b/packages/bodiless-core/src/index.ts
@@ -29,7 +29,7 @@ import withData from './withData';
 import NodeProvider, { useNode, useNodeDataHandlers } from './NodeProvider';
 import { DefaultContentNode } from './ContentNode';
 import {
-  withPageContext,
+  withMenuOptions,
   withNodeAndHandlers,
   withNodeDataHandlers,
   withLocalContextMenu,
@@ -59,7 +59,7 @@ export {
   withNodeDataHandlers,
   withLocalContextMenu,
   PageContextProvider as ContextProvider,
-  withPageContext as withMenuOptions,
+  withMenuOptions,
   PageEditContext,
   useEditContext,
   useContextActivator,

--- a/packages/bodiless-core/src/withEditButton.tsx
+++ b/packages/bodiless-core/src/withEditButton.tsx
@@ -14,7 +14,7 @@
 
 import { ReactNode } from 'react';
 import { flowRight } from 'lodash';
-import { withPageContext, withoutProps, UseGetMenuOptions } from './hoc';
+import { withMenuOptions, withoutProps, UseGetMenuOptions } from './hoc';
 import { PageEditContextInterface } from './PageEditContext/types';
 import contextMenuForm, {
   FormBodyProps as ContextMenuFormBodyProps,
@@ -96,7 +96,7 @@ export const createMenuOptionHook = <P extends object, D extends object>({
 const withEditButton = <P extends object, D extends object>(
   options: EditButtonOptions<P, D>,
 ) => flowRight(
-    withPageContext({
+    withMenuOptions({
       useGetMenuOptions: createMenuOptionHook(options),
       name: options.name,
     }),

--- a/packages/bodiless-layouts/src/SlateSortableResizable.tsx
+++ b/packages/bodiless-layouts/src/SlateSortableResizable.tsx
@@ -16,7 +16,7 @@ import React, { ComponentType } from 'react';
 import { ResizeCallback } from 're-resizable';
 import { SortableElementProps } from 'react-sortable-hoc';
 import {
-  ContextProvider,
+  PageContextProvider,
   TMenuOptionGetter,
   useContextActivator,
   useEditContext,
@@ -81,7 +81,7 @@ const SlateSortableResizable = (props: Props) => {
   } = props;
 
   return (
-    <ContextProvider
+    <PageContextProvider
       name={`flexItem-${uuid}`}
       id={`flexItem-${uuid}`}
       getMenuOptions={getMenuOptions}
@@ -89,7 +89,7 @@ const SlateSortableResizable = (props: Props) => {
       <SortableResizable uuid={uuid} {...rest}>
         {children}
       </SortableResizable>
-    </ContextProvider>
+    </PageContextProvider>
   );
 };
 

--- a/packages/gatsby-theme-bodiless/src/dist/GitProvider.tsx
+++ b/packages/gatsby-theme-bodiless/src/dist/GitProvider.tsx
@@ -18,7 +18,7 @@ import Cookies from 'universal-cookie';
 import {
   contextMenuForm,
   getUI,
-  ContextProvider,
+  PageContextProvider,
   TMenuOption,
   useEditContext,
 } from '@bodiless/core';
@@ -216,12 +216,12 @@ const GitProvider: FC<Props> = ({ children, client }) => {
   const context = useEditContext();
 
   return (
-    <ContextProvider
+    <PageContextProvider
       getMenuOptions={() => getMenuOptions(client, context)}
       name="Git"
     >
       {children}
-    </ContextProvider>
+    </PageContextProvider>
   );
 };
 


### PR DESCRIPTION
## Changes
- Remove all internal references to `withPageContext`. This was always exported as `withMenuOptions`, now the internal naming is consistent.
- Remove export of `PageContextProvider` as `ContextProvider` (now exported as `PageContextProvider`)


<!--
  Before issuing a pull request:

  - Please read our contribution guidelines (https://github.com/johnsonandjohnson/Bodiless-JS/blob/master/packages/bodiless-documentation/doc/Development/Contributing.md), especially the section on Pull Requests.
  - Please first create an issue (https://github.com/johnsonandjohnson/Bodiless-JS/issues/new). All pull requests must be linked to an issue.
-->

<!--
  IMPORTANT
  
  The pull request title will become the commit message title at merge, and
  should adhere to Angular Commit Message Conventions. Please see (https://github.com/johnsonandjohnson/Bodiless-JS/blob/master/packages/bodiless-documentation/doc/Development/Contributing.md) for details and examples.
-->

## Changes
<!-- Brief description of the changes introduced by this PR -->

## Test Instructions
<!-- Detailed description of how this feature was (and should be) tested
  - Setup instructions (if any)?
  - List of test cases, with steps and expected results?
  - List
-->

## Related Issues
<!--
  Link to the issue that is fixed or resolved by this PR (if there is one)
  e.g. Fixes #1234, Closes #4567

  Link to an issue that is partially addressed by this PR (if there are any)
-->

<!-- IF THIS PR INTRODUCES A BREAKING CHANGE

BREAKING CHANGE: Describe the nature of the breaking change here.

More Details about the breaking change.
-->