### PR TITLE
bugfix(cypress-image-is-visible): Revert isImageVisible and Comments

### DIFF
--- a/cypress/integration/smokeTest/cards_spec.js
+++ b/cypress/integration/smokeTest/cards_spec.js
@@ -86,9 +86,10 @@ describe('Card testing', function () {
     cy.xpath(imageIconXpath)
       .click();
     const imagePath = `${imagesFolderPath}/${imageNameOriginal}`;
-    cy.fixture(imagePath).then(fileContent => {
-      cy.get('input[type=file]').attachFile({ fileContent, fileName: imageNameOriginal, mimeType: 'image/jpeg' });
-    })
+    cy.get('input[type="file"]').attachFile(
+      { filePath: imagePath, mimeType: 'image/jpeg'},
+      { subjectType: 'drag-n-drop' },
+    );
     cy.wait(3000);
     cy.xpath(checkmarkIconImageFormXpath)
       .click();
@@ -118,7 +119,7 @@ describe('Card testing', function () {
     cy.xpath(imagePlaceholderXpath)
       .should('have.attr', 'src')
       .and('match', imageOrigPathRegex);
-    // cy.isImageVisible(imagePlaceholderXpath);
+    cy.isImageVisible(imagePlaceholderXpath);
     cy.xpath(imagePlaceholderXpath)
       .should('have.attr', 'alt', imageAltText);
     cy.xpath(imageLinkXpath)
@@ -141,7 +142,7 @@ describe('Card testing', function () {
     cy.xpath(imagePlaceholderXpath)
       .should('have.attr', 'src')
       .and('match', imageOrigPathRegex);
-    // cy.isImageVisible(imagePlaceholderXpath);
+    cy.isImageVisible(imagePlaceholderXpath);
     cy.xpath(imagePlaceholderXpath)
       .should('have.attr', 'alt', imageAltText);
     cy.xpath(imageLinkXpath)
@@ -191,9 +192,10 @@ describe('Card testing', function () {
     cy.xpath(altFieldXpath)
       .type(editedPostfix);
     const imagePath = `${imagesFolderPath}/${imageNameUpdated}`;
-    cy.fixture(imagePath).then(fileContent => {
-      cy.get('input[type=file]').attachFile({ fileContent, fileName: imageNameUpdated, mimeType: "image/jpeg" });
-    })
+    cy.get('input[type=file]').attachFile(
+      { filePath: imagePath, mimeType: 'image/jpeg' },
+      { subjectType: 'drag-n-drop' },
+    );
     cy.wait(3000);
     cy.xpath(checkmarkIconImageFormXpath)
       .click();
@@ -212,7 +214,7 @@ describe('Card testing', function () {
     cy.xpath(imagePlaceholderXpath)
       .should('have.attr', 'src')
       .and('match', imageUpdPathRegex);
-    // cy.isImageVisible(imagePlaceholderXpath);
+    cy.isImageVisible(imagePlaceholderXpath);
     cy.xpath(imagePlaceholderXpath)
       .should('have.attr', 'alt', imageAltText + editedPostfix);
     cy.xpath(ctaButtonXpath)
@@ -235,7 +237,7 @@ describe('Card testing', function () {
     cy.xpath(imagePlaceholderXpath)
       .should('have.attr', 'src')
       .and('match', imageUpdPathRegex);
-    // cy.isImageVisible(imagePlaceholderXpath);
+    cy.isImageVisible(imagePlaceholderXpath);
     cy.xpath(imagePlaceholderXpath)
       .should('have.attr', 'alt', imageAltText + editedPostfix);
     cy.xpath(imageLinkXpath)

--- a/cypress/integration/smokeTest/pdp_spec.js
+++ b/cypress/integration/smokeTest/pdp_spec.js
@@ -104,16 +104,17 @@ describe('PDP (Product Details Page) smoke tests', function () {
     cy.xpath(imageIconXpath)
       .click();
     const imagePath = `${imagesFolderPath}/${imageName}`;
-    cy.fixture(imagePath).then(fileContent => {
-      cy.get('input[type=file]').attachFile({ fileContent, fileName: imageName, mimeType: "image/jpeg" });
-    })
+    cy.get('input[type="file"]').attachFile(
+      { filePath: imagePath, mimeType: 'image/jpeg' },
+      { subjectType: 'drag-n-drop' },
+    );
     cy.wait(3000);
     cy.xpath(checkmarkIconImageFormXpath)
       .click();
     cy.xpath(imagePlaceholderXpath)
       .should('have.attr', 'src')
       .and('match', imagePathRegex);
-    // cy.isImageVisible(imagePlaceholderXpath);
+    cy.isImageVisible(imagePlaceholderXpath);
   })
 
 
@@ -135,7 +136,7 @@ describe('PDP (Product Details Page) smoke tests', function () {
     cy.xpath(imagePlaceholderXpath)
       .should('have.attr', 'src')
       .and('match', imagePathRegex);
-    // cy.isImageVisible(imagePlaceholderXpath);
+    cy.isImageVisible(imagePlaceholderXpath);
   })
 
 
@@ -148,7 +149,7 @@ describe('PDP (Product Details Page) smoke tests', function () {
     cy.xpath(imagePlaceholderXpath)
       .should('have.attr', 'src')
       .and('match', imagePathRegex);
-    // cy.isImageVisible(imagePlaceholderXpath);
+    cy.isImageVisible(imagePlaceholderXpath);
     cy.xpath(flexboxXpath)
       .should('be.visible');
   })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -17,7 +17,7 @@
 // create various custom commands and overwrite
 // existing commands.
 //
-// For more comprehensive sites of custom
+// For more comprehensive examples of custom
 // commands please read more here:
 // https://on.cypress.io/custom-commands
 // ***********************************************

--- a/packages/bodiless-backend/__tests__/fixtures/git/get-changes/hooks/prepare-commit-msg.sample
+++ b/packages/bodiless-backend/__tests__/fixtures/git/get-changes/hooks/prepare-commit-msg.sample
@@ -9,7 +9,7 @@
 #
 # To enable this hook, rename this file to "prepare-commit-msg".
 
-# This hook includes three sites. The first one removes the
+# This hook includes three examples. The first one removes the
 # "# Please enter the commit message..." help message.
 #
 # The second includes the output of "git diff --name-status -r"

--- a/packages/bodiless-backend/__tests__/fixtures/git/get-conflicts/hooks/prepare-commit-msg.sample
+++ b/packages/bodiless-backend/__tests__/fixtures/git/get-conflicts/hooks/prepare-commit-msg.sample
@@ -9,7 +9,7 @@
 #
 # To enable this hook, rename this file to "prepare-commit-msg".
 
-# This hook includes three sites. The first one removes the
+# This hook includes three examples. The first one removes the
 # "# Please enter the commit message..." help message.
 #
 # The second includes the output of "git diff --name-status -r"

--- a/packages/bodiless-core-ui/src/LocalContextMenu.tsx
+++ b/packages/bodiless-core-ui/src/LocalContextMenu.tsx
@@ -44,7 +44,7 @@ const groupClasses = 'bl-px-3';
 // eslint-disable-next-line max-len
 // const groupClasses = 'bl-border-t first:bl-border-t-0 bl-border-white bl-mt-grid-2 first:bl-mt-grid-0';
 
-// For accessibility attributes, see https://www.w3.org/TR/wai-aria-practices/sites/toolbar/toolbar.html
+// For accessibility attributes, see https://www.w3.org/TR/wai-aria-practices/examples/toolbar/toolbar.html
 const Toolbar = flow(
   addClasses(toolbarClasses),
   addProps({ role: 'toolbar', 'aria-label': 'Local Context Menu' }),

--- a/sites/test-site/src/data/pages/chameleon/index.tsx
+++ b/sites/test-site/src/data/pages/chameleon/index.tsx
@@ -314,7 +314,7 @@ export default (props: any) => (
     <Layout>
       <H1>Chameleon</H1>
       <p>
-        The sites below show different uses of the Bodiess &quot;Chameleon&quot;
+        The examples below show different uses of the Bodiess &quot;Chameleon&quot;
         component.
         Note: the layout of this whole page is also a chameleon! You can select
         different layouts by clicking the &quot;Page&quot; button on the toolbar


### PR DESCRIPTION
## Overview
Cypress isImageVisible calls are commented out and some strings of "examples" have been replaced with "sites".

## Changes
Reverted back isImageVisible calls and updated attachFile function since it has been changed a little after cypress upload.
Also, replaced some occurrences of "sites" to "examples".

## Test Instructions
N/A

## Related Issues
N/A