### PR TITLE
feat(gatsby-theme-bodiless): Retry on Error When Saving to the Backend

### DIFF
--- a/packages/gatsby-theme-bodiless/__tests__/GatsbyMobxStoreItem.test.ts
+++ b/packages/gatsby-theme-bodiless/__tests__/GatsbyMobxStoreItem.test.ts
@@ -12,16 +12,41 @@
  * limitations under the License.
  */
 
-import GatsbyMobxStoreItem from '../src/dist/GatsbyMobxStoreItem';
+import GatsbyMobxStoreItem, { DEFAULT_REQUEST_DELAY } from '../src/dist/GatsbyMobxStoreItem';
 import GatsbyMobxStore from '../src/dist/GatsbyMobxStore';
 import BackendClient from '../src/dist/BackendClient';
 import { ItemStateEvent } from '../src/dist/types';
 
-const deletePathMock = jest.fn().mockResolvedValue(true);
-let pendingRequests: any[] = [];
+class RequestsMock {
+  requests: any[] = [];
+
+  public add({ resolve, reject }: any) {
+    this.requests.push({ resolve, reject });
+  }
+
+  public reject(requestId: number) {
+    this.requests[requestId].reject(false);
+  }
+
+  public resolve(requestId: number) {
+    this.requests[requestId].resolve(true);
+  }
+
+  public clear() {
+    this.requests = [];
+  }
+}
+
+const requestsMock = new RequestsMock();
+
 const savePathMock = jest.fn().mockImplementation(
   () => new Promise((resolve, reject) => {
-    pendingRequests.push({ resolve, reject });
+    requestsMock.add({ resolve, reject });
+  }),
+);
+const deletePathMock = jest.fn().mockImplementation(
+  () => new Promise((resolve, reject) => {
+    requestsMock.add({ resolve, reject });
   }),
 );
 jest.mock('../src/dist/BackendClient', () => () => ({
@@ -48,9 +73,13 @@ const createItem = (key?: string, data?: any) => {
   return new GatsbyMobxStoreItem(new GatsbyMobxStore(dataSource), key$, data$);
 };
 
+const flushPromises = () => new Promise(setImmediate);
+const flushItems = () => jest.runAllTimers();
+const processResponse = flushPromises;
+
 describe('GatsbyMobxStoreItem', () => {
   beforeEach(() => {
-    pendingRequests = [];
+    requestsMock.clear();
     jest.useFakeTimers();
     jest.clearAllTimers();
     jest.clearAllMocks();
@@ -59,46 +88,118 @@ describe('GatsbyMobxStoreItem', () => {
     it('should send the item data to the server', async () => {
       createItem();
       jest.runAllTimers();
-      // fulfill the request
-      await pendingRequests[0].resolve(true);
+      await requestsMock.resolve(0);
       expect(savePathMock.mock.calls.length).toBe(1);
       expect(savePathMock.mock.calls[0][0]).toBe('pages/foo$bar');
       expect(savePathMock.mock.calls[0][1]).toStrictEqual(defaultData);
     });
   });
   describe('when item request fails', () => {
-    it('should retry sending the request', async () => {
+    it('should retry sending the request until it succeeds', async () => {
       createItem();
-      await jest.runAllTimers();
-      // reject the request
-      await pendingRequests[0].reject(false);
-      await jest.runAllTimers();
+      await flushItems();
       expect(savePathMock.mock.calls.length).toBe(1);
-      await jest.runAllTimers();
-      await pendingRequests[1].resolve(true);
+      // reject the first request
+      await requestsMock.reject(0);
+      await processResponse();
+      await flushItems();
+      // reject the second request
+      await requestsMock.reject(1);
+      await processResponse();
+      await flushItems();
+      // resolve the third request
+      await requestsMock.resolve(2);
+      await processResponse();
+      expect(savePathMock.mock.calls.length).toBe(3);
+      expect(savePathMock.mock.calls[2][0]).toBe('pages/foo$bar');
+      expect(savePathMock.mock.calls[2][1]).toStrictEqual(defaultData);
+      // flush again and test nothing is flushed
+      await flushItems();
+      expect(savePathMock.mock.calls.length).toBe(3);
+    });
+    it('should incrementally increase delay between subsequent failed requests', async () => {
+      const delay = DEFAULT_REQUEST_DELAY;
+      createItem();
+      await flushItems();
+      expect(savePathMock.mock.calls.length).toBe(1);
+      // reject the first request
+      await requestsMock.reject(0);
+      await processResponse();
+      // increment delay and use jest.advanceTimersByTime instead of flushItems
+      await jest.advanceTimersByTime(delay * 2);
       expect(savePathMock.mock.calls.length).toBe(2);
-      expect(savePathMock.mock.calls[1][0]).toBe('pages/foo$bar');
-      expect(savePathMock.mock.calls[1][1]).toStrictEqual(defaultData);
+      await requestsMock.reject(1);
+      await processResponse();
+      await jest.advanceTimersByTime(delay);
+      // test the request has not flushed yet since delay was increased
+      expect(savePathMock.mock.calls.length).toBe(2);
+      await jest.advanceTimersByTime(delay * 3);
+      expect(savePathMock.mock.calls.length).toBe(3);
+    });
+    it('should reset increased delay after a request succeeds', async () => {
+      const delay = DEFAULT_REQUEST_DELAY;
+      const item = createItem();
+      await flushItems();
+      expect(savePathMock.mock.calls.length).toBe(1);
+      await requestsMock.reject(0);
+      await processResponse();
+      await jest.advanceTimersByTime(delay * 2);
+      expect(savePathMock.mock.calls.length).toBe(2);
+      await requestsMock.resolve(1);
+      await processResponse();
+      item.update({
+        foo1: 'bar1',
+      });
+      await jest.advanceTimersByTime(delay);
+      expect(savePathMock.mock.calls.length).toBe(3);
     });
   });
   describe('when a new request to modify the same node is made, and the original request has no succeeded', () => {
-    it('should abandon original request and retry it until successful', async () => {
+    it('should abandon original request and retry the new request until successful', async () => {
       const item = createItem();
-      await jest.runAllTimers();
+      await flushItems();
       const data1 = {
         foo1: 'bar1',
       };
       item.update(data1);
       // reject the first request
-      await pendingRequests[0].reject(false);
-      await jest.runAllTimers();
-      await jest.runAllTimers();
-      // fulfil the second request
-      await pendingRequests[1].resolve(true);
-      await jest.runAllTimers();
+      await requestsMock.reject(0);
+      await processResponse();
+      await flushItems();
+      // resolve the second request
+      await requestsMock.resolve(1);
+      await processResponse();
       expect(savePathMock.mock.calls.length).toBe(2);
       expect(savePathMock.mock.calls[1][0]).toBe('pages/foo$bar');
       expect(savePathMock.mock.calls[1][1]).toStrictEqual(data1);
+    });
+  });
+  describe('when a request to delete the same node is made, and the original request has no succeeded', () => {
+    it('should abandon original request and retry the delete request until successful', async () => {
+      const item = createItem();
+      await flushItems();
+      expect(savePathMock.mock.calls.length).toBe(1);
+      expect(deletePathMock.mock.calls.length).toBe(0);
+      item.delete();
+      // reject the first request
+      await requestsMock.reject(0);
+      await processResponse();
+      await flushItems();
+      // reject the second request
+      await requestsMock.reject(1);
+      await processResponse();
+      expect(savePathMock.mock.calls.length).toBe(1);
+      expect(deletePathMock.mock.calls.length).toBe(1);
+      await flushItems();
+      // reject the second request
+      await requestsMock.resolve(2);
+      await processResponse();
+      expect(savePathMock.mock.calls.length).toBe(1);
+      expect(deletePathMock.mock.calls.length).toBe(2);
+      // flush again and test nothing is flushed
+      await flushItems();
+      expect(savePathMock.mock.calls.length).toBe(1);
+      expect(deletePathMock.mock.calls.length).toBe(2);
     });
   });
   describe('when item is created and then updated by browser', () => {
@@ -114,10 +215,10 @@ describe('GatsbyMobxStoreItem', () => {
       expect(savePathMock.mock.calls[0][0]).toBe('pages/foo$bar');
       expect(savePathMock.mock.calls[0][1]).toStrictEqual(defaultData);
       // fulfill the first request
-      await pendingRequests[0].resolve(true);
+      await requestsMock.resolve(0);
       jest.runAllTimers();
       // fulfill the second request
-      await pendingRequests[1].resolve(true);
+      await requestsMock.resolve(1);
       expect(savePathMock.mock.calls.length).toBe(2);
       expect(savePathMock.mock.calls[1][0]).toBe('pages/foo$bar');
       expect(savePathMock.mock.calls[1][1]).toStrictEqual(data1);
@@ -128,7 +229,7 @@ describe('GatsbyMobxStoreItem', () => {
       const item = createItem();
       jest.runAllTimers();
       // fulfill the request
-      await pendingRequests[0].resolve(true);
+      await requestsMock.resolve(0);
       const data1 = {
         foo: 'bar1',
       };
@@ -139,7 +240,7 @@ describe('GatsbyMobxStoreItem', () => {
       const item = createItem();
       jest.runAllTimers();
       // fulfill the request
-      await pendingRequests[0].resolve(true);
+      await requestsMock.resolve(0);
       jest.runAllTimers();
       const data1 = {
         foo: 'bar1',
@@ -155,7 +256,7 @@ describe('GatsbyMobxStoreItem', () => {
       const item = createItem();
       jest.runAllTimers();
       // fulfill the request
-      await pendingRequests[0].resolve(true);
+      await requestsMock.resolve(0);
       expect(item.isPending()).toBe(false);
     });
   });

--- a/packages/gatsby-theme-bodiless/src/dist/GatsbyMobxStoreItem.ts
+++ b/packages/gatsby-theme-bodiless/src/dist/GatsbyMobxStoreItem.ts
@@ -27,6 +27,8 @@ enum ItemState {
   Queued,
 }
 
+const DEFAULT_REQUEST_DELAY = 500;
+
 export default class GatsbyMobxStoreItem {
   @observable data = {};
 
@@ -41,6 +43,8 @@ export default class GatsbyMobxStoreItem {
   lockTimeout?: NodeJS.Timeout;
 
   requestTimeout?: NodeJS.Timeout;
+
+  requestDelay: number = DEFAULT_REQUEST_DELAY;
 
   private shouldAccept() {
     const isClean = this.state === ItemState.Clean;
@@ -80,6 +84,7 @@ export default class GatsbyMobxStoreItem {
         this.setState(ItemState.Flushing);
         break;
       case ItemStateEvent.OnRequestEnd:
+        this.requestDelay = DEFAULT_REQUEST_DELAY;
         if (this.state === ItemState.Queued) {
           this.scheduleRequest();
           break;
@@ -88,6 +93,12 @@ export default class GatsbyMobxStoreItem {
         // So that mitigate the problem with stale data coming from the server
         this.setState(ItemState.Locked);
         this.setLockTimeout();
+        break;
+      case ItemStateEvent.OnRequestError:
+        // incrementally increasing times between each subsequent retry
+        this.requestDelay *= 2;
+        this.scheduleRequest();
+        this.setState(ItemState.Queued);
         break;
       case ItemStateEvent.OnLockTimeout:
         if (this.state === ItemState.Locked) {
@@ -121,7 +132,9 @@ export default class GatsbyMobxStoreItem {
       const requestPromise = this.isDeleted
         ? this.store.client.deletePath(this.getResoucePath())
         : this.store.client.savePath(this.getResoucePath(), this.data);
-      requestPromise.then(() => this.updateState(ItemStateEvent.OnRequestEnd));
+      requestPromise
+        .then(() => this.updateState(ItemStateEvent.OnRequestEnd))
+        .catch(() => this.updateState(ItemStateEvent.OnRequestError));
     } else {
       this.updateState(ItemStateEvent.OnRequestEnd);
     }
@@ -132,7 +145,7 @@ export default class GatsbyMobxStoreItem {
     if (this.requestTimeout !== undefined) {
       clearTimeout(this.requestTimeout);
     }
-    this.requestTimeout = setTimeout(this.request.bind(this), 500);
+    this.requestTimeout = setTimeout(this.request.bind(this), this.requestDelay);
   }
 
   private setLockTimeout() {

--- a/packages/gatsby-theme-bodiless/src/dist/GatsbyMobxStoreItem.ts
+++ b/packages/gatsby-theme-bodiless/src/dist/GatsbyMobxStoreItem.ts
@@ -28,6 +28,7 @@ enum ItemState {
 }
 
 export const DEFAULT_REQUEST_DELAY = 500;
+const MAXIMUM_REQUEST_DELAY = 5 * 60 * 1000; // 5 minutes
 
 export default class GatsbyMobxStoreItem {
   @observable data = {};
@@ -96,7 +97,8 @@ export default class GatsbyMobxStoreItem {
         break;
       case ItemStateEvent.OnRequestError:
         // incrementally increasing time between each subsequent retry
-        this.requestDelay *= 2;
+        // ensure new delay is not greater than defined maximum
+        this.requestDelay = Math.min(this.requestDelay * 2, MAXIMUM_REQUEST_DELAY);
         this.scheduleRequest();
         this.setState(ItemState.Queued);
         break;

--- a/packages/gatsby-theme-bodiless/src/dist/GatsbyMobxStoreItem.ts
+++ b/packages/gatsby-theme-bodiless/src/dist/GatsbyMobxStoreItem.ts
@@ -27,7 +27,7 @@ enum ItemState {
   Queued,
 }
 
-const DEFAULT_REQUEST_DELAY = 500;
+export const DEFAULT_REQUEST_DELAY = 500;
 
 export default class GatsbyMobxStoreItem {
   @observable data = {};
@@ -95,7 +95,7 @@ export default class GatsbyMobxStoreItem {
         this.setLockTimeout();
         break;
       case ItemStateEvent.OnRequestError:
-        // incrementally increasing times between each subsequent retry
+        // incrementally increasing time between each subsequent retry
         this.requestDelay *= 2;
         this.scheduleRequest();
         this.setState(ItemState.Queued);

--- a/packages/gatsby-theme-bodiless/src/dist/types.ts
+++ b/packages/gatsby-theme-bodiless/src/dist/types.ts
@@ -21,6 +21,7 @@ export enum ItemStateEvent {
   OnLockTimeout,
   OnRequestEnd,
   OnRequestStart,
+  OnRequestError,
 }
 
 export type ConflictsResponseType = {


### PR DESCRIPTION
## Changes
* when an error occurs after saving data to the backend, the request is retried until successful
* retry delay is incrementally increased between subsequent failed requests

## Test Instructions
<!-- Detailed description of how this feature was (and should be) tested
  - Setup instructions (if any)?
  - List of test cases, with steps and expected results?
  - List
-->

## Related Issues
Fixes #394

<!-- IF THIS PR INTRODUCES A BREAKING CHANGE

BREAKING CHANGE: Describe the nature of the breaking change here.

More Details about the breaking change.
-->
