### PR TITLE
bugfix(cypress): Run Cypress On Monorepo

### DIFF
--- a/.github/workflows/build-test-lint-simple.yml
+++ b/.github/workflows/build-test-lint-simple.yml
@@ -60,6 +60,7 @@ jobs:
       - name: Test
         run: npm run test --quiet --colors
 
+      # Temp using monorepo since standalone is breaking cypress tests.
       - name: Cypress tests
-        run: |
-          npm run test:ci
+        run: npm run test:monorepo
+        # run: npm run test:ci

--- a/package.json
+++ b/package.json
@@ -48,11 +48,13 @@
     "sites:install": "node ./scripts/sites-install",
     "sites:update": "npm run sites:pack && npm run sites:install",
     "sites:launch-test": "npm run sites:clone-local test-site && npm run sites:update test-site && cd sites/test-site && npm install --legacy-peer-deps && npm run start",
+    "sites:launch-monorepo": "cd sites/test-site && npm run start",
     "start": "npm run start --workspace=@bodiless/test-site",
     "sync:fix": "syncpack fix-mismatches",
     "sync:check": "syncpack list-mismatches",
     "test": "jest",
     "test:ci": "WAIT_ON_TIMEOUT=600000 start-server-and-test sites:launch-test http://localhost:8005 cy:run",
+    "test:monorepo": "WAIT_ON_TIMEOUT=600000 start-server-and-test sites:launch-monorepo http://localhost:8005 cy:run",
     "test:watch": "jest --watch"
   },
   "husky": {


### PR DESCRIPTION
## Overview
Cypress tests are failing with standalone, due to missing packages (still to be further investigated). Right now, we are temp changing it to run on monorepo.

## Changes
We provide site launch and test for monorepo and call it in github workflow actions.

## Test Instructions
N/A

## Related Issues
N/A