### PR TITLE
feat(bodiless-core-ui): activate context for group in Local context menu

### DIFF
--- a/packages/bodiless-core-ui/src/LocalContextMenu.tsx
+++ b/packages/bodiless-core-ui/src/LocalContextMenu.tsx
@@ -15,7 +15,12 @@
 import React, { FC } from 'react';
 import ReactTooltip from 'rc-tooltip';
 import { flow } from 'lodash';
-import { addClasses, addProps, removeClasses } from '@bodiless/fclasses';
+import {
+  addClasses,
+  addClassesIf,
+  addProps,
+  removeClasses,
+} from '@bodiless/fclasses';
 import {
   ContextMenu, ContextMenuProps, ContextMenuUI, IContextMenuItemProps,
 } from '@bodiless/core';
@@ -51,19 +56,27 @@ const LocalTooltip: FC<ReactTooltip['props']> = props => (
   />
 );
 
-const GroupTitle = flow(
-  removeClasses('bl-mb-grid-2 bl-min-w-xl-grid-1'),
-)(ComponentFormTitle);
-
-const ContextMenuGroup: FC<IContextMenuItemProps> = ({ option, children }) => {
+const ContextMenuGroup: FC<IContextMenuItemProps> = ({
+  children,
+  index,
+  option,
+}) => {
   const hidden: boolean = Boolean(option && (
     typeof option.isHidden === 'function' ? option.isHidden() : option.isHidden
   ));
   if (hidden) return null;
+  const { context, label } = option || {};
+  const onClick = context ? { onClick: () => context.activate() } : {};
+  const GroupTitle = flow(
+    removeClasses('bl-mb-grid-2 bl-min-w-xl-grid-1'),
+    addClassesIf(() => Number(index) > 0)('hover:bl-underline bl-cursor-pointer'),
+    addClassesIf(() => index === 0)('bl-underline'),
+  )(ComponentFormTitle);
+
   return (
     <div className={groupClasses}>
-      {option && option.label && (
-        <GroupTitle>{option.label}</GroupTitle>
+      {label && (
+        <GroupTitle {...onClick}>{label}</GroupTitle>
       )}
       <div className="flex">
         {children}

--- a/packages/bodiless-core/src/PageEditContext/types.ts
+++ b/packages/bodiless-core/src/PageEditContext/types.ts
@@ -53,7 +53,7 @@ export interface DefinesLocalEditContext {
 }
 
 export interface CanBeActivated {
-  isActive: boolean
+  isActive: boolean;
   isInnermost: boolean;
   hasLocalMenu: boolean;
   isInnermostLocalMenu: boolean;

--- a/packages/bodiless-core/src/Types/ContextMenuTypes.tsx
+++ b/packages/bodiless-core/src/Types/ContextMenuTypes.tsx
@@ -42,7 +42,7 @@ export type IContextMenuItemProps = {
    */
   name: string,
   /**
-   * The context menu option option which this item is rendering
+   * The context menu option which this item is rendering
    */
   option?: TMenuOption;
   /**

--- a/packages/bodiless-core/src/components/ContextMenu.tsx
+++ b/packages/bodiless-core/src/components/ContextMenu.tsx
@@ -35,22 +35,34 @@ const getComponent = (option: TMenuOption, defaultComponents: MenuOptionDefaultC
  * @param defaultComponents Default components to be used when a component does not define one.
  */
 const createChildrenFromOptions = (
-  options: TMenuOption[]|undefined,
+  options: TMenuOption[] | undefined,
   defaultComponents: MenuOptionDefaultComponents,
-) => uniqBy((options || []).map(
-  option => {
-    const Component = getComponent(option, defaultComponents);
-    return (
-      <Component
-        option={option}
-        group={option.group}
-        name={option.name}
-        key={option.name}
-        aria-label={option.name}
-      />
-    );
-  },
-), 'key');
+) => {
+  let index = -1;
+  return uniqBy((options || []).map(
+    (option, i, arr) => {
+      const Component = getComponent(option, defaultComponents);
+      const isGroupComponent = option.Component === 'group';
+      const visibleGroupItemsLength = arr.filter(
+        item => item.Component === 'group'
+        && !(typeof item.isHidden === 'function' ? item.isHidden() : Boolean(item.isHidden)),
+      ).length;
+      const isIndexed = isGroupComponent && visibleGroupItemsLength > 1;
+      index = isIndexed ? index + 1 : index;
+
+      return (
+        <Component
+          key={option.name}
+          aria-label={option.name}
+          group={option.group}
+          index={isIndexed ? index : undefined}
+          name={option.name}
+          option={option}
+        />
+      );
+    },
+  ), 'key');
+};
 
 const ContextMenuBase: FC<IContextMenuProps> = (props) => {
   if (typeof window === 'undefined') return null;


### PR DESCRIPTION
## Changes
* added event listener on local menu group title to activate item on click
* underlined title of leftmost group
* added style for underline not active elements on hover

## Test Instructions
* open Homepage 
* select Edit mode
* click on Image inside block "Giving back to community"
* make sure the conditions are met:
AC1. When you click the group title on the local context menu, the corresponding context is activated
AC2. There is a hover effect on the group title which indicates an interaction (underline).
AC3. The left most (inner most) group title is always underlined.

Group title will be **not clickable** and **without any additional styles** in case a group contains only one element.
