### PR TITLE
feat(test-site, starter): removed richtext filter from flow container

### DIFF
--- a/examples/starter/src/components/FlowContainer/withRichTextVariations.tsx
+++ b/examples/starter/src/components/FlowContainer/withRichTextVariations.tsx
@@ -15,7 +15,6 @@
 import { flow } from 'lodash';
 import {
   withTitle,
-  withFacet,
   withDesc,
   ifComponentSelector,
 } from '@bodiless/layouts';
@@ -33,14 +32,11 @@ import {
 } from '../Editors';
 import { withType } from './Categories';
 
-const withRichText = withFacet('Rich Text');
-
 const richTextVariation = {
   EditorSimple: flow(
     replaceWith(EditorSimple),
     ifComponentSelector(asPreview),
     withType('Rich Text')(),
-    withRichText('Simple')(),
     withTitle('Simple Rich Text'),
     withDesc('Adds a block of text for a Title.\n'),
   ),
@@ -48,7 +44,6 @@ const richTextVariation = {
     replaceWith(EditorBasic),
     ifComponentSelector(asPreview),
     withType('Rich Text')(),
-    withRichText('Basic')(),
     withTitle('Basic Rich Text'),
     withDesc('Adds a block of text with basic formatting.\n'),
   ),
@@ -56,7 +51,6 @@ const richTextVariation = {
     replaceWith(EditorFullFeatured),
     ifComponentSelector(asPreview),
     withType('Rich Text')(),
-    withRichText('Full')(),
     withTitle('Full Rich Text'),
     withDesc('Adds a block of text for more complex HTML.\n'),
   ),

--- a/examples/test-site/src/components/FlowContainer/withRichTextVariations.tsx
+++ b/examples/test-site/src/components/FlowContainer/withRichTextVariations.tsx
@@ -15,7 +15,6 @@
 import { flow } from 'lodash';
 import {
   withTitle,
-  withFacet,
   withDesc,
   ifComponentSelector,
 } from '@bodiless/layouts';
@@ -33,14 +32,11 @@ import {
 } from '../Editors';
 import { withType } from './Categories';
 
-const withRichText = withFacet('Rich Text');
-
 const richTextVariation = {
   EditorSimple: flow(
     replaceWith(EditorSimple),
     ifComponentSelector(asPreview),
     withType('Rich Text')(),
-    withRichText('Simple')(),
     withTitle('Simple Rich Text'),
     withDesc('Adds a block of text for a Title.\n'),
   ),
@@ -48,7 +44,6 @@ const richTextVariation = {
     replaceWith(EditorBasic),
     ifComponentSelector(asPreview),
     withType('Rich Text')(),
-    withRichText('Basic')(),
     withTitle('Basic Rich Text'),
     withDesc('Adds a block of text with basic formatting.\n'),
   ),
@@ -56,7 +51,6 @@ const richTextVariation = {
     replaceWith(EditorFullFeatured),
     ifComponentSelector(asPreview),
     withType('Rich Text')(),
-    withRichText('Full')(),
     withTitle('Full Rich Text'),
     withDesc('Adds a block of text for more complex HTML.\n'),
   ),


### PR DESCRIPTION
## Changes
* removed richtext filter from flow container

## Test Instructions
1. open a page with flow container on starter or test-site
2. click add item
3. tick "RichText" in Type filter

Expected: no Richtext filter displayed

## Related Issues

Fixes: #461 
<!--
  Link to the issue that is fixed or resolved by this PR (if there is one)
  e.g. Fixes #1234, Closes #4567

  Link to an issue that is partially addressed by this PR (if there are any)
-->

<!-- IF THIS PR INTRODUCES A BREAKING CHANGE

BREAKING CHANGE: Describe the nature of the breaking change here.

More Details about the breaking change.
-->
