### PR TITLE
fix(core): Content library button did not merge properly.

### DIFF
--- a/packages/bodiless-layouts/src/ContentLibrary/withContentLibrary.tsx
+++ b/packages/bodiless-layouts/src/ContentLibrary/withContentLibrary.tsx
@@ -93,7 +93,6 @@ const withContentLibrary = (options: ContentLibraryOptions) => (
     const form = useContextMenuForm({ renderForm, hasSubmit: false });
     const baseOption: OptionGroupDefinition = {
       name: 'content-library',
-      group: 'content-library-group',
       label: 'Library',
       groupLabel: 'Content',
       groupMerge: 'merge',


### PR DESCRIPTION
## Changes
- Content library button now correctly merges with buttons provided by the component to which it is attached.

## Related Issues
Fixes #911