### PR TITLE
Fix table cell returning parent node on useNode

### DIFF
--- a/packages/bodiless-table/src/asBodilessTable.tsx
+++ b/packages/bodiless-table/src/asBodilessTable.tsx
@@ -25,11 +25,11 @@ import {
   WithNodeProps,
 } from '@bodiless/core';
 import {
-  withDesign,
   withoutProps,
   HOC,
   flowIf,
   asToken,
+  withFinalDesign,
 } from '@bodiless/fclasses';
 import { v1 } from 'uuid';
 import {
@@ -301,7 +301,7 @@ const asBodilessTable = (nodeKey?: NodeKey, defaultData?:TableBaseProps) => asTo
   } as TableBaseProps),
   withNode,
   withNodeKey(nodeKey),
-  withDesign({
+  withFinalDesign({
     Wrapper: withMenuOptions({ useMenuOptions: useMenuOptionsTableOverview, name: 'Table' }),
     TBody: asToken(withNode, withNodeKey(Section.body)),
     THead: asToken(withNode, withNodeKey(Section.head)),


### PR DESCRIPTION
## Changes
Fixed `useNode` returning a Cell's parent node, instead of returning the Cell node, by changing a `withDesign` call on the `asBodilessTable` token to `withFinalDesign`.

## Test Instructions
As mentioned in #1032:
- Wrap a table element in an `asBodilessTable`
- Add an HOC via `withDesign` to a table cell which uses the current node, like:
```ts
import { CleanTable } from '@bodiless/table';

const withTestHOC: HOC = Component => {
  const WithTestHOC = (props: any) => {
    const { node } = useNode();

    console.debug(node.path);

    return <Component {...props} />;
  };
  return WithTestHOC;
};

const Table = asToken(
  withDesign({
    Cell: withTestHOC,
  }),
)(CleanTable);
```
- Add some data to the table, or apply the `withTestHOC` token to an existing table on the `/table` page.

The `node` constant should represent the Cell node, instead of its parent. On the console, you should see cell paths logged like this:
```
// This is correct, it's a cell path
> Array(5) [ "Page", "table2", "head", "0", "1" ]
```
Instead of paths pointing to rows, like this:
```
// This is incorrect, it's a row path
> Array(4) [ "Page", "table2", "head", "0" ]
```

## Related Issues
Fixes #1032 
