### PR TITLE
fix(docs): Images still missing from docs

### DIFF
--- a/packages/bodiless-richtext/bodiless.docs.json
+++ b/packages/bodiless-richtext/bodiless.docs.json
@@ -3,7 +3,8 @@
     "RichText.md": "./README.md",
     "assets": {
       "SimpleRichTextNew.jpg": "./assets/SimpleRichTextNew.jpg",
-      "SimpleRichTextNew.jpg": "./assets/SimpleRichTextNew.jpg"
+      "BasicRichTextNew.jpg": "./assets/BasicRichTextNew.jpg",
+      "FullRichTextNew.jpg": "./assets/FullRichTextNew.jpg"
     }
   }
 }


### PR DESCRIPTION
- Add correct asset file names to Rich Text Component bodiless.docs.json file 

Issue: 
#810 