### PR TITLE
fix(richtext): Fix RTE inline placeholders wrapping text

### DIFF
--- a/packages/bodiless-richtext/src/core/Content.tsx
+++ b/packages/bodiless-richtext/src/core/Content.tsx
@@ -26,7 +26,9 @@ import {
   Editable,
   DefaultElement,
   DefaultLeaf,
+  DefaultPlaceholder,
   useSlate,
+  RenderPlaceholderProps,
 } from 'slate-react';
 import flow from 'lodash/flow';
 import { useSlateContext } from './SlateEditorContext';
@@ -74,6 +76,25 @@ const renderElement = (props: RenderElementProps) => {
   return renderElement$(props);
 };
 
+const renderPlaceholder = ({
+  attributes,
+  children,
+}: RenderPlaceholderProps) => {
+  return (
+    <DefaultPlaceholder
+      attributes={{
+        ...attributes,
+        style: {
+          ...attributes.style,
+          whiteSpace: 'nowrap',
+        },
+      }}
+    >
+      {children}
+    </DefaultPlaceholder>
+  );
+};
+
 const useIsEmptyEditor = () => {
   const editor = useSlate();
   return Editor.isEmpty(editor, editor.children[0] as Element);
@@ -109,6 +130,7 @@ const Content = flow(
   addProps({
     renderLeaf,
     renderElement,
+    renderPlaceholder,
   }),
   observer,
 )(Editable);


### PR DESCRIPTION
<!--
  Before issuing a pull request:

  - Please read our contribution guidelines (https://github.com/johnsonandjohnson/Bodiless-JS/blob/main/packages/bodiless-documentation/doc/Development/Contributing.md), especially the section on Pull Requests.
  - Please first create an issue (https://github.com/johnsonandjohnson/Bodiless-JS/issues/new). All pull requests must be linked to an issue.
-->

<!--
  IMPORTANT
  
  The pull request title will become the commit message title at merge, and
  should adhere to Angular Commit Message Conventions. Please see (https://github.com/johnsonandjohnson/Bodiless-JS/blob/main/packages/bodiless-documentation/doc/Development/Contributing.md) for details and examples.
-->

## Changes
Fix inline placeholders inside Rich Text Editors wrapping text, which made them unreadable and hard to click on.

## Test Instructions
<!-- Detailed description of how this feature was (and should be) tested
  - Setup instructions (if any)?
  - List of test cases, with steps and expected results?
  - List
-->

## Related Issues
<!--
  Link to the issue that is fixed or resolved by this PR (if there is one)
  e.g. Fixes #1234, Closes #4567

  Link to an issue that is partially addressed by this PR (if there are any)
-->

<!-- IF THIS PR INTRODUCES A BREAKING CHANGE

BREAKING CHANGE: Describe the nature of the breaking change here.

More Details about the breaking change.
-->
