### PR TITLE
fix(gatsby-theme-bodiless): allow to pass props to gatsby img

### DIFF
--- a/packages/gatsby-theme-bodiless/src/dist/GatsbyImage/asGatsbyImage.tsx
+++ b/packages/gatsby-theme-bodiless/src/dist/GatsbyImage/asGatsbyImage.tsx
@@ -44,7 +44,7 @@ const asGatsbyImage$ = (Component: CT<any>) => {
     const { gatsbyImg, preset, ...rest } = props;
     if (gatsbyImg !== undefined) {
       return (
-        <GatsbyImg {...gatsbyImg} {...rest} />
+        <GatsbyImg {...rest} {...gatsbyImg} />
       );
     }
     return (

--- a/packages/gatsby-theme-bodiless/src/dist/GatsbyImage/asGatsbyImage.tsx
+++ b/packages/gatsby-theme-bodiless/src/dist/GatsbyImage/asGatsbyImage.tsx
@@ -15,6 +15,7 @@
 import React, { ComponentType as CT } from 'react';
 import GatsbyImg from 'gatsby-image';
 import {
+  ifEditable,
   ifToggledOn,
   withActivatorWrapper,
 } from '@bodiless/core';
@@ -24,7 +25,7 @@ import type {
   GatsbyImageOptionalProps,
 } from 'gatsby-image';
 import { Div } from '@bodiless/fclasses';
-import { pick, flow } from 'lodash';
+import { flow } from 'lodash';
 
 type ImageProps = {
   src: string;
@@ -36,38 +37,14 @@ export type GasbyImageProps = ImageProps & {
   gatsbyImg?: { fluid: FluidObject | FluidObject[] } | { fixed: FixedObject | FixedObject[] };
 } & GatsbyImageOptionalProps;
 
-// the list is taken from GatsbyImageOptionalProps interface
-const GATSBY_IMG_PROPS = [
-  'fadeIn',
-  'durationFadeIn',
-  'title',
-  'alt',
-  'className',
-  'critical',
-  'crossOrigin',
-  'style',
-  'imgStyle',
-  'placeholderStyle',
-  'placeholderClassName',
-  'backgroundColor',
-  'onLoad',
-  'onError',
-  'onStartLoad',
-  'Tag',
-  'itemProp',
-  'loading',
-  'draggable',
-];
-
 const isGatsbyImage = ({ gatsbyImg }: GasbyImageProps) => gatsbyImg !== undefined;
 
 const asGatsbyImage$ = (Component: CT<any>) => {
   const AsGatsbyImage = (props: GasbyImageProps) => {
     const { gatsbyImg, preset, ...rest } = props;
     if (gatsbyImg !== undefined) {
-      const gatsbyImgProps = pick(props, GATSBY_IMG_PROPS) as GatsbyImageOptionalProps;
       return (
-        <GatsbyImg {...gatsbyImg} {...gatsbyImgProps} />
+        <GatsbyImg {...gatsbyImg} {...rest} />
       );
     }
     return (
@@ -79,7 +56,9 @@ const asGatsbyImage$ = (Component: CT<any>) => {
 
 const asGatsbyImage = flow(
   asGatsbyImage$,
-  ifToggledOn(isGatsbyImage)(withActivatorWrapper('onClick', Div)),
+  ifEditable(
+    ifToggledOn(isGatsbyImage)(withActivatorWrapper('onClick', Div)),
+  ),
 );
 
 export default asGatsbyImage;

--- a/packages/gatsby-theme-bodiless/src/dist/GatsbyImage/asGatsbyImage.tsx
+++ b/packages/gatsby-theme-bodiless/src/dist/GatsbyImage/asGatsbyImage.tsx
@@ -16,6 +16,7 @@ import React, { ComponentType as CT } from 'react';
 import GatsbyImg from 'gatsby-image';
 import type { GatsbyImageProps } from 'gatsby-image';
 import { Div } from '@bodiless/fclasses';
+import { pick } from 'lodash';
 
 type ImageProps = {
   src: string;
@@ -34,13 +35,37 @@ const GatsbyImgWrapper = (props: ImageProps) => {
   );
 };
 
+// the list is taken from GatsbyImageOptionalProps interface
+const GATSBY_IMG_PROPS = [
+  'fadeIn',
+  'durationFadeIn',
+  'title',
+  'alt',
+  'className',
+  'critical',
+  'crossOrigin',
+  'style',
+  'imgStyle',
+  'placeholderStyle',
+  'placeholderClassName',
+  'backgroundColor',
+  'onLoad',
+  'onError',
+  'onStartLoad',
+  'Tag',
+  'itemProp',
+  'loading',
+  'draggable',
+];
+
 const asGatsbyImage = (Component: CT<any>) => {
   const AsGatsbyImage = (props: GasbyImageProps) => {
     const { gatsbyImg, preset, ...rest } = props;
     if (gatsbyImg !== undefined) {
+      const gatsbyImgProps = pick(props, GATSBY_IMG_PROPS);
       return (
         <GatsbyImgWrapper {...rest}>
-          <GatsbyImg {...gatsbyImg} />
+          <GatsbyImg {...gatsbyImg} {...gatsbyImgProps} />
         </GatsbyImgWrapper>
       );
     }

--- a/packages/gatsby-theme-bodiless/src/dist/GatsbyImage/asGatsbyImage.tsx
+++ b/packages/gatsby-theme-bodiless/src/dist/GatsbyImage/asGatsbyImage.tsx
@@ -29,7 +29,8 @@ export type GasbyImageProps = ImageProps & {
 };
 
 const GatsbyImgWrapper = (props: ImageProps) => {
-  const { src, alt, ...rest } = props;
+  // ToDo: get a list of wrapper activator props in a more maintainable way
+  const rest = pick(props, ['data-bl-activator', 'onClick', 'children']);
   return (
     <Div {...rest} />
   );

--- a/packages/gatsby-theme-bodiless/src/dist/GatsbyImage/asGatsbyImage.tsx
+++ b/packages/gatsby-theme-bodiless/src/dist/GatsbyImage/asGatsbyImage.tsx
@@ -59,7 +59,7 @@ const GATSBY_IMG_PROPS = [
   'draggable',
 ];
 
-const isGatsbyImg = ({ gatsbyImg }: GasbyImageProps) => gatsbyImg !== undefined;
+const isGatsbyImage = ({ gatsbyImg }: GasbyImageProps) => gatsbyImg !== undefined;
 
 const asGatsbyImage$ = (Component: CT<any>) => {
   const AsGatsbyImage = (props: GasbyImageProps) => {
@@ -79,7 +79,8 @@ const asGatsbyImage$ = (Component: CT<any>) => {
 
 const asGatsbyImage = flow(
   asGatsbyImage$,
-  ifToggledOn(isGatsbyImg)(withActivatorWrapper('onClick', Div)),
+  ifToggledOn(isGatsbyImage)(withActivatorWrapper('onClick', Div)),
 );
 
 export default asGatsbyImage;
+export { isGatsbyImage };

--- a/packages/gatsby-theme-bodiless/src/index.ts
+++ b/packages/gatsby-theme-bodiless/src/index.ts
@@ -18,7 +18,7 @@ import BackendClient from './dist/BackendClient';
 import useGitButtons from './dist/useGitButtons';
 import GatsbyPageProvider, { useGatsbyPageContext } from './dist/GatsbyPageProvider';
 import Page from './dist/Page';
-import asGatsbyImage from './dist/GatsbyImage/asGatsbyImage';
+import asGatsbyImage, { isGatsbyImage } from './dist/GatsbyImage/asGatsbyImage';
 import withGatsbyImageNode from './dist/GatsbyImage/withGatsbyImageNode';
 import GatsbyImagePresets from './dist/GatsbyImage/GatsbyImagePresets';
 import withGatsbyImageLogger from './dist/GatsbyImage/withGatsbyImageLogger';
@@ -32,6 +32,7 @@ export {
   useGatsbyPageContext,
   Page,
   asGatsbyImage,
+  isGatsbyImage,
   withGatsbyImageNode,
   GatsbyImagePresets,
   withGatsbyImageLogger,


### PR DESCRIPTION
## Changes
* fixed the issue when image attrs including alt and title are not rendered when gatsby image is activated


## Test Instructions
<!-- Detailed description of how this feature was (and should be) tested
  - Setup instructions (if any)?
  - List of test cases, with steps and expected results?
  - List
-->

## Related Issues
<!--
  Link to the issue that is fixed or resolved by this PR (if there is one)
  e.g. Fixes #1234, Closes #4567

  Link to an issue that is partially addressed by this PR (if there are any)
-->

<!-- IF THIS PR INTRODUCES A BREAKING CHANGE

BREAKING CHANGE: Describe the nature of the breaking change here.

More Details about the breaking change.
-->
