### PR TITLE
fix(components): Breadcrumbs lost when a component context is activated in edit mode

### DIFF
--- a/packages/bodiless-components/src/Breadcrumbs/withBreadcrumbs.tsx
+++ b/packages/bodiless-components/src/Breadcrumbs/withBreadcrumbs.tsx
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-import React, { ComponentType } from 'react';
+import React, { ComponentType, useRef } from 'react';
 import { useNode } from '@bodiless/core';
 import { BreadcrumbStore } from './BreadcrumbStore';
 import { Breadcrumbs } from './Breadcrumbs';
@@ -26,9 +26,10 @@ export const withBreadcrumbStore = (Component: ComponentType<any>) => {
   const WithBreadcrumbStore = (props: any) => {
     const { node } = useNode();
     const { pagePath } = node;
-    const store = new BreadcrumbStore(pagePath);
+    const storeRef = useRef<BreadcrumbStore>();
+    if (storeRef.current === undefined) storeRef.current = new BreadcrumbStore(pagePath);
     return (
-      <BreadcrumbStoreProvider store={store}>
+      <BreadcrumbStoreProvider store={storeRef.current}>
         <Component {...props} />
       </BreadcrumbStoreProvider>
     );

--- a/packages/bodiless-organisms/__tests__/SimpleMenuBreadcrumbs.test.tsx
+++ b/packages/bodiless-organisms/__tests__/SimpleMenuBreadcrumbs.test.tsx
@@ -285,4 +285,14 @@ describe('asBreadcrumbsClean', () => {
     const wrapper = mount(<TestBreadcrumbs />);
     expect(breadcrumbHtml(wrapper)).toMatchSnapshot();
   });
+  it('preserves breadcrumbs on rerender', () => {
+    setPagePath('/products/productA');
+    const Breadcrumb = createBreadcrumbComponent({
+      content: generate2LevelMenuContent(),
+    });
+    const wrapper = mount(<Breadcrumb />);
+    // trigger rerender
+    wrapper.setProps({});
+    expect(breadcrumbHtml(wrapper)).toMatchSnapshot();
+  });
 });

--- a/packages/bodiless-organisms/__tests__/__snapshots__/SimpleMenuBreadcrumbs.test.tsx.snap
+++ b/packages/bodiless-organisms/__tests__/__snapshots__/SimpleMenuBreadcrumbs.test.tsx.snap
@@ -13,6 +13,8 @@ exports[`asBreadcrumbsClean creates breadcrumbs for basic 2-level menu 1`] = `"<
 
 exports[`asBreadcrumbsClean does not apply current page styles to the item which is the last derived from the menu but not current page path 1`] = `"<ul><li><a href=\\"/products/\\"><span>products</span></a></li></ul>"`;
 
+exports[`asBreadcrumbsClean preserves breadcrumbs on rerender 1`] = `"<ul><li><a href=\\"/products/\\"><span>products</span></a></li><span></span><li><span>productA</span></li></ul>"`;
+
 exports[`asBreadcrumbsClean renders last menu trail item as link when current page item does not exist in store 1`] = `"<ul><li><a href=\\"/products/\\"><span>products</span></a></li></ul>"`;
 
 exports[`asBreadcrumbsClean when starting trail enabled and


### PR DESCRIPTION
<!--
  Before issuing a pull request:

  - Please read our contribution guidelines (https://github.com/johnsonandjohnson/Bodiless-JS/blob/master/packages/bodiless-documentation/doc/Development/Contributing.md), especially the section on Pull Requests.
  - Please first create an issue (https://github.com/johnsonandjohnson/Bodiless-JS/issues/new). All pull requests must be linked to an issue.
-->

<!--
  IMPORTANT
  
  The pull request title will become the commit message title at merge, and
  should adhere to Angular Commit Message Conventions. Please see (https://github.com/johnsonandjohnson/Bodiless-JS/blob/master/packages/bodiless-documentation/doc/Development/Contributing.md) for details and examples.
-->

## Changes
* fix(components): Breadcrumbs lost when a component context is activated in edit mode

## Notes
* root cause of the issue is that when a component composed with `withBreadcrumbStore` hoc is rerendered then breadcrumb store is reinitialized and breadcrumb store items are lost

## Test Instructions
<!-- Detailed description of how this feature was (and should be) tested
  - Setup instructions (if any)?
  - List of test cases, with steps and expected results?
  - List
-->

## Related Issues
<!--
  Link to the issue that is fixed or resolved by this PR (if there is one)
  e.g. Fixes #1234, Closes #4567

  Link to an issue that is partially addressed by this PR (if there are any)
-->

<!-- IF THIS PR INTRODUCES A BREAKING CHANGE

BREAKING CHANGE: Describe the nature of the breaking change here.

More Details about the breaking change.
-->
