### PR TITLE
fix(starter, gatsby-theme): missing server and other gatsby start warnings on starter.

### DIFF
--- a/packages/gatsby-theme-bodiless/gatsby-node.js
+++ b/packages/gatsby-theme-bodiless/gatsby-node.js
@@ -45,10 +45,6 @@ exports.onCreateBabelConfig = args => {
     options: { legacy: true },
   });
   setBabelPlugin({
-    name: '@babel/plugin-proposal-class-properties',
-    options: { loose: false },
-  });
-  setBabelPlugin({
     name: 'babel-plugin-preval',
   });
 };

--- a/sites/__cxstarter__/package.json
+++ b/sites/__cxstarter__/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.9.0",
+    "@bodiless/backend": "^0.3.7",
     "@bodiless/__cxstarter__": "^0.3.7",
     "@bodiless/components": "^0.3.7",
     "@bodiless/core": "^0.3.7",


### PR DESCRIPTION
## Chantes
- Add bodiless backend as a dependencey of starter (solves cannot find server.js)
- remove unnecessary babel plugin (solves numerous console warnings during build)