### PR TITLE
chore(404): fix 404 page content

### DIFF
--- a/sites/test-site/src/data/pages/404/notfound$5ba01e60-c83a-11ea-b1a8-87fb545d5688.json
+++ b/sites/test-site/src/data/pages/404/notfound$5ba01e60-c83a-11ea-b1a8-87fb545d5688.json
@@ -1,125 +1,60 @@
-{
-  "document": {
-    "object": "document",
-    "data": {},
-    "nodes": [
+[
+  {
+    "type": "H1",
+    "children": [
       {
-        "object": "block",
-        "type": "H1",
-        "data": {},
-        "nodes": [
+        "text": "Page Not Found"
+      }
+    ]
+  },
+  {
+    "type": "paragraph",
+    "children": [
+      {
+        "text": ""
+      }
+    ]
+  },
+  {
+    "type": "paragraph",
+    "children": [
+      {
+        "text": "The requested page could not be found."
+      }
+    ]
+  },
+  {
+    "type": "paragraph",
+    "children": [
+      {
+        "text": ""
+      }
+    ]
+  },
+  {
+    "type": "paragraph",
+    "children": [
+      {
+        "text": ""
+      },
+      {
+        "data": {
+          "openModal": true,
+          "slatenode": {
+            "href": "/",
+            "aria-label": "home"
+          }
+        },
+        "type": "Link",
+        "children": [
           {
-            "object": "text",
-            "leaves": [
-              {
-                "object": "leaf",
-                "text": "Page Not Found",
-                "marks": []
-              }
-            ]
+            "text": "Go to homepage"
           }
         ]
       },
       {
-        "object": "block",
-        "type": "paragraph",
-        "data": {},
-        "nodes": [
-          {
-            "object": "text",
-            "leaves": [
-              {
-                "object": "leaf",
-                "text": "",
-                "marks": []
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "object": "block",
-        "type": "paragraph",
-        "data": {},
-        "nodes": [
-          {
-            "object": "text",
-            "leaves": [
-              {
-                "object": "leaf",
-                "text": "The requested page could not be found.",
-                "marks": []
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "object": "block",
-        "type": "paragraph",
-        "data": {},
-        "nodes": [
-          {
-            "object": "text",
-            "leaves": [
-              {
-                "object": "leaf",
-                "text": "",
-                "marks": []
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "object": "block",
-        "type": "paragraph",
-        "data": {},
-        "nodes": [
-          {
-            "object": "text",
-            "leaves": [
-              {
-                "object": "leaf",
-                "text": "",
-                "marks": []
-              }
-            ]
-          },
-          {
-            "object": "inline",
-            "type": "Link",
-            "data": {
-              "openModal": false,
-              "slatenode": {
-                "href": "/"
-              }
-            },
-            "nodes": [
-              {
-                "object": "text",
-                "leaves": [
-                  {
-                    "object": "leaf",
-                    "text": "Go to homepage",
-                    "marks": []
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "object": "text",
-            "leaves": [
-              {
-                "object": "leaf",
-                "text": "",
-                "marks": []
-              }
-            ]
-          }
-        ]
+        "text": ""
       }
     ]
   }
-}
+]


### PR DESCRIPTION
Fix content of 404 page.
At some point it must have been using the old slate structure and didn't get updated on one of the upgrades.
Replaced content with valid content.