### PR TITLE
fix(accordion): 'aria-labelledby' refers to a missing element, or is empty

### DIFF
--- a/cypress/integration/smokeTest/singleAccordion_spec.js
+++ b/cypress/integration/smokeTest/singleAccordion_spec.js
@@ -19,20 +19,20 @@ describe('Single Accordion smoke tests', function () {
     cy.toggleEditMode()
   })
 
-  after(function() {
+  after(function () {
     cy.togglePreviewMode();
   })
 
   const title = 'AT - Title 1'
   const body = 'AT - Description 1'
   const editedPostfix = ' - edited'
-  const titleFirstXpath = '//*[@id="accordion-1"]//*[@data-accordion-element="accordion-title"]//*[@data-slate-editor="true"]'
-  const bodyFirstXpath = '//*[@id="accordion-1"]//*[@data-accordion-element="accordion-body"]//*[@data-slate-editor="true"]'
-  const plusIconFirstXpath = '//*[@id="accordion-1"]//*[@data-accordion-icon="expand"]'
-  const minusIconFirstXpath = '//*[@id="accordion-1"]//*[@data-accordion-icon="collapse"]'
-  const bodySecondXpath = '//*[@id="accordion-2"]//*[@data-accordion-element="accordion-body"]'
-  const plusIconSecondXpath = '//*[@id="accordion-2"]//*[@data-accordion-icon="expand"]'
-  const minusIconSecondXpath = '//*[@id="accordion-2"]//*[@data-accordion-icon="collapse"]'
+  const titleFirstXpath = '//*[@id="accordion-4"]//*[@data-accordion-element="accordion-title"]//*[@data-slate-editor="true"]'
+  const bodyFirstXpath = '//*[@id="accordion-4"]//*[@data-accordion-element="accordion-body"]//*[@data-slate-editor="true"]'
+  const plusIconFirstXpath = '//*[@id="accordion-4"]//*[@data-accordion-icon="expand"]'
+  const minusIconFirstXpath = '//*[@id="accordion-4"]//*[@data-accordion-icon="collapse"]'
+  const bodySecondXpath = '//*[@id="accordion-5"]//*[@data-accordion-element="accordion-body"]'
+  const plusIconSecondXpath = '//*[@id="accordion-5"]//*[@data-accordion-icon="expand"]'
+  const minusIconSecondXpath = '//*[@id="accordion-5"]//*[@data-accordion-icon="collapse"]'
 
 
   it('accordions: 1 - filling in Title in 1st accordion', () => {
@@ -189,4 +189,4 @@ describe('Single Accordion smoke tests', function () {
     cy.xpath(bodyFirstXpath)
       .should('have.text', body + editedPostfix)
   })
-})   
+})

--- a/packages/bodiless-accordion/src/components/AccordionWrapper.tsx
+++ b/packages/bodiless-accordion/src/components/AccordionWrapper.tsx
@@ -16,9 +16,13 @@ import React from 'react';
 import { HOC } from '@bodiless/fclasses';
 import { AccordionProvider } from './AccordionContext';
 
-const asAccordionWrapper:HOC = Component => {
-  const AsAccordionWrapper = ({ expanded, focus, ...rest }: any) => (
-    <AccordionProvider expanded={expanded} focus={focus}>
+const asAccordionWrapper: HOC = Component => {
+  const AsAccordionWrapper = (
+    {
+      expanded, focus, meta, ...rest
+    }: any,
+  ) => (
+    <AccordionProvider expanded={expanded} focus={focus} meta={meta}>
       <Component {...rest} />
     </AccordionProvider>
   );

--- a/packages/bodiless-accordion/src/components/AccordionWrapper.tsx
+++ b/packages/bodiless-accordion/src/components/AccordionWrapper.tsx
@@ -13,19 +13,29 @@
  */
 
 import React from 'react';
+import nextId from 'react-id-generator';
 import { HOC } from '@bodiless/fclasses';
 import { AccordionProvider } from './AccordionContext';
 
 const asAccordionWrapper: HOC = Component => {
   const AsAccordionWrapper = (
     {
-      expanded, focus, meta, ...rest
+      expanded, focus, meta, id, ...rest
     }: any,
-  ) => (
-    <AccordionProvider expanded={expanded} focus={focus} meta={meta}>
-      <Component {...rest} />
-    </AccordionProvider>
-  );
+  ) => {
+    const accordionId = id ?? nextId('accordion-');
+
+    const accordionMeta = {
+      accordionId,
+      accordionTitleId: `accordion__title-${accordionId}`,
+      accordionContentId: `accordion__content-${accordionId}`,
+    };
+    return (
+      <AccordionProvider expanded={expanded} focus={focus} meta={accordionMeta}>
+        <Component {...rest} />
+      </AccordionProvider>
+    );
+  };
   return AsAccordionWrapper;
 };
 


### PR DESCRIPTION
## Changes
- `aria-labelledby` attributes are now generated for accordions that don't have `AccordionClean` as a start component and rely on `asAccordionWrapper` to provide the context.

## Test Instructions


## Related Issues

