### PR TITLE
fix(search): Typeahead/suggestion item click does not trigger the search

### DIFF
--- a/packages/bodiless-search/src/components/Suggestions.tsx
+++ b/packages/bodiless-search/src/components/Suggestions.tsx
@@ -70,12 +70,18 @@ const withSuggestionLink:HOC<{}, SuggestionLinkProps> = Component => {
   const WithSuggestionLink = (props: SuggestionLinkProps) => {
     const { text, ...rest } = props;
     const searchResultContext = useSearchResultContext();
+    const searchPath = getSearchPagePath(text);
     return (
       <Component
         {...rest as any}
-        href={getSearchPagePath(text)}
+        href={searchPath}
         onClick={(event: React.MouseEvent) => {
           event.preventDefault();
+          if (
+            getSearchPagePath() !== window.location.pathname.replace(/^\//, '').replace(/\/$/, '')
+          ) {
+            window.location.href = searchPath;
+          }
           searchResultContext.setSearchTerm(text);
         }}
       />


### PR DESCRIPTION
<!--
  Before issuing a pull request:

  - Please read our contribution guidelines (https://github.com/johnsonandjohnson/Bodiless-JS/blob/master/packages/bodiless-documentation/doc/Development/Contributing.md), especially the section on Pull Requests.
  - Please first create an issue (https://github.com/johnsonandjohnson/Bodiless-JS/issues/new). All pull requests must be linked to an issue.
-->

<!--
  IMPORTANT
  
  The pull request title will become the commit message title at merge, and
  should adhere to Angular Commit Message Conventions. Please see (https://github.com/johnsonandjohnson/Bodiless-JS/blob/master/packages/bodiless-documentation/doc/Development/Contributing.md) for details and examples.
-->

## Changes
<!-- Brief description of the changes introduced by this PR -->

## Test Instructions
<!-- Detailed description of how this feature was (and should be) tested
  - Setup instructions (if any)?
  - List of test cases, with steps and expected results?
  - List
-->

## Related Issues
<!--
  Link to the issue that is fixed or resolved by this PR (if there is one)
  e.g. Fixes #1234, Closes #4567

  Link to an issue that is partially addressed by this PR (if there are any)
-->

<!-- IF THIS PR INTRODUCES A BREAKING CHANGE

BREAKING CHANGE: Describe the nature of the breaking change here.

More Details about the breaking change.
-->
