### PR TITLE
chore: pre-Release-v0.2.10

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   publish_doc:
     name: Publish documentation
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   publish:
     name: Publish packages
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
## Changes
Upgrade GitHub action ubuntu version to the latest in order to unlock the automated release process.

## Related Issues
https://github.com/johnsonandjohnson/Bodiless-JS/issues/1120
https://github.com/johnsonandjohnson/Bodiless-JS/pull/1119/files#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cR14