### PR TITLE
Add functionality to move assets when move the page

### DIFF
--- a/packages/bodiless-backend/src/backend.js
+++ b/packages/bodiless-backend/src/backend.js
@@ -287,6 +287,7 @@ class Backend {
     this.setRoute(`${backendPrefix}/directory/child/*`, Backend.directoryChild);
     this.setRoute(`${backendPrefix}/directory/exists/*`, Backend.directoryExists);
     this.setRoute(`${backendPrefix}/file/remove/*`, Backend.removeFile);
+    this.setRoute(`${backendPrefix}/assets/remove`, Backend.removeAssets);
   }
 
   setRoute(route, action) {
@@ -752,6 +753,34 @@ class Backend {
         .catch(reason => {
           logger.log(reason);
           res.status(500).send(`${reason}`);
+        });
+    });
+  }
+
+  static removeAssets(route) {
+    route.post(async (req, res) => {
+      const {
+        body: {
+          origin
+        },
+      } = req;
+      const page = Backend.getPage(origin);
+      page.setBasePath(backendPagePath);
+
+      logger.log(`Start removing assets for:${origin}`);
+
+      const originPath = origin.replace(/\/$/, '');
+      const originStaticPath = path.join(backendStaticPath, '/images/pages', originPath);
+
+      page
+        .removePageAssets(originStaticPath)
+        .then(error => {
+          if (error) {
+            logger.log(error);
+            res.send(error);
+          } else {
+            res.send({});
+          }
         });
     });
   }

--- a/packages/bodiless-backend/src/page.js
+++ b/packages/bodiless-backend/src/page.js
@@ -406,6 +406,17 @@ class Page {
     });
     return readPromise;
   }
+
+  removePageAssets(path) {
+    return new Promise((resolve, reject) => {
+      fse.remove(path, err => {
+        if (err) {
+          reject(err);
+        }
+        resolve();
+      });
+    });
+  }
 }
 
 module.exports = Page;

--- a/packages/gatsby-theme-bodiless/src/dist/BackendClient.ts
+++ b/packages/gatsby-theme-bodiless/src/dist/BackendClient.ts
@@ -191,4 +191,12 @@ export default class BackendClient {
     const url = `${this.prefix}/move`;
     return this.post(url, payload);
   }
+
+  deleteStaticAssets(origin: string) {
+    const payload = {
+      origin,
+    };
+    const url = `${this.prefix}/assets/remove`;
+    return this.post(url, payload);
+  }
 }

--- a/packages/gatsby-theme-bodiless/src/dist/withMovePageButton.tsx
+++ b/packages/gatsby-theme-bodiless/src/dist/withMovePageButton.tsx
@@ -89,6 +89,11 @@ const movePage = async ({ origin, destination, client } : any) => {
       } catch (e: any) {
         return Promise.reject(new Error(e.message));
       }
+      try {
+        deleteResult = await handle(client.deleteStaticAssets(origin));
+      } catch (e: any) {
+        return Promise.reject(new Error(e.message));
+      }      
     } else {
       try {
         deleteResult = await handle(client.removeFile(origin));


### PR DESCRIPTION
<!--
  Before issuing a pull request:

  - Please read our contribution guidelines (https://github.com/johnsonandjohnson/Bodiless-JS/blob/main/packages/bodiless-documentation/doc/Development/Contributing.md), especially the section on Pull Requests.
  - Please first create an issue (https://github.com/johnsonandjohnson/Bodiless-JS/issues/new). All pull requests must be linked to an issue.
-->

<!--
  IMPORTANT
  
  The pull request title will become the commit message title at merge, and
  should adhere to Angular Commit Message Conventions. Please see (https://github.com/johnsonandjohnson/Bodiless-JS/blob/main/packages/bodiless-documentation/doc/Development/Contributing.md) for details and examples.
-->

## Changes
<!-- Brief description of the changes introduced by this PR -->

- A feature that enable when a page is moved, related assets will move as well.

## Test Instructions
<!-- Detailed description of how this feature was (and should be) tested
  - Setup instructions (if any)?
  - List of test cases, with steps and expected results?
  - List
-->

## Related Issues
Issue [#1198](https://github.com/johnsonandjohnson/Bodiless-JS/issues/1198)
<!--
  Link to the issue that is fixed or resolved by this PR (if there is one)
  e.g. Fixes #1234, Closes #4567

  Link to an issue that is partially addressed by this PR (if there are any)
-->

<!-- IF THIS PR INTRODUCES A BREAKING CHANGE

BREAKING CHANGE: Describe the nature of the breaking change here.

More Details about the breaking change.
-->
