### PR TITLE
fix(GTM): Sites running with rocketloader are pushing duplicate events

### DIFF
--- a/.github/workflows/build-test-lint-simple.yml
+++ b/.github/workflows/build-test-lint-simple.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   setup:
     name: Setup, Build, Lint and Test
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:

--- a/packages/bodiless-components/src/GTM/gtm.tsx
+++ b/packages/bodiless-components/src/GTM/gtm.tsx
@@ -110,7 +110,7 @@ const withDataLayerScript = (HelmetComponent: CT<BaseProps>) => (
   return (
     <HelmetComponent {...rest}>
       {children}
-      <script>{generateDataLayer(dataLayerData, dataLayerName)}</script>
+      <script data-cfasync="false">{generateDataLayer(dataLayerData, dataLayerName)}</script>
     </HelmetComponent>
   );
 };


### PR DESCRIPTION
Sites running with rocketloader are pushing duplicate events

<!--
  Before issuing a pull request:

  - Please read our contribution guidelines (https://github.com/johnsonandjohnson/Bodiless-JS/blob/master/packages/bodiless-documentation/doc/Development/Contributing.md), especially the section on Pull Requests.
  - Please first create an issue (https://github.com/johnsonandjohnson/Bodiless-JS/issues/new). All pull requests must be linked to an issue.
-->

<!--
  IMPORTANT
  
  The pull request title will become the commit message title at merge, and
  should adhere to Angular Commit Message Conventions. Please see (https://github.com/johnsonandjohnson/Bodiless-JS/blob/master/packages/bodiless-documentation/doc/Development/Contributing.md) for details and examples.
-->

## Changes
/bodiless-components/src/GTM/gtm.tsx#L113

## Test Instructions
- Add GTM container ID in env.site
- Enable rocket loader on cloudlfare
- Open the developer console on browser
- There should be only 1 even fired from GTM data layer.
