### PR TITLE
fix(organisms): Remove w-content token from Menu and move it to test site

### DIFF
--- a/examples/starter/src/components/Menu/SimpleMenu.token.tsx
+++ b/examples/starter/src/components/Menu/SimpleMenu.token.tsx
@@ -75,7 +75,7 @@ const withBaseSubMenuStyles = withDesign({
     List: flow(
       withMenuBackground,
       withMenuForeground,
-      addClasses('z-10'),
+      addClasses('w-content z-10'),
     ),
   }),
   Item: addClasses('leading-loose text-sm'),

--- a/examples/starter/tailwind.config.js
+++ b/examples/starter/tailwind.config.js
@@ -269,7 +269,11 @@ module.exports = mergeWithBodilessConfigs({
     |
     */
 
-    // width: {},
+    extend: {
+      width: {
+        content: 'max-content',
+      },
+    },
 
     /*
     |---------------------------------------------------------------------------

--- a/examples/test-site/src/components/Menu/SimpleMenu.token.tsx
+++ b/examples/test-site/src/components/Menu/SimpleMenu.token.tsx
@@ -77,7 +77,7 @@ const withBaseSubMenuStyles = withDesign({
     List: flow(
       withMenuBackground,
       withMenuForeground,
-      addClasses('z-10'),
+      addClasses('w-content z-10'),
     ),
   }),
   Item: addClasses('leading-loose text-sm'),

--- a/examples/test-site/tailwind.config.js
+++ b/examples/test-site/tailwind.config.js
@@ -271,7 +271,11 @@ module.exports = mergeWithBodilessConfigs({
     |
     */
 
-    // width: {},
+    extend: {
+      width: {
+        content: 'max-content',
+      },
+    },
 
     /*
     |---------------------------------------------------------------------------

--- a/packages/bodiless-organisms/src/components/Menu/SimpleMenu.token.tsx
+++ b/packages/bodiless-organisms/src/components/Menu/SimpleMenu.token.tsx
@@ -51,7 +51,7 @@ const asExpandedOnActive = withDesign({
 
 const asResponsiveSublist = withDesign({
   Wrapper: withDesign({
-    List: addClasses('w-content min-w-full'),
+    List: addClasses('min-w-full'),
   }),
 });
 

--- a/packages/bodiless-organisms/tailwind.config.js
+++ b/packages/bodiless-organisms/tailwind.config.js
@@ -30,9 +30,6 @@ module.exports = {
       '21/9': [21, 9],
     },
     extend: {
-      width: {
-        content: 'max-content',
-      },
       minWidth: {
         full: '100%',
       },


### PR DESCRIPTION
## Changes
- 'w-content' is moved from the Bodiless to test-site and starter

## Test Instructions
- Make sure menus on the test-site look and function the same as in prod.

## Related Issues
Closes: https://github.com/johnsonandjohnson/Bodiless-JS/issues/817
