### PR TITLE
feat(fclasses): asTokenSpec produces token with all domains

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -28,6 +28,7 @@ hooks:
     # Build hooks can modify the application files on disk but not access any services like databases.
     build: |
         set -e
+        export NODE_OPTIONS="--max-old-space-size=2048"
         npm run bootstrap
         npm run build:packages
         npm run build -- --scope @sites/test-site
@@ -70,7 +71,7 @@ hooks:
         node $PLATFORM_APP_DIR/packages/bodiless-psh/lib/generate-ssi-files.js deploy       
 
 # The size of the persistent disk of the application (in MB).
-disk: 320
+disk: 1024
 
 mounts:
     'volume':

--- a/packages/fclasses/__tests__/TokenSpecTypes.test.ts
+++ b/packages/fclasses/__tests__/TokenSpecTypes.test.ts
@@ -36,7 +36,7 @@ import {
 //   C extends DesignableComponents,
 //   D extends Domains<C>,
 // >() => <S extends Partial<D & ReservedDomains<C, D>>>(
-//     // s: Pick<TokenSpecIn<C, D>, K>
+//     // s: Pick<FinalDomains<C, D>, K>
 //     // s: { [k in K]: Design<C> }
 //     s: S,
 //   ): S & { [$TokenSpec]: true } => s as any;
@@ -94,10 +94,9 @@ describe('Fixed type tokens', () => {
   // Creates a token with known properties
   t.Meta;
   t.Theme;
+  t.Layout;
   // @ts-expect-error Globally undefined domain
   t.Foo;
-  // @ts-expect-error Domain which does not exist on this specific token.
-  t.Layout;
 
   // Allows all valid domains
   asTestToken({
@@ -248,10 +247,9 @@ describe('fluid tokens', () => {
   // Creates a token with known properties
   t.Meta;
   t.Theme;
+  t.Layout;
   // @ts-expect-error Globally undefined domain
   t.Foo;
-  // @ts-expect-error Domain which does not exist on this specific token.
-  t.Layout;
 
   // Allows all valid domains
   asTestToken({
@@ -310,9 +308,10 @@ describe('fluid tokens', () => {
     },
   });
 
-  // Allows tokens in Compose to have any design keys.
+  // Does not allow partial domains in compose
   asTestToken({
     Compose: {
+      // @ts-expect-error
       Composed: {
         [$TokenSpec]: true,
         Theme: {

--- a/packages/fclasses/__tests__/tokenSpec.test.tsx
+++ b/packages/fclasses/__tests__/tokenSpec.test.tsx
@@ -87,7 +87,7 @@ describe('extendMeta', () => {
 });
 
 describe('asTokenSpec', () => {
-  it.only('Does not alter tokens when extending them', () => {
+  it('Does not alter tokens when extending them', () => {
     const Inner1 = asTestTokenSpec({
       Core: {
         _: 'foo'

--- a/packages/fclasses/__tests__/tokenSpec.test.tsx
+++ b/packages/fclasses/__tests__/tokenSpec.test.tsx
@@ -16,7 +16,7 @@
 import React, { ComponentType, FC } from 'react';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { mount, shallow } from 'enzyme';
-import { identity, flow } from 'lodash';
+import { identity, flow, omit } from 'lodash';
 import {
   DesignableComponentsProps, Span, designable, Div, addClasses, removeClasses,
   withDesign, HOC, flowHoc, flowIf, withoutProps,
@@ -87,6 +87,55 @@ describe('extendMeta', () => {
 });
 
 describe('asTokenSpec', () => {
+  it.only('Does not alter tokens when extending them', () => {
+    const Inner1 = asTestTokenSpec({
+      Core: {
+        _: 'foo'
+      },
+    });
+    const Inner1Snap = JSON.stringify(Inner1);
+    const Inner2 = asTestTokenSpec({
+      Core: {
+        _: 'foo'
+      },
+    });
+    const Inner2Snap = JSON.stringify(Inner2);
+    const Outer1 = asTestTokenSpec({
+      Core: {
+        _: Inner1,
+      }
+    });
+    const Outer1Snap = JSON.stringify(Outer1);
+    const Outer2 = asTestTokenSpec({
+      Core: {
+        _: Inner2,
+      }
+    });
+    const Outer2Snap = JSON.stringify(Outer2);
+    const final = asTestTokenSpec(Outer1, Outer2);
+    console.log(Outer1, Outer2, final);
+    expect(JSON.stringify(Outer1)).toEqual(Outer1Snap);
+    expect(JSON.stringify(Outer2)).toEqual(Outer2Snap);
+    expect(JSON.stringify(Inner1)).toEqual(Inner1Snap);
+    expect(JSON.stringify(Inner2)).toEqual(Inner2Snap);
+  });
+  it('Provides missing domains', () => {
+    const test = asTestTokenSpec({
+      Behavior: {
+        A: 'foo',
+      }
+    });
+    expect(Object.keys(test)).toEqual([
+      ...Object.keys(defaultDomains),
+      'Compose', 'Flow', 'Meta',
+    ]);
+    Object.keys(omit(test, 'Flow', 'Behavior')).forEach(
+      k => expect(test[k as keyof typeof test]).toEqual({})
+    );
+    expect(test.Flow).toBeUndefined();
+    expect(test.Behavior).toEqual({ A: 'foo' });
+  });
+
   it('Properly merges nested tokens', () => {
     const nested = asTestTokenSpec({
       Layout: {

--- a/packages/fclasses/src/types.ts
+++ b/packages/fclasses/src/types.ts
@@ -233,7 +233,7 @@ export type ReservedDomains<
      * so it will not have access to any contexts or content nodes provided by
      * the token itself.
      */
-  Flow?: FlowHoc,
+  Flow?: FlowHoc|undefined,
   /**
      * Metadata which should be attached to this token (and to any component to
      * to which the token is applied).
@@ -248,12 +248,12 @@ export type ReservedDomains<
  * - A token specified as an HOC
  * - A token specified as a string of classes.
  */
-export type Token = TokenSpec<any, {}, any> | HOCBase | string | undefined;
+export type Token = TokenSpec<any, {}> | HOCBase | string | undefined;
 
 export type ComposedToken<
   C extends DesignableComponents,
   D extends object,
-> = TokenSpec<C, D, keyof D> | HOCBase | string | undefined;
+> = TokenSpec<C, D> | HOCBase | string | undefined;
 
 /**
    * Type of a collection of tokens which apply to a specific designable component.
@@ -266,7 +266,7 @@ export type TokenCollection<
   C extends DesignableComponents,
   D extends object = object,
 > = {
-  [name: string]: TokenSpec<C, D, keyof D>,
+  [name: string]: TokenSpec<C, D>,
 };
 
 export type FinalDesign<
@@ -302,16 +302,10 @@ type Domains<
   [k in keyof D]?: FinalDesign<C>
 };
 
-type FinalDomains<
+export type FinalDomains<
   C extends DesignableComponents,
   D extends object
 > = Domains<C, D> & ReservedDomains<C, D>;
-
-type TokenSpecIn<
-  C extends DesignableComponents,
-  D extends object,
-  K extends keyof (FinalDomains<C, D>) = keyof (FinalDomains<C, D>)
-> = Pick<FinalDomains<C, D>, K>;
 
 /**
    * Type of a token specification, a token expressed in the
@@ -335,31 +329,10 @@ type TokenSpecIn<
 export type TokenSpec<
   C extends DesignableComponents,
   D extends object,
-  K extends keyof (FinalDomains<C, D>) = keyof (FinalDomains<C, D>)
-> = TokenSpecIn<C, D, K> & {
+> = Required<FinalDomains<C, D>> & {
   [$TokenSpec]: true,
 };
 
-export type AsTokenSpec<C extends DesignableComponents, D extends object> = <
-  K0 extends keyof FinalDomains<C, D>,
-  K1 extends keyof FinalDomains<C, D> = never,
-  K2 extends keyof FinalDomains<C, D> = never,
-  K3 extends keyof FinalDomains<C, D> = never,
-  K4 extends keyof FinalDomains<C, D> = never,
-  K5 extends keyof FinalDomains<C, D> = never,
-  K6 extends keyof FinalDomains<C, D> = never,
-  K7 extends keyof FinalDomains<C, D> = never,
-  K8 extends keyof FinalDomains<C, D> = never,
-  K9 extends keyof FinalDomains<C, D> = never
->(
-  s0: TokenSpecIn<C, D, K0>,
-  s1?: TokenSpecIn<C, D, K1>,
-  s2?: TokenSpecIn<C, D, K2>,
-  s3?: TokenSpecIn<C, D, K3>,
-  s4?: TokenSpecIn<C, D, K4>,
-  s5?: TokenSpecIn<C, D, K5>,
-  s6?: TokenSpecIn<C, D, K6>,
-  s7?: TokenSpecIn<C, D, K7>,
-  s8?: TokenSpecIn<C, D, K8>,
-  s9?: TokenSpecIn<C, D, K9>,
-) => TokenSpec<C, D, K0 | K1 | K2 | K3 | K4 | K5 | K6 | K7 | K8 | K9>;
+export type AsTokenSpec<C extends DesignableComponents, D extends object> = (
+  ...specs: FinalDomains<C, D>[]
+) => TokenSpec<C, D>;


### PR DESCRIPTION
## Changes
- asTokenSpec now supplies empty objects for domains which are not specified in the input
- Fixes issue where tokens were altered when using asTokenSpec to extend

## Related Issues
Fixes #1496 
Closes #1525 