### PR TITLE
feat(core): designable child API

### DIFF
--- a/examples/test-site/src/data/pages/richtext/index.tsx
+++ b/examples/test-site/src/data/pages/richtext/index.tsx
@@ -14,14 +14,39 @@
 
 import React from 'react';
 import { graphql } from 'gatsby';
+import flow from 'lodash/flow';
 import {
   NodeViewer,
 } from '@bodiless/components';
+import { withDesign, addProps, Div } from '@bodiless/fclasses';
 import { Page } from '@bodiless/gatsby-theme-bodiless';
 
 import Layout from '../../../components/Layout';
 import { FlowContainerDefault } from '../../../components/FlowContainer';
-import { EditorBasic, EditorFullFeatured, EditorSimple } from '../../../components/Editors';
+import {
+  EditorBasic,
+  EditorSimple,
+  EditorFullFeatured,
+  withEditorFullFeatured,
+} from '../../../components/Editors';
+
+const AlphabeticFullFeaturedEditor = flow(
+  withEditorFullFeatured('alphabeticRTE', 'Type something here...'),
+  withDesign({
+    Child: addProps({
+      onKeyDown: event => {
+        if (
+          // alphabet characters
+          !(event.which >= 65 && event.which <= 120)
+          // backspace, enter, space, delete
+          && ![8, 13, 32, 46].includes(event.which)
+        ) {
+          event.preventDefault();
+        }
+      },
+    }),
+  }),
+)(Div);
 
 const RichTextPage = (props: any) => (
   <Page {...props}>
@@ -45,6 +70,13 @@ const RichTextPage = (props: any) => (
         <h3 className="p-5 font-bold">Full Rich Text:</h3>
         <div className="p-5 pt-0">
           <EditorFullFeatured className="border-solid border-4 border-gray-600 p-5" nodeKey="fullRTE" placeholder="Type something here..." />
+        </div>
+      </div>
+
+      <div className="flex flex-col w-full py-5">
+        <h3 className="p-5 font-bold">Alphabetic Full Rich Text:</h3>
+        <div className="p-5 pt-0">
+          <AlphabeticFullFeaturedEditor className="border-solid border-4 border-gray-600 p-5" />
         </div>
       </div>
 

--- a/packages/bodiless-core/__tests__/withChild.test.tsx
+++ b/packages/bodiless-core/__tests__/withChild.test.tsx
@@ -1,0 +1,119 @@
+import React, { ComponentType as CT } from 'react';
+import { mount } from 'enzyme';
+import {
+  designable,
+  withDesign,
+  Div,
+  Span,
+  addClasses,
+  addProps,
+  DesignableComponentsProps,
+} from '@bodiless/fclasses';
+import flow from 'lodash/flow';
+import withChild from '../src/withChild';
+
+type FooComponents = { Wrapper: CT };
+const BaseFoo: CT<DesignableComponentsProps<FooComponents>> = ({ components, children }) => {
+  const { Wrapper } = components;
+  return (<Wrapper>{children}</Wrapper>);
+};
+const CleanFoo = designable<FooComponents>({
+  Wrapper: Div,
+})(BaseFoo);
+
+describe('withChild', () => {
+  it('adds a component to the given component as a child', () => {
+    const Foo = withChild(Span)(CleanFoo);
+    const wrapper = mount(<Foo />);
+    expect(wrapper.html()).toBe('<div><span></span></div>');
+  });
+  it('allows to update child component using design api', () => {
+    const Foo = flow(
+      withChild(Span),
+      withDesign({
+        Child: addClasses('childClass'),
+      }),
+    )(CleanFoo);
+    const wrapper = mount(<Foo />);
+    expect(wrapper.html()).toBe('<div><span class="childClass"></span></div>');
+  });
+  it('does not impact other parent design elements', () => {
+    const Foo = flow(
+      withChild(Span),
+      withDesign({
+        Wrapper: addClasses('parentClass'),
+      }),
+    )(CleanFoo);
+    const wrapper = mount(<Foo />);
+    expect(wrapper.html()).toBe('<div class="parentClass"><span></span></div>');
+  });
+  it('allows to set a custom child design key name', () => {
+    const Foo = flow(
+      withChild(Span, 'TestChild'),
+      withDesign({
+        TestChild: addClasses('childClass'),
+      }),
+    )(CleanFoo);
+    const wrapper = mount(<Foo />);
+    expect(wrapper.html()).toBe('<div><span class="childClass"></span></div>');
+  });
+  it('does not allow updating child design on runtime', () => {
+    const Foo = flow(
+      withChild(Span),
+      addProps({
+        design: {
+          Wrapper: addClasses('parentClass'),
+          Child: addClasses('childClass'),
+        },
+      }),
+    )(CleanFoo);
+    const wrapper = mount(<Foo />);
+    wrapper.setProps({
+      design: {
+        Wrapper: addClasses('parentClass2'),
+        Child: addClasses('childClass2'),
+      },
+    });
+    expect(wrapper.html()).toBe('<div class="parentClass"><span class="childClass"></span></div>');
+  });
+  it('preserves parent design', () => {
+    const Foo = flow(
+      withDesign({
+        Wrapper: addClasses('parentClass1'),
+      }),
+      withChild(Span),
+      withDesign({
+        Wrapper: addClasses('parentClass2'),
+      }),
+    )(CleanFoo);
+    const wrapper = mount(<Foo />);
+    expect(wrapper.html()).toBe('<div class="parentClass2 parentClass1"><span></span></div>');
+  });
+  it('removes child design from parent design', () => {
+    type BarComponents = { Wrapper: CT, Child: CT };
+    const BaseBar: CT<DesignableComponentsProps<BarComponents>> = ({ components, children }) => {
+      const { Wrapper, Child } = components;
+      return (
+        <Wrapper>
+          <Child />
+          {children}
+        </Wrapper>
+      );
+    };
+    const CleanBar = designable<BarComponents>({
+      Wrapper: Div,
+      Child: Div,
+    })(BaseBar);
+    const Bar = flow(
+      withDesign({
+        Child: addClasses('childClass1'),
+      }),
+      withChild(Span),
+      withDesign({
+        Child: addClasses('childClass2'),
+      }),
+    )(CleanBar);
+    const wrapper = mount(<Bar />);
+    expect(wrapper.html()).toBe('<div><div class="childClass1"></div><span class="childClass2"></span></div>');
+  });
+});

--- a/packages/bodiless-core/src/withChild.tsx
+++ b/packages/bodiless-core/src/withChild.tsx
@@ -12,11 +12,27 @@
  * limitations under the License.
  */
 
-import React, { ComponentType as CT } from 'react';
+import React, { Fragment, ComponentType as CT } from 'react';
+import { extendDesignable } from '@bodiless/fclasses';
+import type { DesignableComponentsProps } from '@bodiless/fclasses';
+import omit from 'lodash/omit';
 
-const withChild = (Child: CT) => <P extends Object>(Parent: CT<P> | string) => (props: P) => (
-  <Parent {...props}>
-    <Child />
-  </Parent>
-);
+type HOC<P = any, Q = P> = (Component?: CT<P>|string|undefined) => CT<Q>;
+
+const withChild = <P extends object>(Child: CT, designKey = 'Child'): HOC<P> => (Parent = Fragment) => {
+  type Components = { [Child: string]: CT };
+  const startComponents: Components = { [designKey]: Child };
+  const WithChild = (props: P & DesignableComponentsProps<Components>) => {
+    const { components, ...rest } = props;
+    const { [designKey]: ChildComponent } = components;
+    return (
+      <Parent {...rest as P}>
+        <ChildComponent />
+      </Parent>
+    );
+  };
+  const applyDesign = extendDesignable(design => omit(design, [designKey]));
+  return applyDesign(startComponents, designKey)(WithChild);
+};
+
 export default withChild;


### PR DESCRIPTION
<!--
  Before issuing a pull request:

  - Please read our contribution guidelines (https://github.com/johnsonandjohnson/Bodiless-JS/blob/master/packages/bodiless-documentation/doc/Development/Contributing.md), especially the section on Pull Requests.
  - Please first create an issue (https://github.com/johnsonandjohnson/Bodiless-JS/issues/new). All pull requests must be linked to an issue.
-->

<!--
  IMPORTANT
  
  The pull request title will become the commit message title at merge, and
  should adhere to Angular Commit Message Conventions. Please see (https://github.com/johnsonandjohnson/Bodiless-JS/blob/master/packages/bodiless-documentation/doc/Development/Contributing.md) for details and examples.
-->

## Changes
* replaced existing withChild hoc so that it is possible to alter the added child using the design API.

## Test Instructions
* for testing purposes, a new richtext called "Alphabetic Full Rich Text"  is added to /richtext page of test-site. Leveraging the implemented API, the richtext accepts only alphabetic characters, space, backspace, delete and enter characters. Please note that the richtext configured so that the logic to disallow characters works only during typing (it still will be possible to insert non-alphabetic characters using pasting)

## Related Issues

Fixes: #797
<!--
  Link to the issue that is fixed or resolved by this PR (if there is one)
  e.g. Fixes #1234, Closes #4567

  Link to an issue that is partially addressed by this PR (if there are any)
-->

<!-- IF THIS PR INTRODUCES A BREAKING CHANGE

BREAKING CHANGE: Describe the nature of the breaking change here.

More Details about the breaking change.
-->
