### PR TITLE
chore(components): examples how to set default alt for an image

### DIFF
--- a/examples/test-site/src/components/Image/index.ts
+++ b/examples/test-site/src/components/Image/index.ts
@@ -28,7 +28,7 @@ import { asEditableImage } from '../Elements.token';
 
 type Data = {
   src: string;
-  alt: string;
+  alt?: string;
 };
 
 // Allows to set default content for image based component.
@@ -42,8 +42,8 @@ const asContentfulImage = (nodeContent: Partial<Data>) => (nodeKey: string) => f
 const DEFAULT_IMAGE_NODE_KEY = 'image';
 const DEFAULT_LINK_NODE_KEY = 'link';
 
-const asEditableImageWithPlaceholder = (placeholder: string) => (nodeKey: string) => flowRight(
-  withImagePlaceholder({ src: placeholder }),
+const asEditableImageWithPlaceholder = (placeholder: Data) => (nodeKey: string) => flowRight(
+  withImagePlaceholder(placeholder),
   asEditableImage(nodeKey),
 );
 const asLinkableImage = (ImageComponent: ComponentType<any>) => (nodeKey: string) => flowRight(
@@ -53,7 +53,7 @@ const asLinkableImage = (ImageComponent: ComponentType<any>) => (nodeKey: string
 const asSquareImage = asEditableImage;
 const SquareImage = asSquareImage(DEFAULT_IMAGE_NODE_KEY)(Img);
 const SquareLinkableImage = asLinkableImage(SquareImage)(DEFAULT_LINK_NODE_KEY)(A);
-const asLandscapeImage = asEditableImageWithPlaceholder(landscapeImage);
+const asLandscapeImage = asEditableImageWithPlaceholder({ src: landscapeImage });
 const LandscapeImage = asLandscapeImage(DEFAULT_IMAGE_NODE_KEY)(Img);
 const LandscapeLinkableImage = asLinkableImage(LandscapeImage)(DEFAULT_LINK_NODE_KEY)(A);
 

--- a/examples/test-site/src/data/pages/images/index.tsx
+++ b/examples/test-site/src/data/pages/images/index.tsx
@@ -46,13 +46,13 @@ import ImageSvgSrc from './image.svg';
 import ImageWebpSrc from './image.webp';
 import ImageResponsiveSvgSrc from './responsive_asvg.svg';
 
-const ImageAnimatedPng = asEditableImageWithPlaceholder(ImageAnimatedPngSrc)('animatedPng')(Img);
-const ImageGif = asEditableImageWithPlaceholder(ImageGifSrc)('gif')(Img);
-const ImageJpg = asEditableImageWithPlaceholder(ImageJpgSrc)('jpg')(Img);
-const ImagePng = asEditableImageWithPlaceholder(ImagePngSrc)('png')(Img);
-const ImageSvg = asEditableImageWithPlaceholder(ImageSvgSrc)('svg')(Img);
-const ImageWebp = asEditableImageWithPlaceholder(ImageWebpSrc)('webp')(Img);
-const ImageResponsiveSvg = asEditableImageWithPlaceholder(ImageResponsiveSvgSrc)('responsiveSvg')(Img);
+const ImageAnimatedPng = asEditableImageWithPlaceholder({ src: ImageAnimatedPngSrc })('animatedPng')(Img);
+const ImageGif = asEditableImageWithPlaceholder({ src: ImageGifSrc })('gif')(Img);
+const ImageJpg = asEditableImageWithPlaceholder({ src: ImageJpgSrc, alt: 'Editable JPG Image' })('jpg')(Img);
+const ImagePng = asEditableImageWithPlaceholder({ src: ImagePngSrc })('png')(Img);
+const ImageSvg = asEditableImageWithPlaceholder({ src: ImageSvgSrc })('svg')(Img);
+const ImageWebp = asEditableImageWithPlaceholder({ src: ImageWebpSrc })('webp')(Img);
+const ImageResponsiveSvg = asEditableImageWithPlaceholder({ src: ImageResponsiveSvgSrc })('responsiveSvg')(Img);
 
 const LinkableImageAnimatedPng = asLinkableImage(ImageAnimatedPng)('animatedPngLink')(A);
 const LinkableImageGif = asLinkableImage(ImageGif)('gifLink')(A);
@@ -86,7 +86,7 @@ export default (props: any) => (
 
         <ImageWrapper>
           <ImageTitle>PNG</ImageTitle>
-          <ImagePng />
+          <ImagePng alt="Editable PNG Image" />
         </ImageWrapper>
 
         <ImageWrapper>

--- a/packages/bodiless-components/src/Image.tsx
+++ b/packages/bodiless-components/src/Image.tsx
@@ -185,7 +185,7 @@ const options: BodilessOptions<Props, Data> = {
   },
 };
 
-export const withImagePlaceholder = withPropsFromPlaceholder(['src']);
+export const withImagePlaceholder = withPropsFromPlaceholder(['src', 'alt']);
 
 export const asBodilessImage = asBodilessComponent<HTMLProps<HTMLImageElement>, Data>(options);
 


### PR DESCRIPTION
<!--
  Before issuing a pull request:

  - Please read our contribution guidelines (https://github.com/johnsonandjohnson/Bodiless-JS/blob/master/packages/bodiless-documentation/doc/Development/Contributing.md), especially the section on Pull Requests.
  - Please first create an issue (https://github.com/johnsonandjohnson/Bodiless-JS/issues/new). All pull requests must be linked to an issue.
-->

<!--
  IMPORTANT
  
  The pull request title will become the commit message title at merge, and
  should adhere to Angular Commit Message Conventions. Please see (https://github.com/johnsonandjohnson/Bodiless-JS/blob/master/packages/bodiless-documentation/doc/Development/Contributing.md) for details and examples.
-->

## Changes
* allowed to set default alt for an image
* provided an example how to set alt using withImagePlaceholder hoc
* provided an example how to set alt using prop

## Test Instructions
<!-- Detailed description of how this feature was (and should be) tested
  - Setup instructions (if any)?
  - List of test cases, with steps and expected results?
  - List
-->

## Related Issues
<!--
  Link to the issue that is fixed or resolved by this PR (if there is one)
  e.g. Fixes #1234, Closes #4567

  Link to an issue that is partially addressed by this PR (if there are any)
-->

<!-- IF THIS PR INTRODUCES A BREAKING CHANGE

BREAKING CHANGE: Describe the nature of the breaking change here.

More Details about the breaking change.
-->
