### PR TITLE
feat(gatsby-theme-bodiless): Disable revert button when not editing (vs hide)

### DIFF
--- a/packages/gatsby-theme-bodiless/src/dist/useGitButtons.tsx
+++ b/packages/gatsby-theme-bodiless/src/dist/useGitButtons.tsx
@@ -166,7 +166,7 @@ const getMenuOptions = (
       name: 'resetchanges',
       label: 'Revert',
       icon: 'undo',
-      isHidden: () => !context.isEdit,
+      isDisabled: () => !context.isEdit,
       handler: () => formGitReset(client),
       group: 'file',
     },


### PR DESCRIPTION
## Changes
- Disable the "revert" button when in preview mode (was previously hidden).