### PR TITLE
[DO NOT MERGE] bug(richtext, core): Prevent unnecessary re-activation of context for slate editor.

### DIFF
--- a/cypress/integration/smokeTest/touts_spec.js
+++ b/cypress/integration/smokeTest/touts_spec.js
@@ -59,6 +59,7 @@ describe('Tout testing', function () {
 
   it('touts: 3 - filling in CTA text', () => {
     cy.xpath(ctaLabelXpath)
+      .click()
       .type(ctaLabel)
       .should('have.text', ctaLabel)
   })
@@ -152,6 +153,7 @@ describe('Tout testing', function () {
 
   it('touts: 11 - editing CTA label', () => {
     cy.xpath(ctaLabelXpath)
+      .click()
       .type(editedPostfix)
       .should('have.text', ctaLabel + editedPostfix)
   })

--- a/examples/test-site/src/components/SingleAccordion/index.tsx
+++ b/examples/test-site/src/components/SingleAccordion/index.tsx
@@ -18,7 +18,7 @@ import {
   asTestableAccordion,
 } from '@bodiless/organisms';
 import {
-  withNode,
+  withNode, withContextActivator, ifEditable,
 } from '@bodiless/core';
 import { withDesign } from '@bodiless/fclasses';
 import asSingleAccordionDefaultStyle from './token';
@@ -27,7 +27,15 @@ import { withEditorSimple, withEditorBasic } from '../Editors';
 const asSingleAccordion = flow(
   withNode,
   withDesign({
-    Title: withEditorSimple('title', 'Accordion Title'),
+    Title: flow(
+      withEditorSimple('title', 'Accordion Title'),
+      // The following is a hack to prevent accordion expanding/contracting while editing
+      // the title. It mimics previous behavior where the click was eaten by the editor.
+      // Now editors do not add a context activator if they have no buttons, so we have
+      // to put one here.
+      // @TODO: Refactor accordions: https://github.com/johnsonandjohnson/Bodiless-JS/issues/390
+      ifEditable(withContextActivator('onClick')),
+    ),
     Body: withEditorBasic(
       'body',
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean euismod bibendum laoreet.',

--- a/packages/bodiless-core/__tests__/ContextWrapper.test.tsx
+++ b/packages/bodiless-core/__tests__/ContextWrapper.test.tsx
@@ -12,10 +12,11 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { FC } from 'react';
 import { mount } from 'enzyme';
 import ContextWrapper from '../src/components/ContextWrapper';
 import PageEditContext from '../src/PageEditContext';
+import { useEditContext } from '../src/hooks';
 
 describe('ContextWrapper', () => {
   beforeEach(() => {
@@ -97,10 +98,24 @@ describe('ContextWrapper', () => {
   // });
 
   it('activates the current context on click', () => {
+    const mockActivate = jest.fn();
+    const MockContext: FC = ({ children }) => {
+      const context = useEditContext();
+      // eslint-disable-next-line react/destructuring-assignment
+      const newContext = context.spawn({
+        getMenuOptions: () => [],
+        name: 'test',
+        id: 'test',
+      });
+      newContext.activate = mockActivate;
+      return <PageEditContext.Provider value={newContext}>{children}</PageEditContext.Provider>;
+    };
     const wrapper = mount(
-      <ContextWrapper clickable>
-        <span>This is the wrapped text.</span>
-      </ContextWrapper>,
+      <MockContext>
+        <ContextWrapper clickable>
+          <span>This is the wrapped text.</span>
+        </ContextWrapper>
+      </MockContext>,
     );
     // TODO: We should have reusable mocks for events.
     const event = {
@@ -108,7 +123,7 @@ describe('ContextWrapper', () => {
       stopPropagation: jest.fn(),
     };
     wrapper.find('div').simulate('click', event);
-    expect(PageEditContext.prototype.activate).toHaveBeenCalledTimes(1);
+    expect(mockActivate).toHaveBeenCalled();
   });
 
   it('does not activate the current context if not clickable', () => {

--- a/packages/bodiless-core/__tests__/LocalContextMenu.test.tsx
+++ b/packages/bodiless-core/__tests__/LocalContextMenu.test.tsx
@@ -87,7 +87,7 @@ describe('LocalContextMenu', () => {
       </PageEditor>,
     );
 
-    expect(wrapper.find('Tooltip').get(0).props.overlay.type).toBe(ContextMenu);
+    expect(wrapper.find(ContextMenu)).toBeDefined();
   });
 
   it('renders Tooltip with overlay of customized ui element.', () => {
@@ -105,7 +105,8 @@ describe('LocalContextMenu', () => {
       </PageEditor>,
     );
 
-    expect(wrapper.find('Tooltip').get(0).props.overlay.type).toBe(Foo2);
+    expect(wrapper.find(ContextMenu)).toHaveLength(0);
+    expect(wrapper.find(Foo2)).toHaveLength(1);
   });
 
   it('renders child component correctly.', () => {
@@ -115,24 +116,6 @@ describe('LocalContextMenu', () => {
       </MockContextProvider>,
     );
     expect(wrapper.find('Foo')).toHaveLength(1);
-  });
-
-  it('renders invisible Tooltip when menu option is not local.', () => {
-    const options1 = () => [
-      {
-        icon: 'add',
-        name: 'add',
-        local: false,
-      },
-    ];
-    const wrapper = mount(
-      <MockContextProvider active getMenuOptions={options1} id="t4" name="menuOptionInvisible">
-        <LocalContextMenu><Foo /></LocalContextMenu>
-      </MockContextProvider>,
-    );
-    expect(wrapper.find('Tooltip[visible=true]')).toHaveLength(0);
-
-    expect(wrapper.find('Tooltip').get(0).props.visible).toBe(false);
   });
 
   it('displays menu options which have "local" flag set.', () => {

--- a/packages/bodiless-core/__tests__/LocalContextMenu.test.tsx
+++ b/packages/bodiless-core/__tests__/LocalContextMenu.test.tsx
@@ -86,8 +86,8 @@ describe('LocalContextMenu', () => {
         </MockContextProvider>
       </PageEditor>,
     );
-
-    expect(wrapper.find(ContextMenu)).toBeDefined();
+    const content = wrapper.find('div.rc-tooltip-content');
+    expect(content.find(ContextMenu)).toHaveLength(1);
   });
 
   it('renders Tooltip with overlay of customized ui element.', () => {
@@ -104,9 +104,9 @@ describe('LocalContextMenu', () => {
         </MockContextProvider>
       </PageEditor>,
     );
-
-    expect(wrapper.find(ContextMenu)).toHaveLength(0);
-    expect(wrapper.find(Foo2)).toHaveLength(1);
+    const content = wrapper.find('div.rc-tooltip-content');
+    expect(content.find(Foo2)).toHaveLength(1);
+    expect(content.find(ContextMenu)).toHaveLength(0);
   });
 
   it('renders child component correctly.', () => {

--- a/packages/bodiless-core/__tests__/LocalContextMenu.test.tsx
+++ b/packages/bodiless-core/__tests__/LocalContextMenu.test.tsx
@@ -81,7 +81,7 @@ describe('LocalContextMenu', () => {
   it('renders Tooltip with overlay of default ContextMenu ui element.', () => {
     const wrapper = mount(
       <PageEditor>
-        <MockContextProvider getMenuOptions={options} id="t1" name="defaultUI">
+        <MockContextProvider active getMenuOptions={options} id="t1" name="defaultUI">
           <LocalContextMenu><Foo /></LocalContextMenu>
         </MockContextProvider>
       </PageEditor>,
@@ -99,7 +99,7 @@ describe('LocalContextMenu', () => {
     };
     const wrapper = mount(
       <PageEditor ui={ui}>
-        <MockContextProvider getMenuOptions={options} id="t2" name="customUI">
+        <MockContextProvider active getMenuOptions={options} id="t2" name="customUI">
           <LocalContextMenu><Foo /></LocalContextMenu>
         </MockContextProvider>
       </PageEditor>,
@@ -115,8 +115,6 @@ describe('LocalContextMenu', () => {
       </MockContextProvider>,
     );
     expect(wrapper.find('Foo')).toHaveLength(1);
-    expect(wrapper.find('Tooltip')).toHaveLength(1);
-    expect(wrapper.find('Tooltip').get(0).props.visible).toBe(false);
   });
 
   it('renders invisible Tooltip when menu option is not local.', () => {
@@ -132,6 +130,7 @@ describe('LocalContextMenu', () => {
         <LocalContextMenu><Foo /></LocalContextMenu>
       </MockContextProvider>,
     );
+    expect(wrapper.find('Tooltip[visible=true]')).toHaveLength(0);
 
     expect(wrapper.find('Tooltip').get(0).props.visible).toBe(false);
   });
@@ -162,7 +161,7 @@ describe('LocalContextMenu', () => {
     expect(wrapper.find('Tooltip').get(0).props.visible).toBe(true);
 
     // Available menu option names from rendered tooltip.
-    const optionNames = wrapper.find('Tooltip').get(0).props.overlay.props.options.map((item: any) => item.name);
+    const optionNames = wrapper.find('ContextMenu').get(0).props.options.map((item: any) => item.name);
     expect(optionNames).toEqual(expect.arrayContaining(['itemLocal']));
     expect(optionNames).not.toEqual(expect.arrayContaining(['itemNonLocal']));
     expect(optionNames).not.toEqual(expect.arrayContaining(['itemLocalOmit']));
@@ -175,7 +174,7 @@ describe('LocalContextMenu', () => {
       </MockContextProvider>,
     );
 
-    expect(wrapper.find('Tooltip').get(0).props.visible).toBe(false);
+    expect(wrapper.find('Tooltip[visible=true]')).toHaveLength(0);
   });
 
   it('renders visible Tooltip when ContextProvider is inner most.', () => {
@@ -185,16 +184,15 @@ describe('LocalContextMenu', () => {
       </MockContextProvider>,
     );
 
-    expect(wrapper.find('Tooltip').get(0).props.visible).toBe(true);
+    expect(wrapper.find('Tooltip[visible=true]')).toHaveLength(1);
   });
 
-  it('renders invisible Tooltip when local tooltips are disabled via edit context.', () => {
+  it('does not render visible Tooltip when local tooltips are disabled via edit context.', () => {
     const wrapper = mount(
       <MockContextProvider active getMenuOptions={options} id="t8" name="toolbarActive" tooltipsDisabled>
         <LocalContextMenu><Foo /></LocalContextMenu>
       </MockContextProvider>,
     );
-
-    expect(wrapper.find('Tooltip').get(0).props.visible).toBe(false);
+    expect(wrapper.find('Tooltip[visible=true]')).toHaveLength(0);
   });
 });

--- a/packages/bodiless-core/__tests__/hooks.test.tsx
+++ b/packages/bodiless-core/__tests__/hooks.test.tsx
@@ -16,7 +16,6 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { useContextActivator } from '../src/hooks';
 import PageEditContext from '../src/PageEditContext';
-import { useEditContext } from '../lib';
 
 const TestComponent = ({ element: Element, event, handler }: any) => (
   <Element {...useContextActivator(event, handler)}>Foo!</Element>
@@ -28,25 +27,25 @@ const event = {
   stopPropagation: jest.fn(),
 };
 
-const getMockContext = (isInnermost: boolean) => {
-  const context = new PageEditContext();
-  Object.defineProperty(context, 'isEdit', { value: true });
-  Object.defineProperty(context, 'activate', { value: jest.fn() });
-  Object.defineProperty(context, 'isInnermost', { value: isInnermost });
-  return context;
-};
-
 describe('useContextActivator', () => {
-  beforeEach(() => {
-    jest.spyOn(PageEditContext.prototype, 'activate');
-    // jest.spyOn(PageEditContext.prototype, 'isInnermost', 'get').mockImplementation(() => false);
-    jest.spyOn(PageEditContext.prototype, 'isEdit', 'get').mockImplementation(() => true);
+  let mockActivate: any;
+  let mockIsInnermost: any;
+  let mockIsEdit: any;
+
+  beforeAll(() => {
+    mockActivate = jest.spyOn(PageEditContext.prototype, 'activate');
+    mockIsInnermost = jest.spyOn(PageEditContext.prototype, 'isInnermost', 'get').mockReturnValue(false);
+    mockIsEdit = jest.spyOn(PageEditContext.prototype, 'isEdit', 'get').mockReturnValue(true);
   });
 
   afterEach(() => {
-    (PageEditContext.prototype.activate as any).mockRestore();
-    // (PageEditContext.prototype.isInnermost as any).mockRestore();
-    (PageEditContext.prototype.isEdit as any).get.mockRestore();
+    mockActivate.mockClear();
+  });
+
+  afterAll(() => {
+    mockActivate.mockRestore();
+    mockIsInnermost.mockRestore();
+    mockIsEdit.mockRestore();
   });
 
   it('creates an activator for a mouseover event', () => {
@@ -55,7 +54,7 @@ describe('useContextActivator', () => {
       trigger: 'mouseover',
       element: 'span',
     };
-    const wrapper =shallow(<TestComponent {...conditions} />);
+    const wrapper = shallow(<TestComponent {...conditions} />);
     wrapper.simulate(conditions.trigger, event);
     expect(PageEditContext.prototype.activate).toHaveBeenCalledTimes(1);
   });
@@ -63,7 +62,7 @@ describe('useContextActivator', () => {
   it('invokes a passed handler', () => {
     const handler = jest.fn();
     const wrapper = shallow(
-      <TestComponent handler={handler} event="onClick" element="div" />
+      <TestComponent handler={handler} event="onClick" element="div" />,
     );
     wrapper.simulate('click', event);
     expect(handler).toHaveBeenCalledTimes(1);

--- a/packages/bodiless-core/src/components/LocalContextMenu.tsx
+++ b/packages/bodiless-core/src/components/LocalContextMenu.tsx
@@ -61,6 +61,9 @@ const LocalContextMenu: FC = ({ children }) => {
   // let the context know it has a localMenu
   context.hasLocalMenu = true;
   const { isInnermostLocalMenu, areLocalTooltipsDisabled } = context;
+  // TODO: Only render tooltip when needed. Currently this causes focus issues with editables.
+  // (The editable gets the focus, then the tooltip re-renders and creates a new editable
+  // which is not focused.  Might be worth investigating this at some point.)
   // if (!isInnermostLocalMenu || areLocalTooltipsDisabled) {
   //   return <>{children}</>;
   // }
@@ -76,7 +79,6 @@ const LocalContextMenu: FC = ({ children }) => {
       {children}
     </Tooltip>
   );
-  // return <InnerLocalContextMenu>{children}</InnerLocalContextMenu>;
 };
 
 export default observer(LocalContextMenu) as ComponentType;

--- a/packages/bodiless-core/src/components/LocalContextMenu.tsx
+++ b/packages/bodiless-core/src/components/LocalContextMenu.tsx
@@ -20,27 +20,28 @@ import { useEditContext } from '../hooks';
 import { useUI } from './PageEditor';
 import { TMenuOption } from '../PageEditContext/types';
 
-const LocalContextMenu: FC = ({ children }) => {
-  const { LocalContextMenu: Menu } = useUI();
+// Purpose of this event handler to control a case when the tooltip shows on a component
+// that became invisible for any reason and the tooltip positioned to the top-left corner
+// of the screen.
+const onPopupAlign = (domNode: Element) => {
+  const element = domNode as HTMLElement;
+  if (element.getBoundingClientRect().left <= 0) {
+    element.style.visibility = 'hidden';
+  } else {
+    element.style.visibility = 'visible';
+  }
+};
+
+const InnerLocalContextMenu$: FC = ({ children }) => {
   const context = useEditContext();
+  const { LocalContextMenu: Menu } = useUI();
   // let the context know it has a localMenu
   context.hasLocalMenu = true;
-  const { contextMenuOptions, isInnermostLocalMenu, areLocalTooltipsDisabled } = context;
+  const { contextMenuOptions } = context;
   const options = contextMenuOptions.filter((option: TMenuOption) => Boolean(option.local));
-  // Purpose of this event handler to control a case when the tooltip shows on a component
-  // that became invisible for any reason and the tooltip positioned to the top-left corner
-  // of the screen.
-  const onPopupAlign = (domNode: Element) => {
-    const element = domNode as HTMLElement;
-    if (element.getBoundingClientRect().left <= 0) {
-      element.style.visibility = 'hidden';
-    } else {
-      element.style.visibility = 'visible';
-    }
-  };
   return (
     <Tooltip
-      visible={isInnermostLocalMenu && options.length > 0 && !areLocalTooltipsDisabled}
+      visible={options.length > 0}
       overlay={<Menu options={options} />}
       trigger={[]}
       destroyTooltipOnHide
@@ -50,6 +51,18 @@ const LocalContextMenu: FC = ({ children }) => {
       {children}
     </Tooltip>
   );
+};
+
+const InnerLocalContextMenu = observer(InnerLocalContextMenu$);
+
+const LocalContextMenu: FC = ({ children }) => {
+  const context = useEditContext();
+
+  const { isInnermostLocalMenu, areLocalTooltipsDisabled } = context;
+  if (!isInnermostLocalMenu || areLocalTooltipsDisabled) {
+    return <>{children}</>;
+  }
+  return <InnerLocalContextMenu>{children}</InnerLocalContextMenu>;
 };
 
 export default observer(LocalContextMenu) as ComponentType;

--- a/packages/bodiless-core/src/components/LocalContextMenu.tsx
+++ b/packages/bodiless-core/src/components/LocalContextMenu.tsx
@@ -43,15 +43,31 @@ const onPopupAlign = (domNode: Element) => {
  *
  * Renders children inside an rc-tooltip whose overlay contents contain all local menu option icons.
  */
-const InnerLocalContextMenu$: FC = ({ children }) => {
+const ContextMenuOverlay = observer<{}>(() => {
   const context = useEditContext();
   const { LocalContextMenu: Menu } = useUI();
   const { contextMenuOptions } = context;
   const options = contextMenuOptions.filter((option: TMenuOption) => Boolean(option.local));
+  return <Menu options={options} />;
+});
+
+/*
+ * Wraps its children in a tooltip displaying local context menu options, but only if the
+ * current context is the innermost context to which a local context menu has been assigned.
+ */
+const LocalContextMenu: FC = ({ children }) => {
+  const context = useEditContext();
+  // console.log('render tooltip for', context.name);
+  // let the context know it has a localMenu
+  context.hasLocalMenu = true;
+  const { isInnermostLocalMenu, areLocalTooltipsDisabled } = context;
+  // if (!isInnermostLocalMenu || areLocalTooltipsDisabled) {
+  //   return <>{children}</>;
+  // }
   return (
     <Tooltip
-      visible={options.length > 0}
-      overlay={<Menu options={options} />}
+      visible={isInnermostLocalMenu && !areLocalTooltipsDisabled}
+      overlay={<ContextMenuOverlay />}
       trigger={[]}
       destroyTooltipOnHide
       placement="bottomLeft"
@@ -60,23 +76,7 @@ const InnerLocalContextMenu$: FC = ({ children }) => {
       {children}
     </Tooltip>
   );
-};
-
-const InnerLocalContextMenu = observer(InnerLocalContextMenu$);
-
-/*
- * Wraps its children in a tooltip displaying local context menu options, but only if the
- * current context is the innermost context to which a local context menu has been assigned.
- */
-const LocalContextMenu: FC = ({ children }) => {
-  const context = useEditContext();
-  // let the context know it has a localMenu
-  context.hasLocalMenu = true;
-  const { isInnermostLocalMenu, areLocalTooltipsDisabled } = context;
-  if (!isInnermostLocalMenu || areLocalTooltipsDisabled) {
-    return <>{children}</>;
-  }
-  return <InnerLocalContextMenu>{children}</InnerLocalContextMenu>;
+  // return <InnerLocalContextMenu>{children}</InnerLocalContextMenu>;
 };
 
 export default observer(LocalContextMenu) as ComponentType;

--- a/packages/bodiless-core/src/components/LocalContextMenu.tsx
+++ b/packages/bodiless-core/src/components/LocalContextMenu.tsx
@@ -20,9 +20,15 @@ import { useEditContext } from '../hooks';
 import { useUI } from './PageEditor';
 import { TMenuOption } from '../PageEditContext/types';
 
-// Purpose of this event handler to control a case when the tooltip shows on a component
-// that became invisible for any reason and the tooltip positioned to the top-left corner
-// of the screen.
+/**
+ * @private
+ *
+ * Purpose of this event handler to control a case when the tooltip shows on a component
+ * that became invisible for any reason and the tooltip positioned to the top-left corner
+ * of the screen.
+ *
+ * @param domNode The element to which the popup is attached.
+ */
 const onPopupAlign = (domNode: Element) => {
   const element = domNode as HTMLElement;
   if (element.getBoundingClientRect().left <= 0) {
@@ -32,11 +38,14 @@ const onPopupAlign = (domNode: Element) => {
   }
 };
 
+/**
+ * @private
+ *
+ * Renders children inside an rc-tooltip whose overlay contents contain all local menu option icons.
+ */
 const InnerLocalContextMenu$: FC = ({ children }) => {
   const context = useEditContext();
   const { LocalContextMenu: Menu } = useUI();
-  // let the context know it has a localMenu
-  context.hasLocalMenu = true;
   const { contextMenuOptions } = context;
   const options = contextMenuOptions.filter((option: TMenuOption) => Boolean(option.local));
   return (
@@ -55,9 +64,14 @@ const InnerLocalContextMenu$: FC = ({ children }) => {
 
 const InnerLocalContextMenu = observer(InnerLocalContextMenu$);
 
+/*
+ * Wraps its children in a tooltip displaying local context menu options, but only if the
+ * current context is the innermost context to which a local context menu has been assigned.
+ */
 const LocalContextMenu: FC = ({ children }) => {
   const context = useEditContext();
-
+  // let the context know it has a localMenu
+  context.hasLocalMenu = true;
   const { isInnermostLocalMenu, areLocalTooltipsDisabled } = context;
   if (!isInnermostLocalMenu || areLocalTooltipsDisabled) {
     return <>{children}</>;

--- a/packages/bodiless-core/src/hooks.ts
+++ b/packages/bodiless-core/src/hooks.ts
@@ -25,9 +25,10 @@ export const useContextActivator = (
   handler?: EventHandler<any>,
 ) => {
   const context = useEditContext();
+
   // Don't attach the handler when not in edit mode.
   // @TODO: Find a better way to keep the outermost context active even when not editing. AESQ-537
-  if (!context.isEdit && context.name !== 'page') {
+  if (!context.isEdit || context.isInnermost) {
     return {
       [event]: handler,
     };
@@ -35,6 +36,7 @@ export const useContextActivator = (
   const handler$1 = (e: React.SyntheticEvent<any>) => {
     const preventDefault = e && e.currentTarget && e.currentTarget.getAttribute('bl-prevent') !== 'false';
     if (handler) handler(e);
+    console.log('activating', context.name);
     context.activate();
     context.toggleLocalTooltipsDisabled(false);
     if (e && e.stopPropagation) e.stopPropagation();

--- a/packages/bodiless-core/src/hooks.ts
+++ b/packages/bodiless-core/src/hooks.ts
@@ -27,8 +27,7 @@ export const useContextActivator = (
   const context = useEditContext();
 
   // Don't attach the handler when not in edit mode.
-  // @TODO: Find a better way to keep the outermost context active even when not editing. AESQ-537
-  if (!context.isEdit || context.isInnermost) {
+  if (!context.isEdit) {
     return {
       [event]: handler,
     };
@@ -36,9 +35,11 @@ export const useContextActivator = (
   const handler$1 = (e: React.SyntheticEvent<any>) => {
     const preventDefault = e && e.currentTarget && e.currentTarget.getAttribute('bl-prevent') !== 'false';
     if (handler) handler(e);
-    console.log('activating', context.name);
-    context.activate();
-    context.toggleLocalTooltipsDisabled(false);
+    // Do not activate the context if it is already active.
+    if (!context.isInnermost) {
+      context.activate();
+      context.toggleLocalTooltipsDisabled(false);
+    }
     if (e && e.stopPropagation) e.stopPropagation();
     // @TODO: We may want to remove next line entirely and do a Regression Testing
     if (preventDefault && e && e.preventDefault && context.name !== 'page') e.preventDefault();

--- a/packages/bodiless-richtext/__tests__/RichText.test.tsx
+++ b/packages/bodiless-richtext/__tests__/RichText.test.tsx
@@ -119,4 +119,3 @@ describe('RichText', () => {
     });
   });
 });
-

--- a/packages/bodiless-richtext/__tests__/RichText.test.tsx
+++ b/packages/bodiless-richtext/__tests__/RichText.test.tsx
@@ -67,6 +67,7 @@ describe('RichText', () => {
       expect(valueProp.toJSON()).toStrictEqual(defaultJSONValue);
     });
   });
+
   describe('richtext content editable', () => {
     // eslint:disable-next-line: max-line-length
     test('richtext is editable, hover menu and buttons rendered when isEdit enabled in pageEditContext', () => {
@@ -79,7 +80,7 @@ describe('RichText', () => {
       );
       expect(wrapper.find('Editor').props().readOnly).toBe(false);
       expect(wrapper.find('HoverMenu').length).toBe(1);
-      expect(wrapper.find('PageContextProvider').length).toBe(1);
+      expect(wrapper.find('PageContextProvider').length).toBe(0);
 
       const editor = wrapper.find('Editor').instance() as Editor;
       PageEditContext.prototype.refresh = jest.fn();
@@ -90,7 +91,7 @@ describe('RichText', () => {
       PageEditContext.prototype.activate = jest.fn();
       expect(PageEditContext.prototype.activate).toHaveBeenCalledTimes(0);
       wrapper.find('Editor').simulate('click');
-      expect(PageEditContext.prototype.activate).toHaveBeenCalledTimes(1);
+      expect(PageEditContext.prototype.activate).toHaveBeenCalledTimes(0);
     });
 
     // eslint:disable-next-line: max-line-length

--- a/packages/bodiless-richtext/__tests__/RichText.test.tsx
+++ b/packages/bodiless-richtext/__tests__/RichText.test.tsx
@@ -85,7 +85,7 @@ describe('RichText', () => {
       PageEditContext.prototype.refresh = jest.fn();
       expect(PageEditContext.prototype.refresh).toHaveBeenCalledTimes(0);
       editor.props.onChange!({ operations: [] as any, value: SlateEditorValue.create() });
-      expect(PageEditContext.prototype.refresh).toHaveBeenCalledTimes(1);
+      expect(PageEditContext.prototype.refresh).toHaveBeenCalledTimes(0);
 
       PageEditContext.prototype.activate = jest.fn();
       expect(PageEditContext.prototype.activate).toHaveBeenCalledTimes(0);
@@ -97,6 +97,8 @@ describe('RichText', () => {
     test('richtext is not editable, hover menu and buttons are not rendered when isEdit disabled in pageEditContext', () => {
       const RichText = createRichtext();
       const pageEditContext = setupPageEditContext(false);
+      pageEditContext.activate = jest.fn();
+      pageEditContext.refresh = jest.fn();
       const wrapper = mount(
         <PageEditContext.Provider value={pageEditContext}>
           <RichText design={getDefaultRichTextItems()} initialValue={getRichTextInitialValue()} />
@@ -109,11 +111,12 @@ describe('RichText', () => {
 
       const editor = wrapper.find('Editor').instance() as Editor;
       editor.props.onChange!({ operations: [] as any, value: SlateEditorValue.create() });
-      expect(PageEditContext.prototype.refresh).toHaveBeenCalledTimes(0);
+      expect(pageEditContext.refresh).not.toHaveBeenCalled();
 
       expect(wrapper.find('Editor').props().onClick).toBeUndefined();
       wrapper.find('Editor').simulate('click');
-      expect(PageEditContext.prototype.activate).toHaveBeenCalledTimes(0);
+      expect(pageEditContext.activate).toHaveBeenCalledTimes(0);
     });
   });
 });
+

--- a/packages/bodiless-richtext/src/RichText.tsx
+++ b/packages/bodiless-richtext/src/RichText.tsx
@@ -150,10 +150,10 @@ const RichTextProvider = flowRight(
   withNodeStateHandlers,
   // @ts-ignore
   withSlateEditor,
-  ifEditable(withMenuOptions({ useGetMenuOptions: richTextUseGetMenuOptions, name: 'editor' })),
+  // ifEditable(withMenuOptions({ useGetMenuOptions: richTextUseGetMenuOptions, name: 'editor' })),
   withoutProps(['className', 'globalButtons', 'plugins', 'readOnly']),
   withSlateSchema,
-  ifEditable(withSlateActivator),
+  // ifEditable(withSlateActivator),
 )(React.Fragment) as RichTextProviderType;
 
 export type RichTextProps<P> = {

--- a/packages/bodiless-richtext/src/RichText.tsx
+++ b/packages/bodiless-richtext/src/RichText.tsx
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-import React, { ComponentType } from 'react';
+import React, { ComponentType, useMemo } from 'react';
 import { flowRight, pick, flow } from 'lodash';
 import {
   ifEditable,
@@ -186,7 +186,15 @@ const BasicRichText = <P extends object, D extends object>(props: P & RichTextPr
     ui,
     ...rest
   } = props;
-  const finalComponents = withDefaults(components);
+  const { finalComponents, plugins, schema, globalButtons } = useMemo(() => {
+    const finalComponents$ = withDefaults(components);
+    return {
+      finalComponents: finalComponents$,
+      plugins: getPlugins(finalComponents$),
+      schema: getSchema(finalComponents$),
+      globalButtons: getGlobalButtons(finalComponents$),
+    };
+  }, [components]);
   const { HoverMenu } = getUI(ui);
   const finalUI = getUI(ui);
   const { isEdit } = useEditContext();
@@ -197,9 +205,9 @@ const BasicRichText = <P extends object, D extends object>(props: P & RichTextPr
       <RichTextProvider
         {...rest}
         initialValue={initialValue || defaultValue}
-        plugins={getPlugins(finalComponents)}
-        globalButtons={getGlobalButtons(finalComponents)}
-        schema={getSchema(finalComponents)}
+        plugins={plugins}
+        globalButtons={globalButtons}
+        schema={schema}
       >
         {
           isEdit

--- a/packages/bodiless-richtext/src/RichText.tsx
+++ b/packages/bodiless-richtext/src/RichText.tsx
@@ -22,7 +22,7 @@ import {
   withMenuOptions,
   withoutProps,
 } from '@bodiless/core';
-import { BasicEditorProps, Plugin } from 'slate-react';
+import { Plugin } from 'slate-react';
 import { SchemaProperties } from 'slate';
 import {
   designable,
@@ -103,18 +103,24 @@ const withSlateSchema = <P extends object>(Component: ComponentType<P>) => (
 const withSlateActivator = <P extends object>(Component: ComponentType<P>) => (props: P) => {
   const previousSlateContext = useSlateContext();
   const previousEditorProps = previousSlateContext!.editorProps;
-  const context = useEditContext();
   const { onClick } = useContextActivator();
+
+  // TODO: The following onCHange handler is only necessary if the menu options provided
+  // by this editor depend on the state of the editor. If this is ever the case, we will
+  // need to add logic to prevent the context from refreshing on *every* change, and
+  // only trigger refresh when necxessary.
+  // const context = useEditContext();
   // tslint:disable-next-line: ter-arrow-parens
-  const onChange: BasicEditorProps['onChange'] = change => {
-    if (typeof previousEditorProps.onChange === 'function' && change) {
-      previousEditorProps.onChange(change);
-    }
-    context.refresh();
-  };
+  // const onChange: BasicEditorProps['onChange'] = change => {
+  //   if (typeof previousEditorProps.onChange === 'function' && change) {
+  //     previousEditorProps.onChange(change);
+  //   }
+  //   context.refresh();
+  // };
+
   const editorProps = {
     ...previousEditorProps!,
-    onChange,
+    // onChange,
     onClick,
   };
 
@@ -150,10 +156,10 @@ const RichTextProvider = flowRight(
   withNodeStateHandlers,
   // @ts-ignore
   withSlateEditor,
-  // ifEditable(withMenuOptions({ useGetMenuOptions: richTextUseGetMenuOptions, name: 'editor' })),
+  ifEditable(withMenuOptions({ useGetMenuOptions: richTextUseGetMenuOptions, name: 'editor' })),
   withoutProps(['className', 'globalButtons', 'plugins', 'readOnly']),
   withSlateSchema,
-  // ifEditable(withSlateActivator),
+  ifEditable(withSlateActivator),
 )(React.Fragment) as RichTextProviderType;
 
 export type RichTextProps<P> = {
@@ -186,7 +192,9 @@ const BasicRichText = <P extends object, D extends object>(props: P & RichTextPr
     ui,
     ...rest
   } = props;
-  const { finalComponents, plugins, schema, globalButtons } = useMemo(() => {
+  const {
+    finalComponents, plugins, schema, globalButtons,
+  } = useMemo(() => {
     const finalComponents$ = withDefaults(components);
     return {
       finalComponents: finalComponents$,

--- a/packages/bodiless-richtext/src/RichText.tsx
+++ b/packages/bodiless-richtext/src/RichText.tsx
@@ -15,14 +15,11 @@
 import React, { ComponentType, useMemo } from 'react';
 import { flowRight, pick, flow } from 'lodash';
 import {
-  ifEditable,
   useEditContext,
-  useContextActivator,
   withNode,
-  withMenuOptions,
   withoutProps,
 } from '@bodiless/core';
-import { BasicEditorProps, Plugin } from 'slate-react';
+import { Plugin } from 'slate-react';
 import { SchemaProperties } from 'slate';
 import {
   designable,
@@ -100,46 +97,47 @@ const withSlateSchema = <P extends object>(Component: ComponentType<P>) => (
   }
 );
 // create item to activate the context not sure whats up with all the old vs new
-const withSlateActivator = <P extends object>(Component: ComponentType<P>) => (props: P) => {
-  const previousSlateContext = useSlateContext();
-  const previousEditorProps = previousSlateContext!.editorProps;
-  const context = useEditContext();
-  const { onClick } = useContextActivator();
-  // tslint:disable-next-line: ter-arrow-parens
-  const onChange: BasicEditorProps['onChange'] = change => {
-    if (typeof previousEditorProps.onChange === 'function' && change) {
-      previousEditorProps.onChange(change);
-    }
-    context.refresh();
-  };
-  const editorProps = {
-    ...previousEditorProps!,
-    onChange,
-    onClick,
-  };
+// This should be restored/debugged if/when slate editor needs to provide menu options.
+// const withSlateActivator = <P extends object>(Component: ComponentType<P>) => (props: P) => {
+//   const previousSlateContext = useSlateContext();
+//   const previousEditorProps = previousSlateContext!.editorProps;
+//   const context = useEditContext();
+//   const { onClick } = useContextActivator();
+//   // tslint:disable-next-line: ter-arrow-parens
+//   const onChange: BasicEditorProps['onChange'] = change => {
+//     if (typeof previousEditorProps.onChange === 'function' && change) {
+//       previousEditorProps.onChange(change);
+//     }
+//     context.refresh();
+//   };
+//   const editorProps = {
+//     ...previousEditorProps!,
+//     onChange,
+//     onClick,
+//   };
+//
+//   const slateContext = {
+//     editorProps,
+//     editorRef: previousSlateContext!.editorRef,
+//     value: previousSlateContext!.value,
+//     editor: previousSlateContext!.editor,
+//   };
+//   return (
+//     <SlateEditorContext.Provider value={slateContext}>
+//       <Component {...props} />
+//     </SlateEditorContext.Provider>
+//   );
+// };
 
-  const slateContext = {
-    editorProps,
-    editorRef: previousSlateContext!.editorRef,
-    value: previousSlateContext!.value,
-    editor: previousSlateContext!.editor,
-  };
-  return (
-    <SlateEditorContext.Provider value={slateContext}>
-      <Component {...props} />
-    </SlateEditorContext.Provider>
-  );
-};
-
-type UseGetMenuOptionsProps = {
-  globalButtons: Function,
-};
+// type UseGetMenuOptionsProps = {
+//   globalButtons: Function,
+// };
 // This is a call back that goes to withMenuOptions so that we can add button to the global menu
-const richTextUseGetMenuOptions = (props: UseGetMenuOptionsProps) => {
-  const slateContext = useSlateContext();
-  const { editor } = slateContext!;
-  return () => props.globalButtons(editor);
-};
+// const richTextUseGetMenuOptions = (props: UseGetMenuOptionsProps) => {
+//   const slateContext = useSlateContext();
+//   const { editor } = slateContext!;
+//   return () => props.globalButtons(editor);
+// };
 type RichTextProviderProps = {
   plugins: Plugin[],
   schema?: SchemaProperties,
@@ -186,7 +184,7 @@ const BasicRichText = <P extends object, D extends object>(props: P & RichTextPr
     ui,
     ...rest
   } = props;
-  const { finalComponents, plugins, schema, globalButtons } = useMemo(() => {
+  const { finalComponents, plugins, schema } = useMemo(() => {
     const finalComponents$ = withDefaults(components);
     return {
       finalComponents: finalComponents$,
@@ -206,7 +204,7 @@ const BasicRichText = <P extends object, D extends object>(props: P & RichTextPr
         {...rest}
         initialValue={initialValue || defaultValue}
         plugins={plugins}
-        globalButtons={globalButtons}
+        // globalButtons={globalButtons}
         schema={schema}
       >
         {

--- a/packages/bodiless-richtext/src/RichTextItemGetters.tsx
+++ b/packages/bodiless-richtext/src/RichTextItemGetters.tsx
@@ -276,12 +276,17 @@ const getSelectorButtons = (components: RichTextComponents) => Object.values(com
   getGlobalButtons takes an array of RichTextitems and maps that to a array of objects used
   to create global buttons
 */
-const getGlobalButtons = (components: RichTextComponents) => (editor:Editor) => (
-  Object.values(components)
+const getGlobalButtons = (components: RichTextComponents) => {
+  const componentsWithButtons = Object.values(components)
     // eslint-disable-next-line no-prototype-builtins
-    .filter(Component => Component.hasOwnProperty('globalButton'))
-    .map(Component => getGlobalButton(Component as RichTextComponentWithGlobalButton)(editor))
-);
+    .filter(Component => Component.hasOwnProperty('globalButton'));
+  if (!componentsWithButtons.length) return undefined;
+  return (
+    (editor:Editor) => componentsWithButtons.map(
+      Component => getGlobalButton(Component as RichTextComponentWithGlobalButton)(editor),
+    )
+  );
+};
 
 export {
   getPlugins,

--- a/packages/gatsby-theme-bodiless/src/dist/Page.tsx
+++ b/packages/gatsby-theme-bodiless/src/dist/Page.tsx
@@ -61,9 +61,11 @@ const Page: FC<Props> = observer(({ children, ui, ...rest }) => {
                 <Editor>
                   <NewPageProvider>
                     <GitProvider>
-                      <DefaultActiveMenuOptions>
-                        {children}
-                      </DefaultActiveMenuOptions>
+                      <Wrapper clickable>
+                        <DefaultActiveMenuOptions>
+                          {children}
+                        </DefaultActiveMenuOptions>
+                      </Wrapper>
                     </GitProvider>
                   </NewPageProvider>
                 </Editor>
@@ -86,16 +88,10 @@ const Page: FC<Props> = observer(({ children, ui, ...rest }) => {
  */
 const DefaultActiveMenuOptions = observer(({ children }: any) => {
   const context = useEditContext();
-  const activate = () => {
-    if (!context.isInnermost) {
-      console.log('Activating default context');
-      context.activate();
-    } else {
-      console.log('Default context already innermost');
-    }
-  }
-  useEffect(activate, []);
-  return <div onClick={activate}>{children}</div>;
+  useEffect(() => {
+    context.activate();
+  });
+  return <>{children}</>;
 });
 
 export default Page;

--- a/packages/gatsby-theme-bodiless/src/dist/Page.tsx
+++ b/packages/gatsby-theme-bodiless/src/dist/Page.tsx
@@ -61,11 +61,9 @@ const Page: FC<Props> = observer(({ children, ui, ...rest }) => {
                 <Editor>
                   <NewPageProvider>
                     <GitProvider>
-                      <Wrapper clickable>
-                        <DefaultActiveMenuOptions>
-                          {children}
-                        </DefaultActiveMenuOptions>
-                      </Wrapper>
+                      <DefaultActiveMenuOptions>
+                        {children}
+                      </DefaultActiveMenuOptions>
                     </GitProvider>
                   </NewPageProvider>
                 </Editor>
@@ -88,10 +86,16 @@ const Page: FC<Props> = observer(({ children, ui, ...rest }) => {
  */
 const DefaultActiveMenuOptions = observer(({ children }: any) => {
   const context = useEditContext();
-  useEffect(() => {
-    context.activate();
-  });
-  return <>{children}</>;
+  const activate = () => {
+    if (!context.isInnermost) {
+      console.log('Activating default context');
+      context.activate();
+    } else {
+      console.log('Default context already innermost');
+    }
+  }
+  useEffect(activate, []);
+  return <div onClick={activate}>{children}</div>;
 });
 
 export default Page;


### PR DESCRIPTION
## Changes
- Memoize props provided to slate editor by RichText.
- Prevent reactivation of a context when it is already innermost.
- Modify RichText so that it does not refresh context on every change.
- Update LocalContextMenu so it only re-renders when it is actually on-screen.


## Test Instructions
- Visit a page with many slate editors
- Click on one slate editor many times and/or type into one
- Observe whether warnings appear in console about re-resolving slate editor props, and whetehr performance of slate editor is acceptable.

## Related Issues
Fixes #379 