### PR TITLE
bugfix(gatsby-theme): Fix Context Menu Type Import

### DIFF
--- a/packages/gatsby-theme-bodiless/src/dist/useGitButtons.tsx
+++ b/packages/gatsby-theme-bodiless/src/dist/useGitButtons.tsx
@@ -16,6 +16,7 @@
 import React, {
   useState, useEffect, useCallback, useMemo,
 } from 'react';
+<<<<<<< Updated upstream:packages/gatsby-theme-bodiless/src/dist/useGitButtons.tsx
 import {
   contextMenuForm,
   getUI,
@@ -27,6 +28,16 @@ import {
   useGetter,
 } from '@bodiless/core';
 import BackendClient from './BackendClient';
+=======
+import type { TMenuOption } from '../Types/ContextMenuTypes';
+import ContextSubMenu from '../ContextMenu/ContextSubMenu';
+import { useRegisterMenuOptions } from '../PageContextProvider';
+import { contextMenuForm } from '../contextMenuForm';
+import { getUI } from '../components';
+import { useEditContext, useGetter } from '../hooks';
+import { useNotify } from '../NotificationProvider';
+import { BodilessBackendClient } from '../BackendClient';
+>>>>>>> Stashed changes:packages/bodiless-core/src/Git/useGitButtons.tsx
 import CommitsList from './CommitsList';
 import RemoteChanges from './RemoteChanges';
 import Reset from './Reset';


### PR DESCRIPTION
## Overview
Setup breaking due to wrong context menu type import on git buttons.

## Changes
Update import path from "types" to "Types".

## Test Instructions
N/A.

## Related Issues
N/A.