### PR TITLE
fix(gatsby-theme-bodiless): Fix changes on bodiless packages not triggering rebuilds

### DIFF
--- a/examples/starter/gatsby-node.js
+++ b/examples/starter/gatsby-node.js
@@ -4,6 +4,7 @@
  * See: https://www.gatsbyjs.org/docs/node-apis/
  *
  */
+const glob = require('glob');
 
 /*
 * extend/mutate the webpack configuration.
@@ -14,6 +15,22 @@ exports.onCreateWebpackConfig = ({ actions, stage }) => {
   if (stage === 'build-html') {
     actions.setWebpackConfig({
       devtool: false,
+    });
+  }
+
+  if (stage === 'develop') {
+    actions.setWebpackConfig({
+      // On development, we want changes on Bodiless packages to trigger
+      // new builds. Webpack won't watch packages inside node_modules by
+      // default, so we remove the @bodiless folder from its default list.
+      //
+      // See: https://webpack.js.org/configuration/other-options/#snapshot
+      snapshot: {
+        managedPaths: glob.sync(
+          './node_modules/!(@bodiless)*', 
+          { absolute: true },
+        ),
+      },
     });
   }
 };

--- a/examples/starter/package.json
+++ b/examples/starter/package.json
@@ -39,6 +39,7 @@
     "gatsby": "~3.13.0",
     "gatsby-plugin-canonical-urls": "^3.6.0",
     "gatsby-plugin-sitemap": "^4.2.0",
+    "glob": "^7.1.6",
     "lodash": "^4.17.19",
     "ora": "^4.0.2",
     "postcss": "^8.2.4",

--- a/examples/test-site/gatsby-node.js
+++ b/examples/test-site/gatsby-node.js
@@ -7,6 +7,7 @@
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 const path = require('path');
 const fs = require('fs');
+const glob = require('glob');
 
 // Fix sourcemap issue
 // See: https://github.com/gatsbyjs/gatsby/issues/6278#issuecomment-402540404
@@ -29,6 +30,17 @@ exports.onCreateWebpackConfig = ({ stage, actions }) => {
         plugins: [new TsconfigPathsPlugin()],
         alias: reactAlias,
       },
+      // On development, we want changes on Bodiless packages to trigger
+      // new builds. Webpack won't watch packages inside node_modules by
+      // default, so we remove the @bodiless folder from its default list.
+      //
+      // See: https://webpack.js.org/configuration/other-options/#snapshot
+      snapshot: {
+        managedPaths: glob.sync(
+          './node_modules/!(@bodiless)*', 
+          { absolute: true },
+        ),
+      }
     });
   }
 };

--- a/examples/test-site/package.json
+++ b/examples/test-site/package.json
@@ -48,6 +48,7 @@
     "gatsby": "~3.13.0",
     "gatsby-plugin-canonical-urls": "^3.6.0",
     "gatsby-plugin-sitemap": "^4.2.0",
+    "glob": "^7.1.6",
     "informed": "^3.34.0",
     "lodash": "^4.17.19",
     "mobx-react-lite": "^1.3.1",

--- a/packages/gatsby-theme-bodiless/gatsby-node.js
+++ b/packages/gatsby-theme-bodiless/gatsby-node.js
@@ -281,20 +281,4 @@ exports.onCreateWebpackConfig = (
       },
     });
   }
-
-  if (stage === 'develop') {
-    actions.setWebpackConfig({
-      // On development, we want changes on Bodiless packages to trigger
-      // new builds. Webpack won't watch packages inside node_modules by
-      // default, so we remove the @bodiless folder from its default list.
-      //
-      // See: https://webpack.js.org/configuration/other-options/#snapshot
-      snapshot: {
-        managedPaths: glob.sync(
-          './node_modules/!(@bodiless)*', 
-          { absolute: true }
-        ),
-      }
-    });
-  }
 };

--- a/packages/gatsby-theme-bodiless/gatsby-node.js
+++ b/packages/gatsby-theme-bodiless/gatsby-node.js
@@ -25,7 +25,6 @@ const { createFilePath } = require('gatsby-source-filesystem');
 const { onCreateNode, createSlug } = require('./create-node');
 const createRedirectAlias = require('./create-redirect-alias');
 const Logger = require('./Logger');
-const glob = require('glob');
 
 const logger = new Logger('gatsby');
 

--- a/packages/gatsby-theme-bodiless/gatsby-node.js
+++ b/packages/gatsby-theme-bodiless/gatsby-node.js
@@ -20,13 +20,12 @@
  */
 const pathUtil = require('path');
 const fs = require('fs');
-
 const { getDisabledPages } = require('@bodiless/components/node-api');
 const { createFilePath } = require('gatsby-source-filesystem');
 const { onCreateNode, createSlug } = require('./create-node');
 const createRedirectAlias = require('./create-redirect-alias');
-
 const Logger = require('./Logger');
+const glob = require('glob');
 
 const logger = new Logger('gatsby');
 
@@ -280,6 +279,22 @@ exports.onCreateWebpackConfig = (
           path: require.resolve('path-browserify'),
         },
       },
+    });
+  }
+
+  if (stage === 'develop') {
+    actions.setWebpackConfig({
+      // On development, we want changes on Bodiless packages to trigger
+      // new builds. Webpack won't watch packages inside node_modules by
+      // default, so we remove the @bodiless folder from its default list.
+      //
+      // See: https://webpack.js.org/configuration/other-options/#snapshot
+      snapshot: {
+        managedPaths: glob.sync(
+          './node_modules/!(@bodiless)*', 
+          { absolute: true }
+        ),
+      }
     });
   }
 };


### PR DESCRIPTION
<!--
  Before issuing a pull request:

  - Please read our contribution guidelines (https://github.com/johnsonandjohnson/Bodiless-JS/blob/main/packages/bodiless-documentation/doc/Development/Contributing.md), especially the section on Pull Requests.
  - Please first create an issue (https://github.com/johnsonandjohnson/Bodiless-JS/issues/new). All pull requests must be linked to an issue.
-->

<!--
  IMPORTANT
  
  The pull request title will become the commit message title at merge, and
  should adhere to Angular Commit Message Conventions. Please see (https://github.com/johnsonandjohnson/Bodiless-JS/blob/main/packages/bodiless-documentation/doc/Development/Contributing.md) for details and examples.
-->

## Changes
<!-- Brief description of the changes introduced by this PR -->
This fixes the problem which made Webpack not trigger new builds when changing files outside the current site folder, eg. a package file.

Webpack 5 implemented a new optimization to ignore "immutable" folders when watching for changes. By default, everything inside `node_modules` is ignored, since files inside this folder don't normally change. This overrides the default by ignoring all folders inside `node_modules`, except the `@bodiless` folder.

## Test Instructions
<!-- Detailed description of how this feature was (and should be) tested
  - Setup instructions (if any)?
  - List of test cases, with steps and expected results?
  - List
-->
Start a test-site or starter server, wait for the build to finish and change any TS file inside any Bodiless package. The server should trigger a new build automatically, as expected.
