### PR TITLE
pin oidc

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,3 +8,9 @@ update, gatsby started intercepting errors on proxied requests, responding with 
 instead of the original one. This affected error messages sent from `bodiless-backend`.
 - Issue: https://github.com/johnsonandjohnson/Bodiless-JS/issues/1174
 - See also: https://github.com/gatsbyjs/gatsby/issues/33333
+
+## oidc-client-ts
+- Locked at: 2.0.0-beta.2
+- Reason: Downstream sites are hosting the oidc-client-ts rc 1 package and producing TS errors.
+- Resolution: When OIDC client is needed update offending code src/UserManager.ts
+- Issue: https://github.com/johnsonandjohnson/Bodiless-JS/issues/1243

--- a/packages/bodiless-oidc/package.json
+++ b/packages/bodiless-oidc/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "axios": "^0.21.0",
     "enzyme": "^3.9.0",
-    "oidc-client-ts": "~2.0.0-beta.2"
+    "oidc-client-ts": "2.0.0-beta.2"
   },
   "peerDependencies": {
     "react": "^17.0.2",

--- a/packages/bodiless-oidc/package.json
+++ b/packages/bodiless-oidc/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "axios": "^0.21.0",
     "enzyme": "^3.9.0",
-    "oidc-client-ts": "^2.0.0-beta.2"
+    "oidc-client-ts": "~2.0.0-beta.2"
   },
   "peerDependencies": {
     "react": "^17.0.2",


### PR DESCRIPTION
## Description
Downstream sites are hosting the oidc-client-ts rc 1 package and producing 

``
@bodiless/oidc: src/UserManager.ts(92,5): error TS2322: Type 'string | undefined' is not assignable to type 'PopupWindowFeatures | undefined'.
@bodiless/oidc:   Type 'string' is not assignable to type 'PopupWindowFeatures | undefined'.
lerna ERR! npm run build exited 2 in '@bodiless/oidc'
``

## Changes
* Pin oidc-client-ts

## Test Instructions
* None


