### PR TITLE
fix(material-icons): remove dependency on google fonts material fonts css & clean up of components.

### DIFF
--- a/packages/bodiless-accordion/src/components/Accordion.tokens.tsx
+++ b/packages/bodiless-accordion/src/components/Accordion.tokens.tsx
@@ -67,7 +67,7 @@ const asAccordionDefaultExpanded = flowHoc(
  * as well as accessibility label support
  */
 const asAccordionIcon = flowHoc(
-  addClasses('material-icons cursor-pointer right-0'),
+  addClasses('cursor-pointer right-0'),
   addProps({ 'data-accordion-element': 'accordion-icon' }),
   addPropsIf(isAccordionContracted)({ 'aria-label': 'Expand Accordion' }),
   addPropsIf(isAccordionExpanded)({ 'aria-label': 'Collapse Accordion' }),

--- a/packages/bodiless-accordion/src/components/SingleAccordion.tsx
+++ b/packages/bodiless-accordion/src/components/SingleAccordion.tsx
@@ -82,7 +82,7 @@ const SingleAccordionBase = observer(({
           tabIndex={0}
           role="button"
           onClick={toggleAccordionState}
-          className="material-icons cursor-pointer select-none"
+          className="cursor-pointer select-none"
           data-accordion-element="accordion-icon"
           data-accordion-icon={accordionState === COLLAPSED ? 'expand' : 'collapse'}
         >

--- a/packages/bodiless-components-ui/src/FileUpload.tsx
+++ b/packages/bodiless-components-ui/src/FileUpload.tsx
@@ -65,7 +65,7 @@ const Input = withForwardedRef()('input');
 const UploadArea = () => (
   <div className="bl-font-bold bl-text-base bl-text-center">
     {`${FileUploadStrings.DragOrClickToUpload}`}
-    <span className="material-icons bl-w-full">cloud_upload</span>
+    <span className="bl-material-icons bl-w-full">cloud_upload</span>
   </div>
 );
 const DragRejected = () => (

--- a/packages/bodiless-layouts-ui/src/ComponentSelector.tsx
+++ b/packages/bodiless-layouts-ui/src/ComponentSelector.tsx
@@ -123,11 +123,11 @@ export const ui: ComponentSelectorUI = {
   )(Label),
 
   AccordionIconContract: () => (
-    <span className="material-icons bl-mr-2">expand_less</span>
+    <span className="bl-material-icons bl-mr-2">expand_less</span>
   ),
 
   AccordionIconExpand: () => (
-    <span className="material-icons bl-mr-2">expand_more</span>
+    <span className="bl-material-icons bl-mr-2">expand_more</span>
   ),
 
   ComponentDescriptionWrapper: addClasses(
@@ -139,7 +139,7 @@ export const ui: ComponentSelectorUI = {
   )(Div),
 
   ComponentDescriptionIcon: addClasses(
-    'bl-absolute bl-top-grid-0 bl-right-grid-0 material-icons bl-z-20 bl-text-gray-800 bl-m-grid-1',
+    'bl-absolute bl-top-grid-0 bl-right-grid-0 bl-material-icons bl-z-20 bl-text-gray-800 bl-m-grid-1',
   )(Div),
 
   ComponentSelectButton: addClasses(
@@ -147,9 +147,9 @@ export const ui: ComponentSelectorUI = {
   )(Button),
 
   ScalingHeader: addClasses('bl-w-full bl-cursor-pointer bl-justify-end bl-text-gray-900 bl-p-grid-2 bl-flex')(Div),
-  ScalingButtonFull: (props) => <span className="material-icons"><span {...props}>view_stream</span></span>,
-  ScalingButtonHalf: (props) => <span className="material-icons"><span {...props}>view_module</span></span>,
-  ScalingButtonQuarter: (props) => <span className="material-icons"><span {...props}>view_comfy</span></span>,
+  ScalingButtonFull: (props) => <span className="bl-material-icons"><span {...props}>view_stream</span></span>,
+  ScalingButtonHalf: (props) => <span className="bl-material-icons"><span {...props}>view_module</span></span>,
+  ScalingButtonQuarter: (props) => <span className="bl-material-icons"><span {...props}>view_comfy</span></span>,
 };
 
 const ComponentSelector: FC<ComponentSelectorProps> = props => (

--- a/packages/bodiless-layouts-ui/src/DragHandle.tsx
+++ b/packages/bodiless-layouts-ui/src/DragHandle.tsx
@@ -15,7 +15,7 @@
 import React, { HTMLProps, FC } from 'react';
 
 const DragHandle: FC<HTMLProps<HTMLSpanElement>> = () => (
-  <span className="bl-absolute bl--top-grid-4 bl-text-2xl material-icons bl-cursor-move bl-text-primary">
+  <span className="bl-absolute bl--top-grid-4 bl-text-2xl bl-material-icons bl-cursor-move bl-text-primary">
     drag_handle
   </span>
 );

--- a/packages/bodiless-layouts/src/ContentLibrary/ContentLibraryIndicator.tsx
+++ b/packages/bodiless-layouts/src/ContentLibrary/ContentLibraryIndicator.tsx
@@ -58,7 +58,7 @@ export const LibraryItemIndicatorClean = designable(LibraryItemIndicatorComponen
 const asDefaultLibraryItemIndicator = withDesign({
   Wrapper: addClasses('hidden group-hover:flex bl-text-white bl-bg-gray-900 absolute bl-px-2 bl-py-1 md:-mt-5 md:-ml-5 bl-z-10'),
   Icon: flowHoc(
-    addClasses('material-icons bl-mr-2'),
+    addClasses('bl-material-icons bl-mr-2'),
     addProps({ children: 'account_balance' }),
   ),
   Label: addProps({ children: 'Library Item' }),

--- a/packages/bodiless-navigation/src/BurgerMenu/BurgerMenu.token.tsx
+++ b/packages/bodiless-navigation/src/BurgerMenu/BurgerMenu.token.tsx
@@ -19,7 +19,7 @@ import {
 import { useIsBurgerMenuVisible, useIsBurgerTransitionCompleted } from './BurgerMenuContext';
 import {
   withLightGrayBg, withNoInsetStyles, withFullWidthStyles, withFullHeightStyles,
-  asFixed, withFullZIndex, withMaterialIconsFont, withPointerCursorStyles, asDisabled,
+  asFixed, withFullZIndex, withPointerCursorStyles, asDisabled,
 } from '../token';
 
 const withSlideInOutAnimation = withDesign({
@@ -52,13 +52,12 @@ const withDefaultBackground = withDesign({
 
 /**
  * A HOC that adds styles to the Button component of Burger Menu Toggler.
- * Adds a bl-material-icon class and pointer styles.
+ * Adds pointer styles.
  *
  * @return HOC that adds styles to the Button component.
  */
 const withBurgerMenuTogglerStyles = withDesign({
   Button: flowHoc(
-    withMaterialIconsFont,
     withPointerCursorStyles,
   ),
 });

--- a/packages/bodiless-navigation/src/BurgerMenu/BurgerMenu.token.tsx
+++ b/packages/bodiless-navigation/src/BurgerMenu/BurgerMenu.token.tsx
@@ -52,7 +52,7 @@ const withDefaultBackground = withDesign({
 
 /**
  * A HOC that adds styles to the Button component of Burger Menu Toggler.
- * Adds a material-icon class and pointer styles.
+ * Adds a bl-material-icon class and pointer styles.
  *
  * @return HOC that adds styles to the Button component.
  */

--- a/packages/bodiless-navigation/src/Menu/asAccessibleMenu.tsx
+++ b/packages/bodiless-navigation/src/Menu/asAccessibleMenu.tsx
@@ -16,7 +16,7 @@ import React, {
   ComponentType, FC, useRef, useCallback, useEffect,
 } from 'react';
 import {
-  withParent, withAppendChild, useNode, useClickOutside,
+  withParent, withAppendChild, useNode, useClickOutside, withChild,
 } from '@bodiless/core';
 import { LinkData, useListContext } from '@bodiless/components';
 import {
@@ -38,6 +38,8 @@ import {
 import { useMenuContext } from './withMenuContext';
 import { useSubmenuContext } from './withMenuItemContext';
 import { DEFAULT_NODE_KEYS } from './MenuTitles';
+
+import ExpandMoreIcon from '../icons/ExpandMore';
 
 const useHasSubmenu = () => useSubmenuContext().hasSubmenu;
 const useHasLink = () => {
@@ -172,10 +174,7 @@ const SubmenuIndicator = flowHoc(
       asAccessibleSubMenuTitle,
       addClasses('flex items-center'),
     ),
-    Title: flowHoc(
-      addClasses('material-icons'),
-      addProps({ children: 'expand_more' }),
-    ),
+    Title: withChild(ExpandMoreIcon),
   }),
 )(SubmenuIndicatorClean);
 

--- a/packages/bodiless-navigation/src/icons/ExpandMore.tsx
+++ b/packages/bodiless-navigation/src/icons/ExpandMore.tsx
@@ -1,0 +1,35 @@
+/**
+ * Copyright © 2022 Johnson & Johnson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { stylable } from '@bodiless/fclasses';
+
+// Source: https://fonts.google.com/icons?selected=Material%20Icons%3Aexpand_more%3A
+const ExpandMore = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    height="24px"
+    viewBox="0 0 24 24"
+    width="24px"
+    fill="#FFFFFF"
+    {...props}
+  >
+    <path d="M0 0h24v24H0z" fill="none" />
+    <path d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z" />
+  </svg>
+);
+
+const ExpandMoreIcon = stylable(ExpandMore);
+
+export default ExpandMoreIcon;

--- a/packages/bodiless-navigation/src/token.tsx
+++ b/packages/bodiless-navigation/src/token.tsx
@@ -30,6 +30,5 @@ export const withColumnDirectionStyles = addClasses('flex-col');
 export const withLightGrayBg = addClasses('bg-gray-200');
 export const withTransformStyles = addClasses('transform');
 export const withSlideInTranslateStyles = addClasses('-translate-x-full');
-export const withMaterialIconsFont = addClasses('material-icons');
 export const withPointerCursorStyles = addClasses('cursor-pointer');
 export const asDisabled = addClasses('pointer-events-none');

--- a/packages/bodiless-organisms/src/components/SocialShare/index.tsx
+++ b/packages/bodiless-organisms/src/components/SocialShare/index.tsx
@@ -38,7 +38,7 @@ const WrapperClean: FC = ({ children, ...props }) => <Div {...props}>{ children 
  *
  * @param buttonContent - a string or JSX element provides content of share button.
  *        for example, to display a Material Share icon, use
- *            <span className="material-icons">share</span>
+ *            <span className="bl-material-icons">share</span>
  */
 const ButtonClean: FC<any> = ({
   buttonContent: content,

--- a/packages/bodiless-richtext/src/components/PluginButton.tsx
+++ b/packages/bodiless-richtext/src/components/PluginButton.tsx
@@ -46,7 +46,7 @@ const PluginButton: ComponentType<Props> = props => {
 
   return (
     <StyledComponent {...rest}>
-      {children || <span className="material-icons bl-material-icons">{icon}</span>}
+      {children || <span className="bl-material-icons">{icon}</span>}
     </StyledComponent>
   );
 };

--- a/packages/bodiless-richtext/src/components/TextSelectorButton.bl-edit.tsx
+++ b/packages/bodiless-richtext/src/components/TextSelectorButton.bl-edit.tsx
@@ -29,7 +29,7 @@ const NodeSelectorButton$ = (props: ButtonProps) => {
   const { Button } = getUI(useUI());
   return (
     <Button {...props}>
-      <i className="material-icons bl-material-icons">more_horiz</i>
+      <i className="bl-material-icons">more_horiz</i>
     </Button>
   );
 };

--- a/packages/bodiless-search/src/components/ResponsiveSearchBox.tsx
+++ b/packages/bodiless-search/src/components/ResponsiveSearchBox.tsx
@@ -52,7 +52,7 @@ const responsiveSearchComponents: ResponsiveSearchComponents = {
   ...searchComponents,
   Wrapper: Div,
   ToggleButton: Button,
-  ToggleIcon: addClasses('material-icons cursor-pointer align-middle')(I),
+  ToggleIcon: addClasses('bl-material-icons cursor-pointer align-middle')(I),
 };
 
 type ToggleButtonContext = {

--- a/packages/bodiless-search/src/components/ResponsiveSearchBox.tsx
+++ b/packages/bodiless-search/src/components/ResponsiveSearchBox.tsx
@@ -52,7 +52,7 @@ const responsiveSearchComponents: ResponsiveSearchComponents = {
   ...searchComponents,
   Wrapper: Div,
   ToggleButton: Button,
-  ToggleIcon: addClasses('bl-material-icons cursor-pointer align-middle')(I),
+  ToggleIcon: addClasses('cursor-pointer align-middle')(I),
 };
 
 type ToggleButtonContext = {

--- a/packages/bodiless-ui/README.md
+++ b/packages/bodiless-ui/README.md
@@ -64,7 +64,7 @@ const Span = stylable<HTMLProps<HTMLSpanElement>>('span');
 
 const ui: UI = {
   Wrapper: addClasses('bg-black text-white')(Div);
-  Icon: addClasses('block material-icon text-xl')(Span);
+  Icon: addClasses('block bl-material-icon text-xl')(Span);
 };
 
 export const MessageBox: FC<Props> = props = <CleanMessageBox {...props} ui={ui} />;

--- a/packages/bodiless-ui/bodiless.tailwind.config.js
+++ b/packages/bodiless-ui/bodiless.tailwind.config.js
@@ -169,12 +169,23 @@ module.exports = {
 
       const components = {
         '.material-icons': {
+          'font-family': 'Material Icons',
+          'font-weight': 'normal',
+          'font-style': 'normal',
           color: '#ddd',
           padding: '2px',
           'font-size': '30px',
           'vertical-align': 'text-bottom',
           'border-radius': '5px',
-
+          'line-height': 1,
+          'letter-spacing': 'normal',
+          'text-transform': 'none',
+          'display': 'inline-block',
+          'white-space': 'nowrap',
+          'word-wrap': 'normal',
+          direction: 'ltr',
+          '-webkit-font-feature-settings': 'liga',
+          '-webkit-font-smoothing': 'antialiased',
           '.active &': {
             color: '#fff',
             'background-color': '#0070c8',

--- a/packages/bodiless-ui/index.tailwind.css
+++ b/packages/bodiless-ui/index.tailwind.css
@@ -116,7 +116,7 @@
   cursor: auto;
 }
 
-.material-icons.md-36 { font-size: 36px; }
+.bl-material-icons.md-36 { font-size: 36px; }
 
 
 /**

--- a/packages/bodiless-ui/src/elements.tsx
+++ b/packages/bodiless-ui/src/elements.tsx
@@ -54,7 +54,7 @@ export const Option = stylable<ChildFieldProps<any, any>>(BaseOption);
 export const Anchor = stylable<HTMLProps<HTMLAnchorElement>>('a');
 
 export const Icon = flow(
-  addClasses('bl-p-grid-1 material-icons'),
+  addClasses('bl-p-grid-1 bl-material-icons'),
   withoutProps<ButtonVariantProps>(['isActive']),
   flowIf(hasProp('isActive'))(
     addClasses('bl-bg-primary bl-rounded'),


### PR DESCRIPTION

## Changes

- Replaced material-icons with bl-material-icons and brought over the material icon styling from tailwind so we are not dependent on that material icons css coming from google.
- Accordion -- removed material-icons as we switched to svg and these were just extra class material-icon not removed.
- BurgerMenu toggler -- same as above
- Searchresults box in desktop header -- same as above
- Menu: SubMenu indicator was dependent on google font material icons -- switched to SVG 

## Test Instructions
 - Any icons in editor could be affected.
 - On UX components confirm icons appear as expected for:   Accordion, Burgermenu toggler, Submenu indicator for Menu

## Related Issues
<!--
  Link to the issue that is fixed or resolved by this PR (if there is one)
  e.g. Fixes #1234, Closes #4567

  Link to an issue that is partially addressed by this PR (if there are any)
-->

<!-- IF THIS PR INTRODUCES A BREAKING CHANGE

BREAKING CHANGE: Describe the nature of the breaking change here.

More Details about the breaking change.
-->
