### PR TITLE
fix(gatsby-theme-bodiless): Fix missing babel-plugin-preval dependency

### DIFF
--- a/packages/gatsby-theme-bodiless/package.json
+++ b/packages/gatsby-theme-bodiless/package.json
@@ -64,6 +64,7 @@
     "@types/walk": "^2.3.0",
     "autoprefixer": "^9.8.6",
     "axios": "^0.21.0",
+    "babel-plugin-preval": "5.0.0",
     "crypto-browserify": "^3.12.0",
     "debug": "^4.1.1",
     "dotenv": "^8.2.0",
@@ -107,7 +108,6 @@
     "walkdir": "^0.4.1"
   },
   "devDependencies": {
-    "babel-plugin-preval": "5.0.0",
     "tailwindcss": "^2.0.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
<!--
  Before issuing a pull request:

  - Please read our contribution guidelines (https://github.com/johnsonandjohnson/Bodiless-JS/blob/main/packages/bodiless-documentation/doc/Development/Contributing.md), especially the section on Pull Requests.
  - Please first create an issue (https://github.com/johnsonandjohnson/Bodiless-JS/issues/new). All pull requests must be linked to an issue.
-->

<!--
  IMPORTANT
  
  The pull request title will become the commit message title at merge, and
  should adhere to Angular Commit Message Conventions. Please see (https://github.com/johnsonandjohnson/Bodiless-JS/blob/main/packages/bodiless-documentation/doc/Development/Contributing.md) for details and examples.
-->

## Changes
<!-- Brief description of the changes introduced by this PR -->
The `babel-plugin-preval` package was added as a dev-only dependency, but it is actually required in projects using Bodiless. This PR moves the package to the normal dependency list.
