### PR TITLE
fix(navigation): breadcrumb current-page attribute

### DIFF
--- a/examples/test-site/src/components/Breadcrumbs/MenuBreadcrumbs.token.tsx
+++ b/examples/test-site/src/components/Breadcrumbs/MenuBreadcrumbs.token.tsx
@@ -27,6 +27,7 @@ import {
   withoutBreadcrumbFinalTrail,
   asAccessibleBreadcrumbs as asBaseAccessibleBreadcrumbs,
   useIsBreadcrumbItemCurrentPage,
+  withAccessibleDefaultMenuTitleEditor,
 } from '@bodiless/navigation';
 import {
   flowIf,
@@ -148,6 +149,7 @@ const $withBreadcrumbStyles = asToken(
 
 const asAccessibleBreadcrumbs = asToken(
   asBaseAccessibleBreadcrumbs,
+  withAccessibleDefaultMenuTitleEditor,
   withDesign({
     NavWrapper: addProps({
       'aria-label': BREADCRUMB_ARIA_LABEL,

--- a/examples/test-site/src/components/Breadcrumbs/MenuBreadcrumbs.token.tsx
+++ b/examples/test-site/src/components/Breadcrumbs/MenuBreadcrumbs.token.tsx
@@ -20,6 +20,7 @@ import {
   withNodeKey,
   withChild,
   asReadOnly,
+  ifToggledOn,
 } from '@bodiless/core';
 import { withoutLinkWhenLinkDataEmpty } from '@bodiless/components';
 import {
@@ -27,7 +28,7 @@ import {
   withoutBreadcrumbFinalTrail,
   asAccessibleBreadcrumbs as asBaseAccessibleBreadcrumbs,
   useIsBreadcrumbItemCurrentPage,
-  withAccessibleDefaultMenuTitleEditor,
+  useIsLastBreadcrumbItemRenderedAsALink,
 } from '@bodiless/navigation';
 import {
   flowIf,
@@ -149,12 +150,22 @@ const $withBreadcrumbStyles = asToken(
 
 const asAccessibleBreadcrumbs = asToken(
   asBaseAccessibleBreadcrumbs,
-  withAccessibleDefaultMenuTitleEditor,
   withDesign({
     NavWrapper: addProps({
       'aria-label': BREADCRUMB_ARIA_LABEL,
     }),
   }),
+  ifToggledOn(useIsLastBreadcrumbItemRenderedAsALink)(
+    withDesign({
+      Title: ifToggledOn(useIsBreadcrumbItemCurrentPage)(
+        withDesign({
+          Link: addProps({
+            'aria-current': 'page',
+          }),
+        }),
+      ),
+    }),
+  ),
 );
 
 export {

--- a/packages/bodiless-components/src/Editable.tsx
+++ b/packages/bodiless-components/src/Editable.tsx
@@ -13,11 +13,11 @@
  */
 
 import React, {
-  ClipboardEvent, useState, useRef, useCallback, FC,
+  ClipboardEvent, useState, useRef, useCallback, ComponentType, HTMLProps,
 } from 'react';
 import ContentEditable from 'react-contenteditable';
 import { observer } from 'mobx-react-lite';
-import { pickBy, identity } from 'lodash';
+import { identity } from 'lodash';
 import {
   withNode,
   useNode,
@@ -25,9 +25,16 @@ import {
   WithNodeProps,
   WithNodeKeyProps,
   withNodeKey,
+  withChild,
 } from '@bodiless/core';
 import './Editable.css';
-import { HOC, asToken } from '@bodiless/fclasses';
+import {
+  HOC,
+  asToken,
+  withoutProps,
+  addProps,
+  ComponentWithMeta,
+} from '@bodiless/fclasses';
 
 type EditableOverrides = {
   sanitizer?: (text: string) => string,
@@ -39,21 +46,27 @@ type EditableProps = {
   placeholder?: string,
   children?: string,
   useOverrides?: UseEditableOverrides,
-} & Partial<WithNodeProps>;
+} & Partial<WithNodeProps> & HTMLProps<HTMLSpanElement>;
 
 type EditableData = {
   text: string;
 };
 
 const Text = observer((props: EditableProps) => {
-  const { placeholder, useOverrides = () => ({}) }: EditableProps = props;
+  const {
+    placeholder,
+    useOverrides = () => ({}),
+    children,
+    nodeKey,
+    ...rest
+  }: EditableProps = props;
   const { sanitizer = identity }: EditableOverrides = useOverrides(props);
   const { node } = useNode<EditableData>();
   const text = sanitizer(
-    (node.data.text !== undefined ? node.data.text : props.children) || placeholder || '',
+    (node.data.text !== undefined ? node.data.text : children) || placeholder || '',
   );
   // eslint-disable-next-line react/no-danger
-  return <span dangerouslySetInnerHTML={{ __html: text }} />;
+  return <span dangerouslySetInnerHTML={{ __html: text }} {...rest} />;
 });
 const EditableText = observer((props: EditableProps) => {
   const { node } = useNode<EditableData>();
@@ -125,33 +138,19 @@ const asEditable = (
   placeholder?: string,
   useOverrides$?: UseEditableOverrides,
 ): HOC<{}, EditableProps> => Component => {
-  // @TODO: Use withChild.
   const useOverrides = useOverrides$ || (() => ({}));
   const EditableChild = asToken(
     withPlaceholder(placeholder),
     withNodeKey(nodeKeys),
+    addProps({
+      useOverrides,
+    }),
   )(Editable);
-  const AsEditable: FC<any> = props => {
-    const {
-      children,
-      nodeKey,
-      nodeCollection,
-      placeholder: placeholderProp,
-      ...rest
-    } = props;
-    const editableProps = pickBy({
-      children,
-      nodeKey,
-      nodeCollection,
-      placeholder: placeholderProp,
-      // useOverrides,
-    });
-    return (
-      <Component {...rest}>
-        <EditableChild {...editableProps} useOverrides={useOverrides} />
-      </Component>
-    );
-  };
+  const editableProps = ['nodeKey', 'nodeCollection', 'placeholder'];
+  const AsEditable = asToken(
+    withoutProps(editableProps),
+    withChild(EditableChild as ComponentType, 'Editor'),
+  )(Component) as ComponentWithMeta;
   return AsEditable;
 };
 

--- a/packages/bodiless-navigation/src/Breadcrumbs/Breadcrumb.token.tsx
+++ b/packages/bodiless-navigation/src/Breadcrumbs/Breadcrumb.token.tsx
@@ -13,6 +13,7 @@
  */
 
 import { ifToggledOn } from '@bodiless/core';
+import negate from 'lodash/negate';
 import {
   stylable,
   withDesign,
@@ -20,7 +21,10 @@ import {
   addProps,
 } from '@bodiless/fclasses';
 import type { TokenDef } from '@bodiless/fclasses';
-import { useIsBreadcrumbItemCurrentPage } from './hooks';
+import {
+  useIsBreadcrumbItemCurrentPage,
+  useIsLastBreadcrumbItemRenderedAsALink,
+} from './hooks';
 
 /**
  * Makes all Breadcrumb design components stylable.
@@ -47,14 +51,40 @@ export const withBreadcrumbItemToken = (...tokenDefs: TokenDef[]) => withDesign(
   Title: asToken({}, ...tokenDefs),
 });
 
+export const withAccessibleDefaultMenuTitleEditor = asToken(
+  ifToggledOn(negate(useIsLastBreadcrumbItemRenderedAsALink))(
+    withDesign({
+      Title: ifToggledOn(useIsBreadcrumbItemCurrentPage)(
+        withDesign({
+          Title: withDesign({
+            Editor: addProps({
+              'aria-current': 'page',
+            }),
+          }),
+        }),
+      ),
+    }),
+  ),
+  ifToggledOn(useIsLastBreadcrumbItemRenderedAsALink)(
+    withDesign({
+      Title: ifToggledOn(useIsBreadcrumbItemCurrentPage)(
+        withDesign({
+          Link: addProps({
+            'aria-current': 'page',
+          }),
+        }),
+      ),
+    }),
+  ),
+);
+
 /**
  * Hoc to make breadcrumbs accessible
  */
-export const asAccessibleBreadcrumbs = withDesign({
-  NavWrapper: addProps({
-    'aria-label': 'Breadcrumb',
+export const asAccessibleBreadcrumbs = asToken(
+  withDesign({
+    NavWrapper: addProps({
+      'aria-label': 'Breadcrumb',
+    }),
   }),
-  Title: ifToggledOn(useIsBreadcrumbItemCurrentPage)(addProps({
-    'aria-current': 'page',
-  })),
-});
+);

--- a/packages/bodiless-navigation/src/Breadcrumbs/Breadcrumb.token.tsx
+++ b/packages/bodiless-navigation/src/Breadcrumbs/Breadcrumb.token.tsx
@@ -51,33 +51,6 @@ export const withBreadcrumbItemToken = (...tokenDefs: TokenDef[]) => withDesign(
   Title: asToken({}, ...tokenDefs),
 });
 
-export const withAccessibleDefaultMenuTitleEditor = asToken(
-  ifToggledOn(negate(useIsLastBreadcrumbItemRenderedAsALink))(
-    withDesign({
-      Title: ifToggledOn(useIsBreadcrumbItemCurrentPage)(
-        withDesign({
-          Title: withDesign({
-            Editor: addProps({
-              'aria-current': 'page',
-            }),
-          }),
-        }),
-      ),
-    }),
-  ),
-  ifToggledOn(useIsLastBreadcrumbItemRenderedAsALink)(
-    withDesign({
-      Title: ifToggledOn(useIsBreadcrumbItemCurrentPage)(
-        withDesign({
-          Link: addProps({
-            'aria-current': 'page',
-          }),
-        }),
-      ),
-    }),
-  ),
-);
-
 /**
  * Hoc to make breadcrumbs accessible
  */
@@ -87,4 +60,13 @@ export const asAccessibleBreadcrumbs = asToken(
       'aria-label': 'Breadcrumb',
     }),
   }),
+  ifToggledOn(negate(useIsLastBreadcrumbItemRenderedAsALink))(
+    withDesign({
+      Item: ifToggledOn(useIsBreadcrumbItemCurrentPage)(
+        addProps({
+          'aria-current': 'page',
+        }),
+      ),
+    }),
+  ),
 );

--- a/packages/bodiless-navigation/src/Breadcrumbs/hooks.ts
+++ b/packages/bodiless-navigation/src/Breadcrumbs/hooks.ts
@@ -12,10 +12,12 @@
  * limitations under the License.
  */
 
-/* eslint-disable import/prefer-default-export */
-
 const useIsBreadcrumbItemCurrentPage = ({ isCurrentPage }: any) => isCurrentPage;
+const useIsLastBreadcrumbItemRenderedAsALink = ({
+  renderLastItemWithoutLink = true,
+}: any) => !renderLastItemWithoutLink;
 
 export {
   useIsBreadcrumbItemCurrentPage,
+  useIsLastBreadcrumbItemRenderedAsALink,
 };

--- a/packages/bodiless-navigation/src/Breadcrumbs/hooks.ts
+++ b/packages/bodiless-navigation/src/Breadcrumbs/hooks.ts
@@ -12,10 +12,15 @@
  * limitations under the License.
  */
 
-const useIsBreadcrumbItemCurrentPage = ({ isCurrentPage }: any) => isCurrentPage;
+import { CleanBreadcrumbsProps, CleanBreadcrumbItemType } from './types';
+
+const useIsBreadcrumbItemCurrentPage = ({
+  isCurrentPage,
+}: CleanBreadcrumbItemType) => isCurrentPage;
+
 const useIsLastBreadcrumbItemRenderedAsALink = ({
   renderLastItemWithoutLink = true,
-}: any) => !renderLastItemWithoutLink;
+}: Partial<CleanBreadcrumbsProps>) => !renderLastItemWithoutLink;
 
 export {
   useIsBreadcrumbItemCurrentPage,


### PR DESCRIPTION
<!--
  Before issuing a pull request:

  - Please read our contribution guidelines (https://github.com/johnsonandjohnson/Bodiless-JS/blob/master/packages/bodiless-documentation/doc/Development/Contributing.md), especially the section on Pull Requests.
  - Please first create an issue (https://github.com/johnsonandjohnson/Bodiless-JS/issues/new). All pull requests must be linked to an issue.
-->

<!--
  IMPORTANT
  
  The pull request title will become the commit message title at merge, and
  should adhere to Angular Commit Message Conventions. Please see (https://github.com/johnsonandjohnson/Bodiless-JS/blob/master/packages/bodiless-documentation/doc/Development/Contributing.md) for details and examples.
-->

## Changes
* when last breadcrumb item is not a link, then 'aria-current' attribute is added to the corresponding 'li' html element

## Test Instructions
<!-- Detailed description of how this feature was (and should be) tested
  - Setup instructions (if any)?
  - List of test cases, with steps and expected results?
  - List
-->

## Related Issues
<!--
  Link to the issue that is fixed or resolved by this PR (if there is one)
  e.g. Fixes #1234, Closes #4567

  Link to an issue that is partially addressed by this PR (if there are any)
-->

<!-- IF THIS PR INTRODUCES A BREAKING CHANGE

BREAKING CHANGE: Describe the nature of the breaking change here.

More Details about the breaking change.
-->
