### PR TITLE
feat(gatsby-theme-bodiless): notify of error saving to backend

### DIFF
--- a/packages/gatsby-theme-bodiless/src/dist/GatsbyMobxStore.ts
+++ b/packages/gatsby-theme-bodiless/src/dist/GatsbyMobxStore.ts
@@ -195,4 +195,10 @@ export default class GatsbyMobxStore {
     const key = keyPath.join(nodeChildDelimiter);
     this.deleteItem(key);
   };
+
+  hasError = () => {
+    const itemsWithError = Array.from(this.store.values())
+      .filter(item => item.hasFlushingError);
+    return itemsWithError.length > 0;
+  };
 }

--- a/packages/gatsby-theme-bodiless/src/dist/GatsbyMobxStoreItem.ts
+++ b/packages/gatsby-theme-bodiless/src/dist/GatsbyMobxStoreItem.ts
@@ -37,6 +37,8 @@ export default class GatsbyMobxStoreItem {
 
   @observable isDeleted = false;
 
+  @observable hasFlushingError = false;
+
   key: string;
 
   store: GatsbyMobxStore;
@@ -86,6 +88,7 @@ export default class GatsbyMobxStoreItem {
         break;
       case ItemStateEvent.OnRequestEnd:
         this.requestDelay = DEFAULT_REQUEST_DELAY;
+        this.hasFlushingError = false;
         if (this.state === ItemState.Queued) {
           this.scheduleRequest();
           break;
@@ -99,6 +102,7 @@ export default class GatsbyMobxStoreItem {
         // incrementally increasing time between each subsequent retry
         // ensure new delay is not greater than defined maximum
         this.requestDelay = Math.min(this.requestDelay * 2, MAXIMUM_REQUEST_DELAY);
+        this.hasFlushingError = true;
         this.scheduleRequest();
         this.setState(ItemState.Queued);
         break;

--- a/packages/gatsby-theme-bodiless/src/dist/GatsbyNodeProvider.tsx
+++ b/packages/gatsby-theme-bodiless/src/dist/GatsbyNodeProvider.tsx
@@ -16,6 +16,7 @@ import React, { Component } from 'react';
 import { pick } from 'lodash';
 import { DefaultContentNode, NodeProvider } from '@bodiless/core';
 import GatsbyMobxStore, { DataSource } from './GatsbyMobxStore';
+import GatsbyStoreProvider from './GatsbyStoreProvider';
 
 type State = {
   store: GatsbyMobxStore,
@@ -69,13 +70,16 @@ class GatsbyNodeProvider extends Component<Props, State> implements DataSource {
   }
 
   render() {
+    const { store } = this.state;
     const { children } = this.props;
     return (
-      <NodeProvider node={this.getRootNode('Site')} collection="site">
-        <NodeProvider node={this.getRootNode('Page')} collection="_default">
-          {children}
+      <GatsbyStoreProvider store={store}>
+        <NodeProvider node={this.getRootNode('Site')} collection="site">
+          <NodeProvider node={this.getRootNode('Page')} collection="_default">
+            {children}
+          </NodeProvider>
         </NodeProvider>
-      </NodeProvider>
+      </GatsbyStoreProvider>
     );
   }
 }

--- a/packages/gatsby-theme-bodiless/src/dist/GatsbyStoreProvider.tsx
+++ b/packages/gatsby-theme-bodiless/src/dist/GatsbyStoreProvider.tsx
@@ -1,0 +1,36 @@
+/**
+ * Copyright © 2020 Johnson & Johnson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useContext } from 'react';
+import GatsbyMobxStore from './GatsbyMobxStore';
+
+type GatsbyStoreContextProps = {
+  store?: GatsbyMobxStore;
+};
+
+const GatsbyStoreContext = React.createContext<GatsbyStoreContextProps>({
+  store: undefined,
+});
+
+const GatsbyStoreProvider: React.FC<GatsbyStoreContextProps> = ({ children, store }) => {
+  const contextValue = {
+    store,
+  };
+  return <GatsbyStoreContext.Provider value={contextValue}>{children}</GatsbyStoreContext.Provider>;
+};
+
+const useGatsbyStoreProvider = () => useContext(GatsbyStoreContext);
+
+export default GatsbyStoreProvider;
+export { useGatsbyStoreProvider };

--- a/packages/gatsby-theme-bodiless/src/dist/OnStoreErrorNotification.tsx
+++ b/packages/gatsby-theme-bodiless/src/dist/OnStoreErrorNotification.tsx
@@ -1,0 +1,32 @@
+/**
+ * Copyright © 2020 Johnson & Johnson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { observer } from 'mobx-react-lite';
+import { useNotify } from '@bodiless/core';
+import { useGatsbyStoreProvider } from './GatsbyStoreProvider';
+
+const STORE_ERROR_NOTIFICATION_ID = 'STORE_ERROR_NOTIFICATION_ID';
+
+const OnStoreErrorNotification = observer(({ children }) => {
+  const { store } = useGatsbyStoreProvider();
+  const notifications = store && store.hasError() ? [{
+    id: STORE_ERROR_NOTIFICATION_ID,
+    message: 'There is an error with saving data',
+  }] : [];
+  useNotify(notifications);
+  return <>{children}</>;
+});
+
+export default OnStoreErrorNotification;

--- a/packages/gatsby-theme-bodiless/src/dist/Page.tsx
+++ b/packages/gatsby-theme-bodiless/src/dist/Page.tsx
@@ -31,6 +31,7 @@ import NewPageProvider from './NewPageProvider';
 import GatsbyPageProvider, {
   Props as PageProviderProps,
 } from './GatsbyPageProvider';
+import OnStoreErrorNotification from './OnStoreErrorNotification';
 
 type FinalUI = {
   ContextWrapper: ComponentType<ContextWrapperProps>;
@@ -58,17 +59,19 @@ const Page: FC<Props> = observer(({ children, ui, ...rest }) => {
           <SwitcherButtonProvider>
             <NotificationProvider>
               <NotificationButtonProvider>
-                <Editor>
-                  <NewPageProvider>
-                    <GitProvider>
-                      <Wrapper clickable>
-                        <DefaultActiveMenuOptions>
-                          {children}
-                        </DefaultActiveMenuOptions>
-                      </Wrapper>
-                    </GitProvider>
-                  </NewPageProvider>
-                </Editor>
+                <OnStoreErrorNotification>
+                  <Editor>
+                    <NewPageProvider>
+                      <GitProvider>
+                        <Wrapper clickable>
+                          <DefaultActiveMenuOptions>
+                            {children}
+                          </DefaultActiveMenuOptions>
+                        </Wrapper>
+                      </GitProvider>
+                    </NewPageProvider>
+                  </Editor>
+                </OnStoreErrorNotification>
               </NotificationButtonProvider>
             </NotificationProvider>
           </SwitcherButtonProvider>


### PR DESCRIPTION
<!--
  Before issuing a pull request:

  - Please read our contribution guidelines (https://github.com/johnsonandjohnson/Bodiless-JS/blob/master/packages/bodiless-documentation/doc/Development/Contributing.md), especially the section on Pull Requests.
  - Please first create an issue (https://github.com/johnsonandjohnson/Bodiless-JS/issues/new). All pull requests must be linked to an issue.
-->

<!--
  IMPORTANT
  
  The pull request title will become the commit message title at merge, and
  should adhere to Angular Commit Message Conventions. Please see (https://github.com/johnsonandjohnson/Bodiless-JS/blob/master/packages/bodiless-documentation/doc/Development/Contributing.md) for details and examples.
-->

## Changes
* a notification is displayed for the user when an error occurs saving data to the back-end
* the notification is removed when all queued retries are completed

## Notes
* alternative approach is to manage notifications on node level. wip pr - https://github.com/beliayeu/Bodiless-JS/pull/9

## Test Instructions
<!-- Detailed description of how this feature was (and should be) tested
  - Setup instructions (if any)?
  - List of test cases, with steps and expected results?
  - List
-->

## Related Issues
Closes #391

<!--
  Link to the issue that is fixed or resolved by this PR (if there is one)
  e.g. Fixes #1234, Closes #4567

  Link to an issue that is partially addressed by this PR (if there are any)
-->

<!-- IF THIS PR INTRODUCES A BREAKING CHANGE

BREAKING CHANGE: Describe the nature of the breaking change here.

More Details about the breaking change.
-->
