### PR TITLE
Update withAppendChild and withPrependChild

### DIFF
--- a/examples/test-site/src/components/Menu/BurgerMenu.token.tsx
+++ b/examples/test-site/src/components/Menu/BurgerMenu.token.tsx
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-import { withPrependChild } from '@bodiless/core';
+import { withAppendChild } from '@bodiless/core';
 import {
   Div, asToken, replaceWith, startWith, withDesign, addClasses, withoutProps,
 } from '@bodiless/fclasses';
@@ -47,7 +47,7 @@ const $withBurgerMenuHeaderStyles = asToken(
   withDesign({
     SiteReturn: asToken(
       withoutProps('design'),
-      withPrependChild(BurgerMenuDefaultToggler, 'MenuToggler'),
+      withAppendChild(BurgerMenuDefaultToggler, 'MenuToggler'),
       asTealBackground,
       withDesign({
         MenuToggler: $withTogglerStyles,

--- a/packages/bodiless-core/src/withChild.tsx
+++ b/packages/bodiless-core/src/withChild.tsx
@@ -46,15 +46,15 @@ const insertChild = (Child: CT, options: InsertChildOptions): HOC => (
       case 'append':
         return (
           <Component {...restWithoutChildren as any}>
-            <ChildComponent />
             {children}
+            <ChildComponent />
           </Component>
         );
       case 'prepend':
         return (
           <Component {...restWithoutChildren as any}>
-            {children}
             <ChildComponent />
+            {children}
           </Component>
         );
       default:

--- a/packages/bodiless-navigation/src/Menu/asAccessibleMenu.tsx
+++ b/packages/bodiless-navigation/src/Menu/asAccessibleMenu.tsx
@@ -16,7 +16,7 @@ import React, {
   ComponentType, FC, useRef, useCallback, useEffect,
 } from 'react';
 import {
-  withParent, withPrependChild, useNode, useClickOutside,
+  withParent, withAppendChild, useNode, useClickOutside,
 } from '@bodiless/core';
 import type { LinkData } from '@bodiless/components';
 import {
@@ -187,7 +187,7 @@ const SubmenuIndicator = asToken(
  * it has a submenu and it's title is a link.
  */
 const withSubmenuIndicator = flowIf(useHasLink)(
-  withPrependChild(SubmenuIndicator, 'SubmenuIndicator'),
+  withAppendChild(SubmenuIndicator, 'SubmenuIndicator'),
 );
 
 /**


### PR DESCRIPTION
## Changes
<!-- Brief description of the changes introduced by this PR -->

- Function names of `withAppendChild` & `withPrependChild` names are swapped to match actual functions behavior in bodiless-core.


## Test Instructions
<!-- Detailed description of how this feature was (and should be) tested
  - Setup instructions (if any)?
  - List of test cases, with steps and expected results?
  - List
-->
This change has an impact on the below area and needs to be tested accordingly.

- /packages/bodiless-navigation/src/Menu/asAccessibleMenu.tsx ( Only the `SubmenuIndicator` may be affected )
- /examples/test-site/src/components/Menu/BurgerMenu.token.tsx ( Only the BM Toggle Button may be affected )



## Related Issues
<!--
  Link to the issue that is fixed or resolved by this PR (if there is one)
  e.g. Fixes #1234, Closes #4567

  Link to an issue that is partially addressed by this PR (if there are any)
-->

<!-- IF THIS PR INTRODUCES A BREAKING CHANGE

BREAKING CHANGE: Describe the nature of the breaking change here.

More Details about the breaking change.
-->

Closes: https://github.com/johnsonandjohnson/Bodiless-JS/issues/1067
