### PR TITLE
fix(test-site): use test site colors

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -47,7 +47,7 @@ Gatsby-theme-bodiless
 * Color palette changes -- 
 ** replaced -green- with -emerald-
 ** replaced -yellow- with -amber-
-** repleaced -violet- with -violet-
+** repleaced -purple- with -violet-
 ** left -gray- as -gray....
 * Class name changes -- 
 ** overflow-clip with text-clip

--- a/packages/vital-elements/doc/Tokens.md
+++ b/packages/vital-elements/doc/Tokens.md
@@ -330,7 +330,7 @@ import { brandLink } from '@canvasx/brand';
 const Base = {
   ...brandLink.Base,
   Theme: {
-    Wrapper: addClasses('text-purple'),
+    Wrapper: addClasses('text-violet'),
   },
 };
 export const siteLink = {

--- a/sites/test-site/src/data/pages/api/fclasses/index.tsx
+++ b/sites/test-site/src/data/pages/api/fclasses/index.tsx
@@ -53,7 +53,9 @@ const Button: FC = props => {
 };
 
 const StyledButton = flowHoc(
-  addClassesIf(isToggled)('bg-emerald-200'),
+  // Not converting to tailwind 3.0 bg-emerald-200 as test site
+  // overides all colors in tailwind theme.
+  addClassesIf(isToggled)('bg-green-200'),
   addClasses('border p-2 my-2'),
 )(Button);
 

--- a/sites/test-site/src/data/pages/chameleon/index.tsx
+++ b/sites/test-site/src/data/pages/chameleon/index.tsx
@@ -53,7 +53,7 @@ const BaseComponent = addClasses('border-8 py-5 text-center')(Div);
 const basicChameleonDesign = {
   Red: addClasses('border-red-500 text-red-500'),
   Blue: addClasses('border-blue-500 text-blue-500'),
-  Green: addClasses('border-emerald-500 text-emerald-500'),
+  Green: addClasses('border-green-500 text-green-500'),
 };
 
 const BasicChameleon = flowHoc(
@@ -91,7 +91,7 @@ const YellowStart = flowHoc(
       </>
     ) as ReactNode,
   }),
-  addClasses('border-amber-500 text-amber-500'),
+  addClasses('border-yellow-500 text-yellow-500'),
 )(BaseComponent);
 
 const DynamicStartChameleon = flowHoc(

--- a/sites/test-site/src/data/pages/gallery-final/Gallery.tsx
+++ b/sites/test-site/src/data/pages/gallery-final/Gallery.tsx
@@ -31,7 +31,7 @@ import CaptionedImage from './CaptionedImage';
 const asGalleryTile = addClasses('mx-2 border-8');
 
 const withBlueBorder = addClasses('border-blue-400');
-const withGreenBorder = addClasses('border-emerald-400');
+const withGreenBorder = addClasses('border-green-400');
 const withRedBorder = addClasses('border-red-400');
 
 const galleryDesign = varyDesign(


### PR DESCRIPTION


Issue: Tailwind site has defined its color and doesn't use tailwind default colors (so yellow, green & purple still exist) and shouldn't have gotten the search replacement.
* Color palette changes -- 
** replaced -green- with -emerald-
** replaced -yellow- with -amber-
** replaced -purple- with -violet-

Fix: 
- Revert emerald back to test sites color 'green' instead on test site only
- Revert amber back to test sites color 'yellow' instead on test site only

Fix will restore following issues:
- /chameleon will change to green or yellow
- /api/fclasses/ button on click will turn green
- /gallery-final/ placing a green component will have green border.

confirmed no cases of replacement in test site for
** replaced -purple- with -violet-