### PR TITLE
feat(gatsby-theme-bodiless): Replace crypto-browserify with crypto-js

### DIFF
--- a/packages/bodiless-backend/package.json
+++ b/packages/bodiless-backend/package.json
@@ -15,6 +15,7 @@
     "@bodiless/cli": "^1.0.0-beta.4",
     "body-parser": "^1.18.3",
     "copyfiles": "^2.1.1",
+    "crypto-js": "^4.1.1",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "formidable": "^1.2.1",
@@ -32,6 +33,7 @@
   "author": "Dewen Li <dli94@its.jnj.com>",
   "license": "Apache-2.0",
   "devDependencies": {
+    "@types/crypto-js": "4.1.1",
     "@types/supertest": "^2.0.8",
     "morgan": "^1.9.1",
     "morgan-body": "^2.4.8",

--- a/packages/bodiless-backend/src/fileHelper.js
+++ b/packages/bodiless-backend/src/fileHelper.js
@@ -15,7 +15,7 @@
 const fs = require('fs');
 const fse = require('fs-extra');
 const path = require('path');
-const crypto = require('crypto');
+const MD5 = require('crypto-js/md5');
 
 const backendStaticPath = process.env.BODILESS_BACKEND_STATIC_PATH || '';
 
@@ -27,7 +27,7 @@ const copyFilePromise = (from, to) => new Promise((resolve, reject) => {
   });
 });
 
-const generateHash = str => crypto.createHash('md5').update(str).digest('hex');
+const generateHash = str => MD5(str).toString();
 
 const isImage = fileType => {
   const imageFileTypes = [

--- a/packages/bodiless-backend/src/fileHelper.js
+++ b/packages/bodiless-backend/src/fileHelper.js
@@ -15,7 +15,7 @@
 const fs = require('fs');
 const fse = require('fs-extra');
 const path = require('path');
-const MD5 = require('crypto-js/md5');
+const crypto = require('crypto-js');
 
 const backendStaticPath = process.env.BODILESS_BACKEND_STATIC_PATH || '';
 
@@ -27,7 +27,7 @@ const copyFilePromise = (from, to) => new Promise((resolve, reject) => {
   });
 });
 
-const generateHash = str => MD5(str).toString();
+const generateHash = str => crypto.MD5(str).toString();
 
 const isImage = fileType => {
   const imageFileTypes = [

--- a/packages/bodiless-layouts/package.json
+++ b/packages/bodiless-layouts/package.json
@@ -41,6 +41,7 @@
     "@bodiless/core": "^1.0.0-beta.4",
     "@bodiless/fclasses": "^1.0.0-beta.4",
     "axios": "^0.21.0",
+    "crypto-js": "^4.1.1",
     "html2canvas": "^1.0.0-rc.3",
     "informed": "^3.34.0",
     "lodash": "^4.17.19",
@@ -52,6 +53,7 @@
     "uuid": "^3.3.2"
   },
   "devDependencies": {
+    "@types/crypto-js": "4.1.1",
     "@types/rc-tooltip": "^3.7.1",
     "enzyme": "^3.9.0"
   }

--- a/packages/bodiless-layouts/src/FlowContainer/EditFlowContainer.tsx
+++ b/packages/bodiless-layouts/src/FlowContainer/EditFlowContainer.tsx
@@ -13,7 +13,7 @@
  */
 
 import React, { FC } from 'react';
-import { createHash } from 'crypto';
+import MD5 from 'crypto-js/md5';
 import { arrayMove, SortEnd } from 'react-sortable-hoc';
 import { observer } from 'mobx-react';
 import flowRight from 'lodash/flowRight';
@@ -59,7 +59,7 @@ const withKeyFromDesign = (Component: ComponentOrTag<any>) => {
       return <Component {...props} />;
     }
     const json = JSON.stringify(Object.keys(design).sort());
-    const key = createHash('md5').update(json).digest('hex');
+    const key = MD5(json).toString();
     return <Component {...props} key={key} />;
   };
   return WithKeyFromDesign;

