### PR TITLE
doc(core): Add notes about node key conflicts with module names

### DIFF
--- a/examples/test-site/src/data/pages/gallery-final/index.tsx
+++ b/examples/test-site/src/data/pages/gallery-final/index.tsx
@@ -38,7 +38,7 @@ export default (props: PageProps) => (
       <LandscapeLinkableImage />
       <PrimaryHeader />
       <Body />
-      <Gallery nodeKey="gallery">
+      <Gallery nodeKey="gallery-content">
         <GalleryTile nodeKey="tile1" />
         <GalleryTile nodeKey="tile2" />
       </Gallery>

--- a/packages/bodiless-documentation/doc/Development/Architecture/Data.md
+++ b/packages/bodiless-documentation/doc/Development/Architecture/Data.md
@@ -113,8 +113,8 @@ In order to take advantage of the Bodiless data flow, your page-level component
 `default template` is a good example and can be copied to form the basis of your
 pages.
 
-Note that the Gatsby page query exported by the default template uses a GraphQL
-"fragment":
+Note that the Gatsby page query exported by the default template uses GraphQL
+"fragments":
 
 ```javascript
 export const query = graphql`
@@ -125,9 +125,10 @@ export const query = graphql`
 `;
 ```
 
-The fragment is defined by Gatsby Theme Bodiless and queries the contents of all
-json files in the directory corresponding to the page. This can be used as-is,
-or the page query could be extended in case the page requires additional data.
+The fragments are defined by Gatsby Theme Bodiless. The first queries the
+contents of all json files in the directory corresponding to the page, while the
+second queries those in a directory containing site-wide data. These can be used
+as-is, or extended in case the page requires additional data.
 
 ### Component Data
 
@@ -211,6 +212,13 @@ So, in the above example, there would be 4 files:
   blurb-2$title.json
   blurb-2$body.json
 ```
+
+> Note: be sure that you do not use a node key which results in a json file with
+> the same name as a source module in the same directory. For example, don't use
+> a node key of 'foo' (producing a `foo.json`) if you have a 'foo.ts(x)' file in
+> the same directory. Doing so can cause issues with module resolution if you
+> set the `resolveJsonModules` directive to `true` in your projects
+> `tsconfig.json`.
 
 ### "Sidecar" nodes.
 

--- a/packages/bodiless-documentation/doc/Development/Guides/IntroToBodilessConcepts.md
+++ b/packages/bodiless-documentation/doc/Development/Guides/IntroToBodilessConcepts.md
@@ -563,7 +563,7 @@ import Gallery, { GalleryTile } from './Gallery';
 And place it on the page after the `<Body />` tag:
 
 ```
-<Gallery nodeKey="gallery">
+<Gallery nodeKey="gallery-content">
   <GalleryTile nodeKey="tile1" />
   <GalleryTile nodeKey="tile2" />
 </Gallery>
@@ -572,15 +572,15 @@ And place it on the page after the `<Body />` tag:
 Using the edit UI, upload images and add captions to your two new components. 
 
 Look at the contents of `src/data/pages/gallery`. You should see new `json`
-files whose names begin with `gallery$tile1$` and `gallery$tile2$...`. These
-names correspond to the `nodeKey` props on the `Gallery` and `CaptionedImage`
-components you added to `index.tsx` and `Gallery.tsx` respectively. The rest of
-those filenames (`...image` and `...caption`) are derived from the `nodeKey`
-specified in your `CaptionedImage` component. Each is namespaced by the
-`nodeKey` of the parent component. As a result, you can add any number of
-`CaptionedImage` components to the same gallery, and any number of `Gallery`
-components on the same page, as long as each has a distinct `nodeKey`, they will
-not collide.
+files whose names begin with `gallery-content$tile1$` and
+`gallery-content$tile2$...`. These names correspond to the `nodeKey` props on
+the `Gallery` and `CaptionedImage` components you added to `index.tsx` and
+`Gallery.tsx` respectively. The rest of those filenames (`...image` and
+`...caption`) are derived from the `nodeKey` specified in your `CaptionedImage`
+component. Each is namespaced by the `nodeKey` of the parent component. As a
+result, you can add any number of `CaptionedImage` components to the same
+gallery, and any number of `Gallery` components on the same page, as long as
+each has a distinct `nodeKey`, they will not collide.
 
 It's the `withNode()` HOC (imported from `@bodiless/core`) which adds the
 `nodeKey` prop to your `CaptionedImage` and `Gallery` components. Anytime you
@@ -681,14 +681,14 @@ to
 Now remove the following from `index.tsx`:
 
 ```ts
-<Gallery nodeKey="gallery">
+<Gallery nodeKey="gallery-content">
   <GalleryTile nodeKey="tile1" />
   <GalleryTile nodeKey="tile2" />
 </Gallery>
 ```
 And replace with:
 ```ts
-<Gallery nodeKey="gallery" />
+<Gallery nodeKey="gallery-content" />
 ```
 
 Be sure to update the imports in `Gallery.tsx`.  They should now be:


### PR DESCRIPTION
## Changes
Update documentation to warn about potential module resolution issues if a node key produces a json file with the same name as a source module in the same directory.