### PR TITLE
Package Release failed due to @bodiless/cli auto README.md update

### DIFF
--- a/packages/bodiless-cli/README.md
+++ b/packages/bodiless-cli/README.md
@@ -1,7 +1,6 @@
 # Bodiless-JS CLI
 
 ## Usage
-<!-- usage -->
 ```sh-session
 $ npm install -g @bodiless/cli
 $ bodiless COMMAND
@@ -13,10 +12,8 @@ USAGE
   $ bodiless COMMAND
 ...
 ```
-<!-- usagestop -->
 
 ## Commands
-<!-- commands -->
 * [`bodiless help [COMMAND]`](#bodiless-help-command)
 * [`bodiless pack`](#bodiless-pack)
 
@@ -68,4 +65,3 @@ EXAMPLES
 ```
 
 _See code: [lib/commands/pack.js](https://github.com/johnsonandjohnson/Bodiless-JS/tree/master/packages/bodiless-cli/src)_
-<!-- commandsstop -->


### PR DESCRIPTION

<!--
  Before issuing a pull request:

  - Please read our contribution guidelines (https://github.com/johnsonandjohnson/Bodiless-JS/blob/master/packages/bodiless-documentation/doc/Development/Contributing.md), especially the section on Pull Requests.
  - Please first create an issue (https://github.com/johnsonandjohnson/Bodiless-JS/issues/new). All pull requests must be linked to an issue.
-->

<!--
  IMPORTANT
  
  The pull request title will become the commit message title at merge, and
  should adhere to Angular Commit Message Conventions. Please see (https://github.com/johnsonandjohnson/Bodiless-JS/blob/master/packages/bodiless-documentation/doc/Development/Contributing.md) for details and examples.
-->

## Changes
<!-- Brief description of the changes introduced by this PR -->


Remove README placeholder for replacement.

## Test Instructions
<!-- Detailed description of how this feature was (and should be) tested
  - Setup instructions (if any)?
  - List of test cases, with steps and expected results?
  - List
-->

- Run cmd
```git clone https://github.com/dewen/Bodiless-JS.git -b feat/package-release-failed-due-to-auto-readme-md-update-during-prepack BodilessJS504 && \
cd BodilessJS504 && \
npm run setup && \
cd packages/bodiless-cli && \
sed -i '' 's/0.0.52/0.0.53/g' package.json && \
./node_modules/.bin/oclif-dev readme && \
git diff README.md
```

Expect:
- No README.md changes (it will replace version to 0.0.53 before fix). 

