### PR TITLE
fix(navigation): Fix asTopNav adding every submenu option to Chameleon.

### DIFF
--- a/examples/test-site/src/components/Menu/Menu.token.tsx
+++ b/examples/test-site/src/components/Menu/Menu.token.tsx
@@ -116,4 +116,9 @@ const $asNavStyles = asToken(
 export default $asNavStyles;
 export {
   $withTitleEditors,
+  $withBaseMenuStyles,
+  $withBaseSubMenuStyles,
+  $withTitleStyles,
+  $withListSubmenuStyles,
+  $withColumnsSublistStyles,
 };

--- a/examples/test-site/src/data/pages/menu/index.tsx
+++ b/examples/test-site/src/data/pages/menu/index.tsx
@@ -20,11 +20,18 @@ import {
 } from '@bodiless/fclasses';
 import { observer } from 'mobx-react-lite';
 import { useNode, withNode, withNodeKey } from '@bodiless/core';
-import { withBurgerMenuProvider, withOverviewLink, withMenuDesign } from '@bodiless/navigation';
+import {
+  withBurgerMenuProvider, withOverviewLink, withMenuDesign,
+  asBodilessMenu, asTopNav, withListSubMenu, withColumnSubMenu,
+} from '@bodiless/navigation';
 
 import Layout from '../../../components/Layout';
 import { asHeader2, asHeader1, asTealBackground } from '../../../components/Elements.token';
 import ResponsiveMenu, { BurgerMenuToggler } from '../../../components/Menu';
+import {
+  $withTitleEditors, $withBaseMenuStyles, $withBaseSubMenuStyles, $withListSubmenuStyles,
+  $withTitleStyles, $withColumnsSublistStyles,
+} from '../../../components/Menu/Menu.token';
 
 // Example of custom OverviewLink
 const $withMenuOverviewLink = withMenuDesign(['List', 'Columns', 'Cards'])(
@@ -40,6 +47,27 @@ const DemoMenu = asToken(
     _default: withDesign({ Menu: $withMenuOverviewLink }),
   }),
 )(ResponsiveMenu);
+
+const DemoListMenu = asToken(
+  asBodilessMenu('demo-list-menu'),
+  withListSubMenu(),
+  asTopNav('Main', 'List'),
+  withMenuDesign('Main')($withBaseMenuStyles),
+  withMenuDesign(['Main', 'List'])($withTitleEditors, $withTitleStyles),
+  withMenuDesign('List')($withBaseSubMenuStyles, $withListSubmenuStyles),
+)(Ul) as ComponentType<any>;
+
+const DemoListAndColumnsMenu = asToken(
+  asBodilessMenu('demo-list-and-columns-menu'),
+  withListSubMenu(),
+  withColumnSubMenu(),
+  asTopNav('Main', 'List', 'Columns'),
+  withMenuDesign('Main')($withBaseMenuStyles),
+  withMenuDesign(['Main', 'List', 'Columns'])($withTitleEditors, $withTitleStyles),
+  withMenuDesign(['List', 'Columns'])($withBaseSubMenuStyles),
+  withMenuDesign('List')($withListSubmenuStyles),
+  withMenuDesign('Columns', 2)($withColumnsSublistStyles),
+)(Ul) as ComponentType<any>;
 
 const BurgerMenuTogglerFullWidth = withDesign({
   Wrapper: asToken(
@@ -116,6 +144,26 @@ export default (props: any) => (
           title and the link becomes the CTA link).
         </p>
       </Description>
+
+      <H2>Bodiless List Menu</H2>
+      <Description>
+        <p>
+          This is an example of the menu where only one type of the submenu ( List ) is allowed.
+          Note that this is not a &quot;Responsive&quot; menu and
+          will not be transformed to the Burger Menu.
+        </p>
+      </Description>
+      <DemoListMenu />
+
+      <H2>Bodiless List and Columns Menu</H2>
+      <Description>
+        <p>
+          This is an example of the menu where List and Columns submenus are configured.
+          Note that this is not a &quot;Responsive&quot; menu and
+          will not be transformed to the Burger Menu.
+        </p>
+      </Description>
+      <DemoListAndColumnsMenu />
 
       <DataPreviewContainer>
         <H2>Data</H2>

--- a/packages/bodiless-navigation/src/Menu/Menu.token.tsx
+++ b/packages/bodiless-navigation/src/Menu/Menu.token.tsx
@@ -13,6 +13,7 @@
  */
 
 import { useEditContext } from '@bodiless/core';
+import type { Token } from '@bodiless/fclasses';
 import {
   addClasses,
   removeClassesIf,
@@ -128,19 +129,16 @@ const asFullWidthSubMenu = asToken(
  * @return Token that applies default top navigation styles based on provided keys.
  */
 const asTopNav = (...keys: string[]) => {
-  const mainMenuStyles = (keys.length === 0 || keys.indexOf('Main') > -1)
-    ? withBaseMenuStyles
-    : asToken({});
-  const listSubmenuStyles = keys.indexOf('List') > -1 ? asListSubMenu : asToken({});
-  const cardsSubmenuStyles = keys.indexOf('Cards') > -1 ? asFullWidthSubMenu : asToken({});
-  const columnsSubmenuStyles = keys.indexOf('Columns') > -1 ? asFullWidthSubMenu : asToken({});
+  const TopNavDesign: { [key: string]: Token } = {
+    Main: withMenuDesign('Main')(withBaseMenuStyles),
+    List: withMenuDesign('List')(asListSubMenu),
+    Cards: withMenuDesign('Cards')(asFullWidthSubMenu),
+    Columns: withMenuDesign('Columns', 1)(asFullWidthSubMenu),
+  };
 
-  return asToken(
-    withMenuDesign('Main')(mainMenuStyles),
-    withMenuDesign('List')(listSubmenuStyles),
-    withMenuDesign('Cards')(cardsSubmenuStyles),
-    withMenuDesign('Columns', 1)(columnsSubmenuStyles),
-  );
+  return keys.length === 0
+    ? asToken(TopNavDesign.Main)
+    : asToken(...keys.map(key => TopNavDesign[key]));
 };
 
 export default asTopNav;


### PR DESCRIPTION
## Changes
- Fix `asTopNav` preventing it from adding every submenu option from being added to the Chameleon component picker regardless of the submenu type being used.

## Test Instructions
- Make sure the Site Navigation menu works the same as in the production.
- Check two new menu examples on the /menu/ page.
  - One should add a List submenu automatically without the Chameleon picker
  - Another menu example should only have List and Columns options.

## Related Issues