--- a/packages/bodiless-layouts/src/deserializers/createFlowContainerItem.ts
+++ b/packages/bodiless-layouts/src/deserializers/createFlowContainerItem.ts
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-import { createHash } from 'crypto';
+import MD5 from 'crypto-js/md5';
 
 export type FlowContainerItem = {
   uuid: string,
@@ -30,9 +30,8 @@ export type CreateFlowContainerItem = (args: CreateFlowContainerItemArgs) => Flo
 export const generateUuid = (
   content: string,
   index: number,
-) => createHash('md5')
-  .update(JSON.stringify({ content, index }))
-  .digest('hex');
+) => MD5(JSON.stringify({ content, index }))
+  .toString();
 
 export const createFlowContainerItem: CreateFlowContainerItem = ({
   type,

--- a/packages/bodiless-tokens/package.json
+++ b/packages/bodiless-tokens/package.json
@@ -35,10 +35,14 @@
     "@bodiless/fclasses": "^1.0.0-beta.4",
     "@bodiless/layouts": "^1.0.0-beta.4",
     "@bodiless/layouts-ui": "^1.0.0-beta.4",
+    "crypto-js": "^4.1.1",
     "informed": "^3.34.0",
     "lodash": "^4.17.19",
     "md5-hex": "^4.0.0",
     "uuid": "^3.3.2"
+  },
+  "devDependencies": {
+    "@types/crypto-js": "4.1.1"
   },
   "peerDependencies": {
     "mobx-react": "^7.2.1",

--- a/packages/bodiless-tokens/src/TokenEditor/withTokenEditorComponent.tsx
+++ b/packages/bodiless-tokens/src/TokenEditor/withTokenEditorComponent.tsx
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-import { createHash } from 'crypto';
+import MD5 from 'crypto-js/md5';
 import {
   addClasses, withDesign, HOC,
   addProps, flowHoc, startWith, Design,
@@ -36,7 +36,7 @@ import { TokenEditorComponentDef } from './types';
  */
 const useNodeKeyHash = () => {
   const { node } = useNode();
-  return createHash('md5').update(node.path.join('$')).digest('hex');
+  return MD5(node.path.join('$')).toString();
 };
 
 /**

--- a/packages/bodiless-tokens/src/withTokenSelector.tsx
+++ b/packages/bodiless-tokens/src/withTokenSelector.tsx
@@ -13,7 +13,7 @@
  */
 
 import React, { ComponentType, FC } from 'react';
-import { createHash } from 'crypto';
+import MD5 from 'crypto-js/md5';
 import {
   useMenuOptionUI, WithNodeKeyProps, withNodeKey, withNode, ifEditable,
   withLocalContextMenu, withContextActivator, withEditButton, withNodeDataHandlers,
@@ -141,7 +141,7 @@ export const withKeyFromData = <P extends { componentData: any }>(Component: Com
   const WithKeyFromData = (props: P) => {
     const { componentData } = props;
     const json = JSON.stringify(componentData);
-    const key = createHash('md5').update(json).digest('hex');
+    const key = MD5(json).toString();
     return <Component {...props} key={key} />;
   };
   return WithKeyFromData;

--- a/packages/gatsby-theme-bodiless/create-node.js
+++ b/packages/gatsby-theme-bodiless/create-node.js
@@ -17,7 +17,7 @@
 
 const pathUtil = require('path');
 const slash = require('slash');
-const crypto = require('crypto');
+const MD5 = require('crypto-js/md5');
 const fs = require('fs');
 const fse = require('fs-extra');
 const md5File = require('md5-file');
@@ -157,10 +157,8 @@ const addSlugField = ({ node, getNode, actions }) => {
   });
 };
 
-const generateStringDigest = content => crypto
-  .createHash('md5')
-  .update(content)
-  .digest('hex');
+const generateStringDigest = content => MD5(content)
+  .toString();
 
 const generateFileDigest = absolutePath => md5File.sync(absolutePath);
 

--- a/packages/gatsby-theme-bodiless/create-node.js
+++ b/packages/gatsby-theme-bodiless/create-node.js
@@ -17,7 +17,7 @@
 
 const pathUtil = require('path');
 const slash = require('slash');
-const MD5 = require('crypto-js/md5');
+const crypto = require('crypto-js');
 const fs = require('fs');
 const fse = require('fs-extra');
 const md5File = require('md5-file');
@@ -157,7 +157,7 @@ const addSlugField = ({ node, getNode, actions }) => {
   });
 };
 
-const generateStringDigest = content => MD5(content)
+const generateStringDigest = content => crypto.MD5(content)
   .toString();
 
 const generateFileDigest = absolutePath => md5File.sync(absolutePath);

--- a/packages/gatsby-theme-bodiless/gatsby-node.js
+++ b/packages/gatsby-theme-bodiless/gatsby-node.js
@@ -271,9 +271,6 @@ exports.onCreateWebpackConfig = ({
       ],
       resolve: {
         fallback: {
-          crypto: require.resolve('crypto-browserify'),
-          // stream is required for crypto
-          stream: require.resolve('stream-browserify'),
           path: require.resolve('path-browserify'),
         },
       },

--- a/packages/gatsby-theme-bodiless/package.json
+++ b/packages/gatsby-theme-bodiless/package.json
@@ -64,7 +64,7 @@
     "@types/walk": "^2.3.0",
     "autoprefixer": "^10.4.2",
     "axios": "^0.21.0",
-    "crypto-browserify": "^3.12.0",
+    "crypto-js": "^4.1.1",
     "debug": "^4.1.1",
     "dotenv": "^8.2.0",
     "fast-glob": "^3.2.5",

--- a/packages/gatsby-theme-bodiless/src/dist/DefaultContent/createPlugins.ts
+++ b/packages/gatsby-theme-bodiless/src/dist/DefaultContent/createPlugins.ts
@@ -13,9 +13,9 @@
  */
 
 import path from 'path';
-import crypto from 'crypto';
+import MD5 from 'crypto-js/md5';
 
-const hash = (name: string) => crypto.createHash('md5').update(name).digest('hex');
+const hash = (name: string) => MD5(name).toString();
 
 const createPlugins = (...paths: string[]) => paths.map(path$ => ({
   resolve: 'gatsby-source-filesystem',


### PR DESCRIPTION
## Changes
crypto-browserify bring inside the bundle a dependencies to two versions of bn.js and readable-stream, resulting in bn.js included in the bundle 6 times, readable-stream 2 times.

Instead of using crypto and then fallback it using crypto-browserify, use directly crypto-js solve the issue.

E.g. test-site bundle is reduced by 737.25 KB to 577.27 KB