### PR TITLE
fix(core): Context Menu Panel for link/image/seo disappear when you mouse moves off

### DIFF
--- a/packages/bodiless-core/src/hooks.ts
+++ b/packages/bodiless-core/src/hooks.ts
@@ -131,11 +131,11 @@ export const useClickOutside = (
   }, []);
 
   useEffect(() => {
-    document.body.addEventListener('click', clickListener);
+    document.body.addEventListener('mousedown', clickListener);
     document.body.addEventListener('keyup', escapeListener);
 
     return () => {
-      document.body.removeEventListener('click', clickListener);
+      document.body.removeEventListener('mousedown', clickListener);
       document.body.removeEventListener('keyup', escapeListener);
     };
   });


### PR DESCRIPTION
## Changes
- Click outside is now registered on `mousedown` instead of `click`

## Test Instructions

## Related Issues

