### PR TITLE
docs(bodiless-documentation): Update release process for version 1.x

### DIFF
--- a/packages/bodiless-documentation/doc/Development/Release/README.md
+++ b/packages/bodiless-documentation/doc/Development/Release/README.md
@@ -1,56 +1,114 @@
 # Releases
 
-> While we adhere to the principles of
-[Semantic Versioning](https://semver.org/), please note that we are currently in
-["Major Version Zero"](https://semver.org/#spec-item-4) status, meaning that
-*stability or backwards compatibility is not guaranteed.*,
+?> We adhere to the principles of [Semantic Versioning](https://semver.org/ ':target=_blank').
 
-## 0.x Versions
+<!-- tabs:start -->
 
-- All Bodiless packages will maintain a common version line at `0.y.z`.
-- New "patch" versions (0.y.**Z**) will be published every two weeks, coinciding
-  with our internal sprint cadence.
-- In exceptional circumstances (critical bugfixes), we may publish a new version
-  mid-sprint.
-- New "minor" versions (0.**Y**.0) will be released periodically as we hit major
-  milestones on our roadmap.
+## **`1.x` Versions**
 
-### 0.x Release Process
+- All Bodiless packages will maintain a common version line at `1.y.z`.
+- New "patch" versions (`1.y.Z`) will be published every two weeks, coinciding with our internal
+  sprint cadence.
+- In exceptional circumstances (critical bugfixes), we may publish a new version mid-sprint.
+- New "minor" versions (`1.Y.0`) will be released periodically as we hit major milestones on our
+  roadmap.
 
-At end of Sprint, a new 0.0.x package version should be published as follows.
+## `1.x` Release Process
 
-1. Take a fresh clone of the reposotory.
-1. Checkout ```release``` branch, eg:
-   ```
+At the end of the Sprint, a new `1.x` package version should be published as follows:
+
+01. Create a fresh clone of the repository.
+01. Checkout the release branch, e.g.:
+   ```shell-session
    git checkout -b release origin/release
    ```
-1. Merge in latest commits from main
-   ```
+01. Merge in the latest commits from `main`.
+   ```shell-session
    git merge main
    ```
-1. Initialize all dependencies and build the project:
-   ```
+01. Initialize all dependencies, and build the project.
+   ```shell-session
    npm run setup
    npm run build
    ```
-1. Publish packages with patch version update.
-   ```
+01. Publish packages with the patch version update.
+   ```shell-session
    npm run publish:patch
    ```
-1. Update dependencies in `package-lock.json` for each example site by following [these steps](../Release/UpdatePackages?id=updating-example-sites39-package-lockjson).
-1. Create a PR to main from the ```release``` branch.  PR title should be, eg:
-   ```
-   chore: Release v0.0.45
-   ```
-    Commits in the PR should not be squashed since the tag is already attached to the appropriate commit hash.
+01. Update the dependencies in `package-lock.json` for each example site by following [these
+    steps](../Release/UpdatePackages#updating-example-sites39-package-lockjson).
+01. Create a PR to `main` from the release branch.
+    - The PR title should emulate the following form:
+      ```
+      chore: Release v1.0.45
+      ```
+    - Commits in the PR should _not_ be squashed, since the tag is already attached to the
+      appropriate commit hash.
 
-> Ensure that you do not squash/merge the release branch, You must use the
+!> **IMPORTANT:** Ensure that you **do not squash/merge the release branch**. You _must_ use the
    "fast-forward" merge strategy.
 
-#### Notes:
-- We specify an explicit version number because we are in pre-1.0, so the
-  normal semver bumps which would be created by conventional-commits are not
-  appropriate. We use the `--conventional-commits` option to generate the
-  changelog.
-- We push the commit to a release branch which must be merged to main using
-  the standard PR process.
+### Notes
+
+- We use the `--conventional-commits` option to generate the changelog.
+- We push the commit to a release branch, which must be merged to `main` using the standard PR
+  process.
+
+## **`0.x` Versions**
+
+?> While we adhere to the principles of [Semantic Versioning](https://semver.org/ ':target=_blank'),
+please note that `0.x` versions of BodilessJS were developed under ["Major Version
+Zero"](https://semver.org/#spec-item-4 ':target=_blank') status, meaning that _stability and
+backwards compatibility is not guaranteed_ for those versions.
+
+- All Bodiless packages will maintain a common version line at `0.y.z`.
+- New "patch" versions (`0.y.Z`) will be published every two weeks, coinciding with our internal
+  sprint cadence.
+- In exceptional circumstances (critical bugfixes), we may publish a new version mid-sprint.
+- New "minor" versions (`0.Y.0`) will be released periodically as we hit major milestones on our
+  roadmap.
+
+## `0.x` Release Process
+
+At the end of the Sprint, a new `0.x` package version should be published as follows:
+
+01. Create a fresh clone of the repository.
+01. Checkout the release branch, e.g.:
+   ```shell-session
+   git checkout -b release origin/release
+   ```
+01. Merge in the latest commits from `main`.
+   ```shell-session
+   git merge main
+   ```
+01. Initialize all dependencies, and build the project.
+   ```shell-session
+   npm run setup
+   npm run build
+   ```
+01. Publish packages with the patch version update.
+   ```shell-session
+   npm run publish:patch
+   ```
+01. Update the dependencies in `package-lock.json` for each example site by following [these
+    steps](../Release/UpdatePackages#updating-example-sites39-package-lockjson).
+01. Create a PR to `main` from the release branch.
+    - The PR title should emulate the following form:
+      ```
+      chore: Release v0.0.45
+      ```
+    - Commits in the PR should _not_ be squashed, since the tag is already attached to the
+      appropriate commit hash.
+
+!> **IMPORTANT:** Ensure that you **do not squash/merge the release branch**. You _must_ use the
+   "fast-forward" merge strategy.
+
+### Notes
+
+- We specify an explicit version number because we are in pre-`1.0`, so the normal semver bumps
+  which would be created by conventional-commits are not appropriate. We use the
+  `--conventional-commits` option to generate the changelog.
+- We push the commit to a release branch, which must be merged to `main` using the standard PR
+  process.
+
+<!-- tabs:end -->


### PR DESCRIPTION
## Changes

* Draft version `1.x` release process.
* Move version `0.x` release process to its own tab.

---

Resolves #1481 