### PR TITLE
bugfix(cs-perf): Temp Fix For CS Perf Issues

### DIFF
--- a/sites/test-site/src/data/pages/cs-perf/heavy.tsx
+++ b/sites/test-site/src/data/pages/cs-perf/heavy.tsx
@@ -43,6 +43,11 @@ export const heavyDesign = varyDesigns(
   createTextDesign(5),
 );
 
+// @TODO: Investigate withDesign performance.
+// With old withDesign implementation, every call passing heavyDesign takes less than 1ms
+// To process, but the new implementation after upgrade deps takes more than 500ms in average.
+export const withHeavyDesign = withDesign(heavyDesign);
+
 export const withPrunedDesign: HOC = Component => {
   const WithPrunedDesign: FC<any> = props => {
     const { design } = props;
@@ -54,7 +59,7 @@ export const withPrunedDesign: HOC = Component => {
 
 export const createHeavyFlowContainer = (n: number = 1) => flowHoc(
   // withPrunedDesign,
-  withDesign(heavyDesign),
+  withHeavyDesign,
   withNodeKey(`fc-${n}`),
   addProps({ key: `fc-${n}` }),
   withParent(Div),
@@ -66,7 +71,7 @@ export const createHeavyFlowContainer = (n: number = 1) => flowHoc(
 export const createHeavyChameleon = (n: number = 1) => flowHoc(
   asBodilessChameleon(`chameleon-${n}`),
   // withPrunedDesign,
-  withDesign(heavyDesign),
+  withHeavyDesign,
   addProps({ key: `chameleon-${n}` }),
 )(Box);
 


### PR DESCRIPTION
## Overview
/cs-perf page is taking too long to load: every chameleon and flow container component is taking between 0.5s and 1s to process in the upgrade deps branch, as it takes around **0.5ms** for each component in the main branch. In the end, in average:
| Component                 | Upgrade Branch  | Main Branch |
| ----------------------------- | ----------------------- | ---------------- |
| Chameleon (20x)        |              18006ms |            12ms |
| Flow Containers (20x) |             12826ms |              8ms |

**Note:** Also, in the upgrade branch, after chameleons are processed, there is a delay of ~30 seconds before flow containers start processing (not noticeable on the main branch), which means it takes around one whole minute to process all chameleon/flow container components.

After some investigation, it has been noted that this difference in time between upgrade and main branches might be related to withDesign call (see lines [57](https://github.com/johnsonandjohnson/Bodiless-JS/blob/chore/upgrade-deps/sites/test-site/src/data/pages/cs-perf/heavy.tsx#L57) and [69](https://github.com/johnsonandjohnson/Bodiless-JS/blob/chore/upgrade-deps/sites/test-site/src/data/pages/cs-perf/heavy.tsx#L69)). Vary designs (line [38](https://github.com/johnsonandjohnson/Bodiless-JS/blob/chore/upgrade-deps/sites/test-site/src/data/pages/cs-perf/heavy.tsx#L38)) is creating more than 1500 and for some reason, after withDesign refactoring, it's consuming more significant time to process the heavy designs (if we comment lines 43, createTextDesign, for example, the total variations decrease to less than 1000 thousand and the impact on performance is much smaller):

| Function call | Upgrade Branch  | Main Branch |
| ----------------- | ----------------------- | ---------------- |
| varyDesigns | 1190ms | 750ms |
| withDesign(heavyDesign) | 757ms | below 1ms |

## Changes
To real fix the issue, some investigation is required for withDesign. It seems the more variations are passed, time consuming grows exponentially. Right now, for a temp fix on the page, we can create a constant to save all return of withDesign(heavyDesign), which means it will take only 0.8ms and add it to the chameleon and flow container hocs, instead of calling withDesign everytime a new component is created.

## Test Instructions
N/A

## Related Issues
N/A