### PR TITLE
Fix (core, backend): Revert operation - consider location of root git folder

### DIFF
--- a/packages/bodiless-backend/src/backend.js
+++ b/packages/bodiless-backend/src/backend.js
@@ -362,13 +362,21 @@ class Backend {
           const gitStatus = await GitCmd.cmd()
             .add('status', '--porcelain', backendPagePath)
             .exec();
+          const gitRootRelPath = await GitCmd.cmd()
+            .add('rev-parse', '--show-cdup')
+            .exec();
           const reGetDeletedAndUntracked = /(?<= D |\?\? ).*/gm;
           const deletedAndUntracked = gitStatus.stdout.match(reGetDeletedAndUntracked);
           if (deletedAndUntracked !== null) {
             const dataPagePath = path.join(backendFilePath, 'pages');
             const obsoletePublicPages = deletedAndUntracked.map(gitPath => {
               const publicPagePath = gitPath.replace(dataPagePath, backendPublicPath);
-              return path.resolve('../..', publicPagePath);
+              // Get absolute path considering location of .git folder
+              const absolutePublicPagePath = path.resolve(
+                gitRootRelPath.stdout.trim(),
+                publicPagePath,
+              );
+              return absolutePublicPagePath;
             });
             // Have to loop through every path since 'git clean' can work incorrectly when passing
             // all the paths at once.

--- a/packages/bodiless-backend/src/backend.js
+++ b/packages/bodiless-backend/src/backend.js
@@ -372,11 +372,10 @@ class Backend {
             const obsoletePublicPages = deletedAndUntracked.map(gitPath => {
               const publicPagePath = gitPath.replace(dataPagePath, backendPublicPath);
               // Get absolute path considering location of .git folder
-              const absolutePublicPagePath = path.resolve(
+              return path.resolve(
                 gitRootRelPath.stdout.trim(),
                 publicPagePath,
               );
-              return absolutePublicPagePath;
             });
             // Have to loop through every path since 'git clean' can work incorrectly when passing
             // all the paths at once.


### PR DESCRIPTION
## Changes
Make git revert operation considering location of .git folder and resolve path base on that.
This is important when launching the site outside the monorepo.

## Testing notes
- launch starter site by running `npm run sites:launch-test` or in a standalone folder
- init clean git repo in the site folder, add and commit everything
- try adding and reverting new pages in edit mode

## Related Issues
Fixes #427