### PR TITLE
Feat (core, ui): Add remaining informed components

### DIFF
--- a/examples/test-site/src/data/pages/form-elements/index.tsx
+++ b/examples/test-site/src/data/pages/form-elements/index.tsx
@@ -14,7 +14,6 @@
 
 import React, { FC } from 'react';
 import { graphql } from 'gatsby';
-import { addClasses } from '@bodiless/fclasses';
 import { PageContextProvider } from '@bodiless/core';
 import {
   Form,
@@ -33,20 +32,6 @@ import {
 } from '@bodiless/ui';
 import { Page } from '@bodiless/gatsby-theme-bodiless';
 import Layout from '../../../components/Layout';
-
-const ExampleFormButtonProvider: FC = ({ children }) => {
-    const getMenuOptions = () => [{
-      name: 'Example Form',
-      label: 'Test',
-      icon: 'article',
-      handler: () => ExampleForm,
-    }];
-    return (
-      <PageContextProvider getMenuOptions={getMenuOptions}>
-        {children}
-      </PageContextProvider>
-    );
-  };
 
 const ExampleForm = () => (
   <Form>
@@ -130,12 +115,26 @@ const ExampleForm = () => (
   </Form>
 );
 
+const ExampleFormButtonProvider: FC = ({ children }) => {
+  const getMenuOptions = () => [{
+    name: 'Example Form',
+    label: 'Test',
+    icon: 'article',
+    handler: () => ExampleForm,
+  }];
+  return (
+    <PageContextProvider getMenuOptions={getMenuOptions}>
+      {children}
+    </PageContextProvider>
+  );
+};
+
 export default props => (
   <ExampleFormButtonProvider>
     <Page {...props}>
       <Layout>
         <h1 className="bl-p-8">
-          Click the 'Test' button in the toolbar in order to see the example form.
+          Click the &apos;Test&lsquo; button in the toolbar in order to see the example form.
         </h1>
       </Layout>
     </Page>

--- a/examples/test-site/src/data/pages/form-elements/index.tsx
+++ b/examples/test-site/src/data/pages/form-elements/index.tsx
@@ -24,7 +24,7 @@ const ExampleForm = () => contextMenuForm()(
       ComponentFormTitle, ComponentFormFieldWrapper, ComponentFormDescription,
       ComponentFormFieldTitle, ComponentFormText, ComponentFormTextArea,
       ComponentFormRadioGroup, ComponentFormLabel, ComponentFormRadio,
-      ComponentFormCheckBox, ComponentFormSelect, ComponentFormOption
+      ComponentFormCheckBox, ComponentFormSelect, ComponentFormOption,
     } = getUI(ui);
     return (
       <>

--- a/examples/test-site/src/data/pages/form-elements/index.tsx
+++ b/examples/test-site/src/data/pages/form-elements/index.tsx
@@ -12,11 +12,12 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { FC } from 'react';
 import { graphql } from 'gatsby';
 import { addClasses } from '@bodiless/fclasses';
+import { PageContextProvider } from '@bodiless/core';
 import {
-  ComponentFormWrapper as BaseComponentFormWapper,
+  Form,
   ComponentFormFieldWrapper,
   ComponentFormFieldTitle,
   ComponentFormDescription,
@@ -33,12 +34,22 @@ import {
 import { Page } from '@bodiless/gatsby-theme-bodiless';
 import Layout from '../../../components/Layout';
 
-const ComponentFormWrapper = addClasses(
-  'bl-mt-grid-10 bl-mb-grid-10 bl-w-1/4 bl-rounded',
-)(BaseComponentFormWapper);
+const ExampleFormButtonProvider: FC = ({ children }) => {
+    const getMenuOptions = () => [{
+      name: 'Example Form',
+      label: 'Test',
+      icon: 'article',
+      handler: () => ExampleForm,
+    }];
+    return (
+      <PageContextProvider getMenuOptions={getMenuOptions}>
+        {children}
+      </PageContextProvider>
+    );
+  };
 
 const ExampleForm = () => (
-  <ComponentFormWrapper>
+  <Form>
     <ComponentFormTitle>Multi-Field Example Form</ComponentFormTitle>
 
     <ComponentFormFieldWrapper>
@@ -116,15 +127,19 @@ const ExampleForm = () => (
       <ComponentFormFieldTitle>Number</ComponentFormFieldTitle>
       <ComponentFormText field="number-text-field" type="number" placeholder="100" />
     </ComponentFormFieldWrapper>
-  </ComponentFormWrapper>
+  </Form>
 );
 
 export default props => (
-  <Page {...props}>
-    <Layout>
-      <ExampleForm />
-    </Layout>
-  </Page>
+  <ExampleFormButtonProvider>
+    <Page {...props}>
+      <Layout>
+        <h1 className="bl-p-8">
+          Click the 'Test' button in the toolbar in order to see the example form.
+        </h1>
+      </Layout>
+    </Page>
+  </ExampleFormButtonProvider>
 );
 
 export const query = graphql`

--- a/examples/test-site/src/data/pages/form-elements/index.tsx
+++ b/examples/test-site/src/data/pages/form-elements/index.tsx
@@ -1,0 +1,124 @@
+/**
+ * Copyright © 2020 Johnson & Johnson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { graphql } from 'gatsby';
+import { addClasses } from '@bodiless/fclasses';
+import {
+  ComponentFormWrapper as BaseComponentFormWapper,
+  ComponentFormFieldWrapper,
+  ComponentFormFieldTitle,
+  ComponentFormDescription,
+  ComponentFormLabel,
+  ComponentFormTitle,
+  ComponentFormText,
+  ComponentFormTextArea,
+  ComponentFormRadioGroup,
+  ComponentFormRadio,
+  ComponentFormCheckbox,
+  ComponentFormSelect,
+  ComponentFormOption,
+} from '@bodiless/ui';
+import { Page } from '@bodiless/gatsby-theme-bodiless';
+import Layout from '../../../components/Layout';
+
+const ComponentFormWrapper = addClasses(
+  'bl-mt-grid-10 bl-mb-grid-10 bl-w-1/4 bl-rounded'
+)(BaseComponentFormWapper);
+
+const ExampleForm = () => {
+  return (
+    <ComponentFormWrapper>
+      <ComponentFormTitle>Multi-Field Example Form</ComponentFormTitle>
+
+      <ComponentFormFieldWrapper>
+        <ComponentFormDescription>
+          Description or instructions. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+        </ComponentFormDescription>
+      </ComponentFormFieldWrapper>
+
+      <ComponentFormFieldWrapper>
+        <ComponentFormFieldTitle>Text</ComponentFormFieldTitle>
+        <ComponentFormText field="text-field" placeholder="Name" />
+      </ComponentFormFieldWrapper>
+
+      <ComponentFormFieldWrapper>
+        <ComponentFormFieldTitle>Text Area</ComponentFormFieldTitle>
+        <ComponentFormTextArea field="text-area" placeholder="Comments" />
+      </ComponentFormFieldWrapper>
+
+      <ComponentFormFieldWrapper>
+      <ComponentFormFieldTitle>Radio Button Group</ComponentFormFieldTitle>
+        <ComponentFormRadioGroup field="gender" style={{backgroundColor: 'blue'}}>
+          <ComponentFormLabel><ComponentFormRadio value="male" />Male</ComponentFormLabel>
+          <ComponentFormLabel><ComponentFormRadio value="female" />Female</ComponentFormLabel>
+          <ComponentFormLabel><ComponentFormRadio value="other" />Other</ComponentFormLabel>       
+        </ComponentFormRadioGroup>
+      </ComponentFormFieldWrapper>
+
+      <ComponentFormFieldWrapper>
+        <ComponentFormFieldTitle>Checkbox</ComponentFormFieldTitle>
+        <ComponentFormLabel><ComponentFormCheckbox field="checkbox" />I agree</ComponentFormLabel>
+      </ComponentFormFieldWrapper>
+
+      <ComponentFormFieldWrapper>
+      <ComponentFormFieldTitle>Select</ComponentFormFieldTitle>
+        <ComponentFormSelect field="city">
+          <ComponentFormOption value="" disabled>
+            Select      
+          </ComponentFormOption>
+          <ComponentFormOption value="ny">NY</ComponentFormOption>
+          <ComponentFormOption value="nj">NJ</ComponentFormOption>
+          <ComponentFormOption value="ct">CT</ComponentFormOption>
+        </ComponentFormSelect>
+      </ComponentFormFieldWrapper>
+
+      <ComponentFormFieldWrapper>
+        <ComponentFormFieldTitle>Multi-Select</ComponentFormFieldTitle>
+        <ComponentFormSelect
+          field="colors"
+          id="select-colors"
+          multiple
+        >
+          <ComponentFormOption value="red">Red</ComponentFormOption>
+          <ComponentFormOption value="green">Green</ComponentFormOption>
+          <ComponentFormOption value="blue">Blue</ComponentFormOption>
+          <ComponentFormOption value="yellow">Yellow</ComponentFormOption>
+          <ComponentFormOption value="orange">Orange</ComponentFormOption>
+          <ComponentFormOption value="purple">Purple</ComponentFormOption>
+        </ComponentFormSelect>
+      </ComponentFormFieldWrapper>
+
+      <ComponentFormFieldWrapper>
+        <ComponentFormFieldTitle>Number</ComponentFormFieldTitle>
+        <ComponentFormText field="number-text-field" type="number" placeholder="100" />
+      </ComponentFormFieldWrapper>
+    </ComponentFormWrapper>
+  );
+};
+
+export default props => (
+  <Page {...props}>
+    <Layout>
+      <ExampleForm />
+    </Layout>
+  </Page>
+);
+
+export const query = graphql`
+  query($slug: String!) {
+    ...PageQuery
+    ...SiteQuery
+  }
+`;

--- a/examples/test-site/src/data/pages/form-elements/index.tsx
+++ b/examples/test-site/src/data/pages/form-elements/index.tsx
@@ -26,7 +26,7 @@ import {
   ComponentFormTextArea,
   ComponentFormRadioGroup,
   ComponentFormRadio,
-  ComponentFormCheckbox,
+  ComponentFormCheckBox,
   ComponentFormSelect,
   ComponentFormOption,
 } from '@bodiless/ui';
@@ -34,79 +34,90 @@ import { Page } from '@bodiless/gatsby-theme-bodiless';
 import Layout from '../../../components/Layout';
 
 const ComponentFormWrapper = addClasses(
-  'bl-mt-grid-10 bl-mb-grid-10 bl-w-1/4 bl-rounded'
+  'bl-mt-grid-10 bl-mb-grid-10 bl-w-1/4 bl-rounded',
 )(BaseComponentFormWapper);
 
-const ExampleForm = () => {
-  return (
-    <ComponentFormWrapper>
-      <ComponentFormTitle>Multi-Field Example Form</ComponentFormTitle>
+const ExampleForm = () => (
+  <ComponentFormWrapper>
+    <ComponentFormTitle>Multi-Field Example Form</ComponentFormTitle>
 
-      <ComponentFormFieldWrapper>
-        <ComponentFormDescription>
-          Description or instructions. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-        </ComponentFormDescription>
-      </ComponentFormFieldWrapper>
+    <ComponentFormFieldWrapper>
+      <ComponentFormDescription>
+        Description or instructions.
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      </ComponentFormDescription>
+    </ComponentFormFieldWrapper>
 
-      <ComponentFormFieldWrapper>
-        <ComponentFormFieldTitle>Text</ComponentFormFieldTitle>
-        <ComponentFormText field="text-field" placeholder="Name" />
-      </ComponentFormFieldWrapper>
+    <ComponentFormFieldWrapper>
+      <ComponentFormFieldTitle>Text</ComponentFormFieldTitle>
+      <ComponentFormText field="text-field" placeholder="Name" />
+    </ComponentFormFieldWrapper>
 
-      <ComponentFormFieldWrapper>
-        <ComponentFormFieldTitle>Text Area</ComponentFormFieldTitle>
-        <ComponentFormTextArea field="text-area" placeholder="Comments" />
-      </ComponentFormFieldWrapper>
+    <ComponentFormFieldWrapper>
+      <ComponentFormFieldTitle>Text Area</ComponentFormFieldTitle>
+      <ComponentFormTextArea field="text-area" placeholder="Comments" />
+    </ComponentFormFieldWrapper>
 
-      <ComponentFormFieldWrapper>
+    <ComponentFormFieldWrapper>
       <ComponentFormFieldTitle>Radio Button Group</ComponentFormFieldTitle>
-        <ComponentFormRadioGroup field="gender" style={{backgroundColor: 'blue'}}>
-          <ComponentFormLabel><ComponentFormRadio value="male" />Male</ComponentFormLabel>
-          <ComponentFormLabel><ComponentFormRadio value="female" />Female</ComponentFormLabel>
-          <ComponentFormLabel><ComponentFormRadio value="other" />Other</ComponentFormLabel>       
-        </ComponentFormRadioGroup>
-      </ComponentFormFieldWrapper>
+      <ComponentFormRadioGroup field="gender" style={{ backgroundColor: 'blue' }}>
+        <ComponentFormLabel>
+          <ComponentFormRadio value="male" />
+          Male
+        </ComponentFormLabel>
+        <ComponentFormLabel>
+          <ComponentFormRadio value="female" />
+          Female
+        </ComponentFormLabel>
+        <ComponentFormLabel>
+          <ComponentFormRadio value="other" />
+          Other
+        </ComponentFormLabel>
+      </ComponentFormRadioGroup>
+    </ComponentFormFieldWrapper>
 
-      <ComponentFormFieldWrapper>
-        <ComponentFormFieldTitle>Checkbox</ComponentFormFieldTitle>
-        <ComponentFormLabel><ComponentFormCheckbox field="checkbox" />I agree</ComponentFormLabel>
-      </ComponentFormFieldWrapper>
+    <ComponentFormFieldWrapper>
+      <ComponentFormFieldTitle>Checkbox</ComponentFormFieldTitle>
+      <ComponentFormLabel>
+        <ComponentFormCheckBox field="checkbox" />
+        I agree
+      </ComponentFormLabel>
+    </ComponentFormFieldWrapper>
 
-      <ComponentFormFieldWrapper>
+    <ComponentFormFieldWrapper>
       <ComponentFormFieldTitle>Select</ComponentFormFieldTitle>
-        <ComponentFormSelect field="city">
-          <ComponentFormOption value="" disabled>
-            Select      
-          </ComponentFormOption>
-          <ComponentFormOption value="ny">NY</ComponentFormOption>
-          <ComponentFormOption value="nj">NJ</ComponentFormOption>
-          <ComponentFormOption value="ct">CT</ComponentFormOption>
-        </ComponentFormSelect>
-      </ComponentFormFieldWrapper>
+      <ComponentFormSelect field="city">
+        <ComponentFormOption value="" disabled>
+          Select
+        </ComponentFormOption>
+        <ComponentFormOption value="ny">NY</ComponentFormOption>
+        <ComponentFormOption value="nj">NJ</ComponentFormOption>
+        <ComponentFormOption value="ct">CT</ComponentFormOption>
+      </ComponentFormSelect>
+    </ComponentFormFieldWrapper>
 
-      <ComponentFormFieldWrapper>
-        <ComponentFormFieldTitle>Multi-Select</ComponentFormFieldTitle>
-        <ComponentFormSelect
-          field="colors"
-          id="select-colors"
-          multiple
-        >
-          <ComponentFormOption value="red">Red</ComponentFormOption>
-          <ComponentFormOption value="green">Green</ComponentFormOption>
-          <ComponentFormOption value="blue">Blue</ComponentFormOption>
-          <ComponentFormOption value="yellow">Yellow</ComponentFormOption>
-          <ComponentFormOption value="orange">Orange</ComponentFormOption>
-          <ComponentFormOption value="purple">Purple</ComponentFormOption>
-        </ComponentFormSelect>
-      </ComponentFormFieldWrapper>
+    <ComponentFormFieldWrapper>
+      <ComponentFormFieldTitle>Multi-Select</ComponentFormFieldTitle>
+      <ComponentFormSelect
+        field="colors"
+        id="select-colors"
+        multiple
+      >
+        <ComponentFormOption value="red">Red</ComponentFormOption>
+        <ComponentFormOption value="green">Green</ComponentFormOption>
+        <ComponentFormOption value="blue">Blue</ComponentFormOption>
+        <ComponentFormOption value="yellow">Yellow</ComponentFormOption>
+        <ComponentFormOption value="orange">Orange</ComponentFormOption>
+        <ComponentFormOption value="purple">Purple</ComponentFormOption>
+      </ComponentFormSelect>
+    </ComponentFormFieldWrapper>
 
-      <ComponentFormFieldWrapper>
-        <ComponentFormFieldTitle>Number</ComponentFormFieldTitle>
-        <ComponentFormText field="number-text-field" type="number" placeholder="100" />
-      </ComponentFormFieldWrapper>
-    </ComponentFormWrapper>
-  );
-};
+    <ComponentFormFieldWrapper>
+      <ComponentFormFieldTitle>Number</ComponentFormFieldTitle>
+      <ComponentFormText field="number-text-field" type="number" placeholder="100" />
+    </ComponentFormFieldWrapper>
+  </ComponentFormWrapper>
+);
 
 export default props => (
   <Page {...props}>

--- a/examples/test-site/src/data/pages/form-elements/index.tsx
+++ b/examples/test-site/src/data/pages/form-elements/index.tsx
@@ -14,105 +14,100 @@
 
 import React, { FC } from 'react';
 import { graphql } from 'gatsby';
-import { PageContextProvider } from '@bodiless/core';
-import {
-  Form,
-  ComponentFormFieldWrapper,
-  ComponentFormFieldTitle,
-  ComponentFormDescription,
-  ComponentFormLabel,
-  ComponentFormTitle,
-  ComponentFormText,
-  ComponentFormTextArea,
-  ComponentFormRadioGroup,
-  ComponentFormRadio,
-  ComponentFormCheckBox,
-  ComponentFormSelect,
-  ComponentFormOption,
-} from '@bodiless/ui';
+import { PageContextProvider, contextMenuForm, getUI } from '@bodiless/core';
 import { Page } from '@bodiless/gatsby-theme-bodiless';
 import Layout from '../../../components/Layout';
 
-const ExampleForm = () => (
-  <Form>
-    <ComponentFormTitle>Multi-Field Example Form</ComponentFormTitle>
+const ExampleForm = () => contextMenuForm()(
+  ({ ui }: any) => {
+    const {
+      ComponentFormTitle, ComponentFormFieldWrapper, ComponentFormDescription,
+      ComponentFormFieldTitle, ComponentFormText, ComponentFormTextArea,
+      ComponentFormRadioGroup, ComponentFormLabel, ComponentFormRadio,
+      ComponentFormCheckBox, ComponentFormSelect, ComponentFormOption
+    } = getUI(ui);
+    return (
+      <>
+        <ComponentFormTitle>Multi-Field Example Form</ComponentFormTitle>
 
-    <ComponentFormFieldWrapper>
-      <ComponentFormDescription>
-        Description or instructions.
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-      </ComponentFormDescription>
-    </ComponentFormFieldWrapper>
+        <ComponentFormFieldWrapper>
+          <ComponentFormDescription>
+            Description or instructions.
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+          </ComponentFormDescription>
+        </ComponentFormFieldWrapper>
 
-    <ComponentFormFieldWrapper>
-      <ComponentFormFieldTitle>Text</ComponentFormFieldTitle>
-      <ComponentFormText field="text-field" placeholder="Name" />
-    </ComponentFormFieldWrapper>
+        <ComponentFormFieldWrapper>
+          <ComponentFormFieldTitle>Text</ComponentFormFieldTitle>
+          <ComponentFormText field="text-field" placeholder="Name" />
+        </ComponentFormFieldWrapper>
 
-    <ComponentFormFieldWrapper>
-      <ComponentFormFieldTitle>Text Area</ComponentFormFieldTitle>
-      <ComponentFormTextArea field="text-area" placeholder="Comments" />
-    </ComponentFormFieldWrapper>
+        <ComponentFormFieldWrapper>
+          <ComponentFormFieldTitle>Text Area</ComponentFormFieldTitle>
+          <ComponentFormTextArea field="text-area" placeholder="Comments" />
+        </ComponentFormFieldWrapper>
 
-    <ComponentFormFieldWrapper>
-      <ComponentFormFieldTitle>Radio Button Group</ComponentFormFieldTitle>
-      <ComponentFormRadioGroup field="gender" style={{ backgroundColor: 'blue' }}>
-        <ComponentFormLabel>
-          <ComponentFormRadio value="male" />
-          Male
-        </ComponentFormLabel>
-        <ComponentFormLabel>
-          <ComponentFormRadio value="female" />
-          Female
-        </ComponentFormLabel>
-        <ComponentFormLabel>
-          <ComponentFormRadio value="other" />
-          Other
-        </ComponentFormLabel>
-      </ComponentFormRadioGroup>
-    </ComponentFormFieldWrapper>
+        <ComponentFormFieldWrapper>
+          <ComponentFormFieldTitle>Radio Button Group</ComponentFormFieldTitle>
+          <ComponentFormRadioGroup field="gender" style={{ backgroundColor: 'blue' }}>
+            <ComponentFormLabel>
+              <ComponentFormRadio value="male" />
+              Male
+            </ComponentFormLabel>
+            <ComponentFormLabel>
+              <ComponentFormRadio value="female" />
+              Female
+            </ComponentFormLabel>
+            <ComponentFormLabel>
+              <ComponentFormRadio value="other" />
+              Other
+            </ComponentFormLabel>
+          </ComponentFormRadioGroup>
+        </ComponentFormFieldWrapper>
 
-    <ComponentFormFieldWrapper>
-      <ComponentFormFieldTitle>Checkbox</ComponentFormFieldTitle>
-      <ComponentFormLabel>
-        <ComponentFormCheckBox field="checkbox" />
-        I agree
-      </ComponentFormLabel>
-    </ComponentFormFieldWrapper>
+        <ComponentFormFieldWrapper>
+          <ComponentFormFieldTitle>Checkbox</ComponentFormFieldTitle>
+          <ComponentFormLabel>
+            <ComponentFormCheckBox field="checkbox" />
+            I agree
+          </ComponentFormLabel>
+        </ComponentFormFieldWrapper>
 
-    <ComponentFormFieldWrapper>
-      <ComponentFormFieldTitle>Select</ComponentFormFieldTitle>
-      <ComponentFormSelect field="city">
-        <ComponentFormOption value="" disabled>
-          Select
-        </ComponentFormOption>
-        <ComponentFormOption value="ny">NY</ComponentFormOption>
-        <ComponentFormOption value="nj">NJ</ComponentFormOption>
-        <ComponentFormOption value="ct">CT</ComponentFormOption>
-      </ComponentFormSelect>
-    </ComponentFormFieldWrapper>
+        <ComponentFormFieldWrapper>
+          <ComponentFormFieldTitle>Select</ComponentFormFieldTitle>
+          <ComponentFormSelect field="city">
+            <ComponentFormOption value="" disabled>
+              Select
+            </ComponentFormOption>
+            <ComponentFormOption value="ny">NY</ComponentFormOption>
+            <ComponentFormOption value="nj">NJ</ComponentFormOption>
+            <ComponentFormOption value="ct">CT</ComponentFormOption>
+          </ComponentFormSelect>
+        </ComponentFormFieldWrapper>
 
-    <ComponentFormFieldWrapper>
-      <ComponentFormFieldTitle>Multi-Select</ComponentFormFieldTitle>
-      <ComponentFormSelect
-        field="colors"
-        id="select-colors"
-        multiple
-      >
-        <ComponentFormOption value="red">Red</ComponentFormOption>
-        <ComponentFormOption value="green">Green</ComponentFormOption>
-        <ComponentFormOption value="blue">Blue</ComponentFormOption>
-        <ComponentFormOption value="yellow">Yellow</ComponentFormOption>
-        <ComponentFormOption value="orange">Orange</ComponentFormOption>
-        <ComponentFormOption value="purple">Purple</ComponentFormOption>
-      </ComponentFormSelect>
-    </ComponentFormFieldWrapper>
+        <ComponentFormFieldWrapper>
+          <ComponentFormFieldTitle>Multi-Select</ComponentFormFieldTitle>
+          <ComponentFormSelect
+            field="colors"
+            id="select-colors"
+            multiple
+          >
+            <ComponentFormOption value="red">Red</ComponentFormOption>
+            <ComponentFormOption value="green">Green</ComponentFormOption>
+            <ComponentFormOption value="blue">Blue</ComponentFormOption>
+            <ComponentFormOption value="yellow">Yellow</ComponentFormOption>
+            <ComponentFormOption value="orange">Orange</ComponentFormOption>
+            <ComponentFormOption value="purple">Purple</ComponentFormOption>
+          </ComponentFormSelect>
+        </ComponentFormFieldWrapper>
 
-    <ComponentFormFieldWrapper>
-      <ComponentFormFieldTitle>Number</ComponentFormFieldTitle>
-      <ComponentFormText field="number-text-field" type="number" placeholder="100" />
-    </ComponentFormFieldWrapper>
-  </Form>
+        <ComponentFormFieldWrapper>
+          <ComponentFormFieldTitle>Number</ComponentFormFieldTitle>
+          <ComponentFormText field="number-text-field" type="number" placeholder="100" />
+        </ComponentFormFieldWrapper>
+      </>
+    );
+  },
 );
 
 const ExampleFormButtonProvider: FC = ({ children }) => {
@@ -120,7 +115,7 @@ const ExampleFormButtonProvider: FC = ({ children }) => {
     name: 'Example Form',
     label: 'Test',
     icon: 'article',
-    handler: () => ExampleForm,
+    handler: ExampleForm,
   }];
   return (
     <PageContextProvider getMenuOptions={getMenuOptions}>

--- a/packages/bodiless-core-ui/src/GlobalContextMenu.tsx
+++ b/packages/bodiless-core-ui/src/GlobalContextMenu.tsx
@@ -27,7 +27,7 @@ import {
   ComponentFormError, ComponentFormSubmitButton, ComponentFormList, ComponentFormListItem,
   ComponentFormDescription, ComponentFormWarning, ComponentFormFieldWrapper,
   ComponentFormFieldTitle, ComponentFormCheckBox, ComponentFormRadio, ComponentFormRadioGroup,
-  ComponentFormSelect, ComponentFormOption,
+  ComponentFormSelect, ComponentFormOption, ComponentFormTextArea,
 } from '@bodiless/ui';
 import ReactTagsField from './ReactTags';
 
@@ -78,6 +78,7 @@ const ui: ContextMenuUI = {
   ComponentFormLabel,
   ComponentFormDescription,
   ComponentFormText,
+  ComponentFormTextArea,
   ComponentFormFieldWrapper,
   ComponentFormFieldTitle,
   ComponentFormCheckBox,

--- a/packages/bodiless-core-ui/src/GlobalContextMenu.tsx
+++ b/packages/bodiless-core-ui/src/GlobalContextMenu.tsx
@@ -25,7 +25,9 @@ import {
   ComponentFormTitle, ComponentFormCloseButton, ComponentFormLabel, ComponentFormText,
   ComponentFormButton, Icon, Div, Hr, ToolbarButton, ComponentFormUnwrapButton,
   ComponentFormError, ComponentFormSubmitButton, ComponentFormList, ComponentFormListItem,
-  ComponentFormDescription, ComponentFormWarning,
+  ComponentFormDescription, ComponentFormWarning, ComponentFormFieldWrapper,
+  ComponentFormFieldTitle, ComponentFormCheckBox, ComponentFormRadio, ComponentFormRadioGroup,
+  ComponentFormSelect, ComponentFormOption,
 } from '@bodiless/ui';
 import ReactTagsField from './ReactTags';
 
@@ -76,6 +78,13 @@ const ui: ContextMenuUI = {
   ComponentFormLabel,
   ComponentFormDescription,
   ComponentFormText,
+  ComponentFormFieldWrapper,
+  ComponentFormFieldTitle,
+  ComponentFormCheckBox,
+  ComponentFormRadio,
+  ComponentFormRadioGroup,
+  ComponentFormSelect,
+  ComponentFormOption,
   ComponentFormButton,
   ComponentFormCloseButton,
   ComponentFormSubmitButton,

--- a/packages/bodiless-core-ui/src/LocalContextMenu.tsx
+++ b/packages/bodiless-core-ui/src/LocalContextMenu.tsx
@@ -23,6 +23,8 @@ import {
   ComponentFormTitle, ComponentFormLabel, ComponentFormText, ComponentFormButton,
   ComponentFormCloseButton, ComponentFormSubmitButton, Icon, Div, ToolbarButton,
   ComponentFormUnwrapButton, ComponentFormTextArea, ComponentFormDescription, ComponentFormWarning,
+  ComponentFormFieldWrapper, ComponentFormFieldTitle, ComponentFormCheckBox, ComponentFormRadio,
+  ComponentFormRadioGroup, ComponentFormSelect, ComponentFormOption,
 } from '@bodiless/ui';
 import ReactTagsField from './ReactTags';
 
@@ -42,6 +44,13 @@ const LocalTooltip: FC<ReactTooltip['props']> = props => (
 const ui = {
   ComponentFormText,
   ComponentFormTextArea,
+  ComponentFormFieldWrapper,
+  ComponentFormFieldTitle,
+  ComponentFormCheckBox,
+  ComponentFormRadio,
+  ComponentFormRadioGroup,
+  ComponentFormSelect,
+  ComponentFormOption,
   ComponentFormButton,
   ComponentFormCloseButton,
   ComponentFormUnwrapButton,

--- a/packages/bodiless-core/src/Types/ContextMenuTypes.tsx
+++ b/packages/bodiless-core/src/Types/ContextMenuTypes.tsx
@@ -17,7 +17,11 @@ import {
   HTMLProps,
   ReactNode,
 } from 'react';
-import { FieldProps } from 'informed';
+import {
+  FieldProps,
+  ChildFieldProps,
+  SelectFieldProps,
+} from 'informed';
 import Tooltip from 'rc-tooltip';
 import { TMenuOption } from '../PageEditContext/types';
 import { ReactTagsFieldProps } from '../components/ReactTagsField';
@@ -48,10 +52,10 @@ export type UI = {
   ComponentFormText?: ComponentType<FieldProps<any, any>>;
   ComponentFormTextArea?: ComponentType<FieldProps<any, any>>;
   ComponentFormRadioGroup?: ComponentType<FieldProps<any, any>>;
-  ComponentFormRadio?: ComponentType<HTMLProps<HTMLInputElement>>;
+  ComponentFormRadio?: ComponentType<ChildFieldProps<any, any>>;
   ComponentFormCheckbox?: ComponentType<FieldProps<any, any>>;
-  ComponentFormSelect?: ComponentType<FieldProps<any, any>>;
-  ComponentFormOption?: ComponentType<HTMLProps<HTMLInputElement>>;
+  ComponentFormSelect?: ComponentType<SelectFieldProps<any, any>>;
+  ComponentFormOption?: ComponentType<ChildFieldProps<any, any>>;
   ComponentFormError?: ComponentType<HTMLProps<HTMLDivElement>> | string;
   Form?: ComponentType<HTMLProps<HTMLFormElement>> | string;
   Tooltip?: ComponentType<Tooltip['props']>;

--- a/packages/bodiless-core/src/Types/ContextMenuTypes.tsx
+++ b/packages/bodiless-core/src/Types/ContextMenuTypes.tsx
@@ -47,13 +47,17 @@ export type UI = {
   ComponentFormUnwrapButton?: ComponentType<HTMLProps<HTMLButtonElement>> | string;
   ComponentFormText?: ComponentType<FieldProps<any, any>>;
   ComponentFormTextArea?: ComponentType<FieldProps<any, any>>;
+  ComponentFormRadioGroup?: ComponentType<FieldProps<any, any>>;
+  ComponentFormRadio?: ComponentType<HTMLProps<HTMLInputElement>>;
+  ComponentFormCheckbox?: ComponentType<FieldProps<any, any>>;
+  ComponentFormSelect?: ComponentType<FieldProps<any, any>>;
+  ComponentFormOption?: ComponentType<HTMLProps<HTMLInputElement>>;
   ComponentFormError?: ComponentType<HTMLProps<HTMLDivElement>> | string;
   Form?: ComponentType<HTMLProps<HTMLFormElement>> | string;
   Tooltip?: ComponentType<Tooltip['props']>;
   ReactTags?: ComponentType<ReactTagsFieldProps>;
   ComponentFormList?: ComponentType<HTMLProps<HTMLUListElement>> | string;
   ComponentFormListItem?: ComponentType<HTMLProps<HTMLLIElement>> | string;
-  // @TODO: Add other controls from informed.
 };
 
 export type IContextMenuProps = {

--- a/packages/bodiless-core/src/Types/ContextMenuTypes.tsx
+++ b/packages/bodiless-core/src/Types/ContextMenuTypes.tsx
@@ -42,6 +42,7 @@ export type UI = {
   ToolbarButton?: ComponentType<ButtonVariantProps> | string;
   FormWrapper?: ComponentType<HTMLProps<HTMLDivElement>> | string;
   ToolbarDivider?: ComponentType<HTMLProps<HTMLHRElement>> | string;
+  ComponentFormFieldWrapper?: ComponentType<HTMLProps<HTMLDivElement>> | string;
   ComponentFormTitle?: ComponentType<HTMLProps<HTMLHeadingElement>> | string;
   ComponentFormLabel?: ComponentType<HTMLProps<HTMLLabelElement>> | string;
   ComponentFormDescription?: ComponentType<HTMLProps<HTMLDivElement>> | string;
@@ -52,8 +53,9 @@ export type UI = {
   ComponentFormText?: ComponentType<FieldProps<any, any>>;
   ComponentFormTextArea?: ComponentType<FieldProps<any, any>>;
   ComponentFormRadioGroup?: ComponentType<FieldProps<any, any>>;
+  ComponentFormFieldTitle?: ComponentType<HTMLProps<HTMLDivElement>> | string;
   ComponentFormRadio?: ComponentType<ChildFieldProps<any, any>>;
-  ComponentFormCheckbox?: ComponentType<FieldProps<any, any>>;
+  ComponentFormCheckBox?: ComponentType<FieldProps<any, any>>;
   ComponentFormSelect?: ComponentType<SelectFieldProps<any, any>>;
   ComponentFormOption?: ComponentType<ChildFieldProps<any, any>>;
   ComponentFormError?: ComponentType<HTMLProps<HTMLDivElement>> | string;

--- a/packages/bodiless-layouts/src/ComponentSelector/FilterWrapper.tsx
+++ b/packages/bodiless-layouts/src/ComponentSelector/FilterWrapper.tsx
@@ -52,6 +52,7 @@ function Checkbox({
   return (
     <finalUI.AccordionCheckboxWrapper>
       <finalUI.AccordionCheckBox
+        field="accordion-checkbox"
         onChange={onToggle}
         checked={isChecked}
         disabled={disabled}

--- a/packages/bodiless-layouts/src/ComponentSelector/types.tsx
+++ b/packages/bodiless-layouts/src/ComponentSelector/types.tsx
@@ -15,7 +15,7 @@
 import {
   ComponentType, HTMLProps, MouseEvent, ReactNode,
 } from 'react';
-import { FormApi, FormState } from 'informed';
+import { FormApi, FormState, FieldProps } from 'informed';
 
 export type AllowedComponent = ComponentWithMeta<any>;
 export type RenderList = (options: {
@@ -82,7 +82,7 @@ export type FinalUI = {
   // A label that will be displayed by the AccordionCheckbox
   AccordionCheckboxLabel: ComponentType<HTMLProps<HTMLLabelElement>> | string;
   // A input that will be displayed by the Accordion Label
-  AccordionCheckBox: ComponentType<HTMLProps<HTMLInputElement>> | string;
+  AccordionCheckBox: ComponentType<FieldProps<any, any>> | string;
   // A div that will wrap the search bar
   SearchBarWrapper: ComponentType<HTMLProps<HTMLDivElement>> | string;
   // A styled text input

--- a/packages/bodiless-ui/src/elements.tsx
+++ b/packages/bodiless-ui/src/elements.tsx
@@ -14,7 +14,16 @@
 
 import React, { FC, HTMLProps } from 'react';
 import { flow } from 'lodash';
-import { Text as BaseText, TextArea as BaseTextArea, FieldProps } from 'informed';
+import { 
+  Text as BaseText,
+  TextArea as BaseTextArea,
+  RadioGroup as BaseRadioGroup,
+  Radio as BaseRadio,
+  Checkbox as BaseCheckbox,
+  Select as BaseSelect,
+  Option as BaseOption,
+  FieldProps
+} from 'informed';
 import {
   Li, Ul, stylable, addClasses, StylableProps, withoutProps, flowIf, hasProp, addProps,
   removeClasses,
@@ -34,10 +43,15 @@ export const Button = stylable<HTMLProps<HTMLButtonElement>>('button');
 export const Hr = stylable<HTMLProps<HTMLHRElement>>('hr');
 export const Text = stylable<FieldProps<any, any>>(BaseText);
 export const TextArea = stylable<FieldProps<any, any>>(BaseTextArea);
+export const RadioGroup = stylable<FieldProps<any, any>>(BaseRadioGroup);
+export const Radio = stylable<HTMLProps<HTMLInputElement>>(BaseRadio);
+export const Checkbox = stylable<FieldProps<any, any>>(BaseCheckbox);
+export const Select = stylable<FieldProps<any, any>>(BaseSelect);
+export const Option = stylable<HTMLProps<HTMLInputElement>>(BaseOption);
 export const Anchor = stylable<HTMLProps<HTMLAnchorElement>>('a');
 
-const CheckBoxBase: FC<HTMLProps<HTMLInputElement>> = props => <input {...props} type="checkbox" />;
-export const CheckBox = stylable(CheckBoxBase);
+// const CheckBoxBase: FC<HTMLProps<HTMLInputElement>> = props => <input {...props} type="checkbox" />;
+// export const CheckBox = stylable(CheckBoxBase);
 
 export const Icon = flow(
   addClasses('bl-rounded bl-p-grid-1 material-icons'),
@@ -49,9 +63,21 @@ export const Icon = flow(
   addProps({ 'aria-hidden': true }),
 )(Span);
 
+export const ComponentFormWrapper = addClasses(
+  'bl-bg-black bl-p-grid-5',
+)(Div);
+
 export const ComponentFormTitle = addClasses(
   'bl-text-lg bl-font-bold bl-text-grey-100 bl-block bl-mb-grid-2',
 )(Title);
+
+export const ComponentFormFieldWrapper = addClasses(
+  'bl-mb-grid-3',
+)(Div);
+
+export const ComponentFormFieldTitle = addClasses(
+  'bl-mb-grid-2 bl-font-bold bl-text-grey-100',
+)(Div);
 
 export const ComponentFormDescription = addClasses(
   'bl-text-xs bl-text-grey-100 bl-block bl-mb-grid-2 bl-max-w-xl-grid-1',
@@ -74,8 +100,27 @@ export const ComponentFormText = addClasses(
 )(Text);
 
 export const ComponentFormTextArea = addClasses(
-  'bl-resize bl-text-grey-900 bg-grey-100 bl-text-xs bl-w-full bl-min-w-xl-grid-1 bl-block bl-my-grid-2 bl-p-grid-1',
+  'bl-resize bl-text-grey-900 bg-grey-100 bl-text-xs bl-w-full bl-min-w-xl-grid-1 bl-min-h-grid-16 bl-block bl-my-grid-2 bl-p-grid-1',
 )(TextArea);
+
+export const ComponentFormRadioGroup = addClasses(
+  'bl-mb-grid-2'
+)(RadioGroup);
+
+export const ComponentFormRadio = addClasses(
+  'bl-mr-grid-2 bl-mb-grid-2 align-baseline'
+)(Radio);
+
+export const ComponentFormCheckbox = addClasses(
+  'bl-mr-grid-2 bl-mb-grid-2 align-baseline'
+)(Checkbox);
+
+export const ComponentFormSelect = addClasses(
+  `bl-text-grey-900 bg-grey-100 bl-text-xs bl-w-full
+  bl-min-w-xl-grid-1 bl-block bl-my-grid-2 bl-p-grid-1`
+)(Select);
+
+export const ComponentFormOption = Option;
 
 export const ComponentFormButton = addClasses(
   'bl-text-grey-200 bl-cursor-pointer hover:bl-text-green',

--- a/packages/bodiless-ui/src/elements.tsx
+++ b/packages/bodiless-ui/src/elements.tsx
@@ -43,6 +43,7 @@ export const Div = stylable<HTMLProps<HTMLDivElement>>('div');
 export const Span = stylable<HTMLProps<HTMLSpanElement>>('span');
 export const Button = stylable<HTMLProps<HTMLButtonElement>>('button');
 export const Hr = stylable<HTMLProps<HTMLHRElement>>('hr');
+export const Form = stylable<HTMLProps<HTMLFormElement>>('form');
 export const Text = stylable<FieldProps<any, any>>(BaseText);
 export const TextArea = stylable<FieldProps<any, any>>(BaseTextArea);
 export const RadioGroup = stylable<FieldProps<any, any>>(BaseRadioGroup);
@@ -62,16 +63,12 @@ export const Icon = flow(
   addProps({ 'aria-hidden': true }),
 )(Span);
 
-export const ComponentFormWrapper = addClasses(
-  'bl-bg-black bl-p-grid-5',
-)(Div);
-
 export const ComponentFormTitle = addClasses(
   'bl-text-lg bl-font-bold bl-text-grey-100 bl-block bl-mb-grid-2',
 )(Title);
 
 export const ComponentFormFieldWrapper = addClasses(
-  'bl-mb-grid-3',
+  'bl-mb-grid-3 bl-w-full',
 )(Div);
 
 export const ComponentFormFieldTitle = addClasses(

--- a/packages/bodiless-ui/src/elements.tsx
+++ b/packages/bodiless-ui/src/elements.tsx
@@ -14,15 +14,15 @@
 
 import React, { FC, HTMLProps } from 'react';
 import { flow } from 'lodash';
-import { 
+import {
   Text as BaseText,
   TextArea as BaseTextArea,
   RadioGroup as BaseRadioGroup,
   Radio as BaseRadio,
-  Checkbox as BaseCheckbox,
+  Checkbox as BaseCheckBox,
   Select as BaseSelect,
   Option as BaseOption,
-  FieldProps
+  FieldProps,
 } from 'informed';
 import {
   Li, Ul, stylable, addClasses, StylableProps, withoutProps, flowIf, hasProp, addProps,
@@ -45,13 +45,10 @@ export const Text = stylable<FieldProps<any, any>>(BaseText);
 export const TextArea = stylable<FieldProps<any, any>>(BaseTextArea);
 export const RadioGroup = stylable<FieldProps<any, any>>(BaseRadioGroup);
 export const Radio = stylable<HTMLProps<HTMLInputElement>>(BaseRadio);
-export const Checkbox = stylable<FieldProps<any, any>>(BaseCheckbox);
+export const CheckBox = stylable<any>(BaseCheckBox);
 export const Select = stylable<FieldProps<any, any>>(BaseSelect);
 export const Option = stylable<HTMLProps<HTMLInputElement>>(BaseOption);
 export const Anchor = stylable<HTMLProps<HTMLAnchorElement>>('a');
-
-// const CheckBoxBase: FC<HTMLProps<HTMLInputElement>> = props => <input {...props} type="checkbox" />;
-// export const CheckBox = stylable(CheckBoxBase);
 
 export const Icon = flow(
   addClasses('bl-rounded bl-p-grid-1 material-icons'),
@@ -104,20 +101,20 @@ export const ComponentFormTextArea = addClasses(
 )(TextArea);
 
 export const ComponentFormRadioGroup = addClasses(
-  'bl-mb-grid-2'
+  'bl-mb-grid-2',
 )(RadioGroup);
 
 export const ComponentFormRadio = addClasses(
-  'bl-mr-grid-2 bl-mb-grid-2 align-baseline'
+  'bl-mr-grid-2 bl-mb-grid-2 align-baseline',
 )(Radio);
 
-export const ComponentFormCheckbox = addClasses(
-  'bl-mr-grid-2 bl-mb-grid-2 align-baseline'
-)(Checkbox);
+export const ComponentFormCheckBox = addClasses(
+  'bl-mr-grid-2 bl-mb-grid-2 align-baseline',
+)(CheckBox);
 
 export const ComponentFormSelect = addClasses(
   `bl-text-grey-900 bg-grey-100 bl-text-xs bl-w-full
-  bl-min-w-xl-grid-1 bl-block bl-my-grid-2 bl-p-grid-1`
+  bl-min-w-xl-grid-1 bl-block bl-my-grid-2 bl-p-grid-1`,
 )(Select);
 
 export const ComponentFormOption = Option;

--- a/packages/bodiless-ui/src/elements.tsx
+++ b/packages/bodiless-ui/src/elements.tsx
@@ -23,6 +23,8 @@ import {
   Select as BaseSelect,
   Option as BaseOption,
   FieldProps,
+  ChildFieldProps,
+  SelectFieldProps,
 } from 'informed';
 import {
   Li, Ul, stylable, addClasses, StylableProps, withoutProps, flowIf, hasProp, addProps,
@@ -44,10 +46,10 @@ export const Hr = stylable<HTMLProps<HTMLHRElement>>('hr');
 export const Text = stylable<FieldProps<any, any>>(BaseText);
 export const TextArea = stylable<FieldProps<any, any>>(BaseTextArea);
 export const RadioGroup = stylable<FieldProps<any, any>>(BaseRadioGroup);
-export const Radio = stylable<HTMLProps<HTMLInputElement>>(BaseRadio);
-export const CheckBox = stylable<any>(BaseCheckBox);
-export const Select = stylable<FieldProps<any, any>>(BaseSelect);
-export const Option = stylable<HTMLProps<HTMLInputElement>>(BaseOption);
+export const Radio = stylable<ChildFieldProps<any, any>>(BaseRadio);
+export const CheckBox = stylable<FieldProps<any, any>>(BaseCheckBox);
+export const Select = stylable<SelectFieldProps<any, any>>(BaseSelect);
+export const Option = stylable<ChildFieldProps<any, any>>(BaseOption);
 export const Anchor = stylable<HTMLProps<HTMLAnchorElement>>('a');
 
 export const Icon = flow(


### PR DESCRIPTION
## Changes
- Add remaining elements from https://joepuzzo.github.io/informed/?path=/story/inputs--intro
- Add example 'form-elements' page

## Test Instructions
- Go to /form-elements page
- Make sure it follows the wireframe https://jhdfdc.axshare.com/#id=3ct389&p=aries

## Related Issues
Closes #336
