### PR TITLE
fix(bodiless-ui): fix icon size & color

### DIFF
--- a/packages/bodiless-layouts-ui/src/ComponentSelector.tsx
+++ b/packages/bodiless-layouts-ui/src/ComponentSelector.tsx
@@ -139,7 +139,7 @@ export const ui: ComponentSelectorUI = {
   )(Div),
 
   ComponentDescriptionIcon: addClasses(
-    'bl-absolute bl-top-grid-0 bl-right-grid-0 bl-material-icons bl-z-20 bl-text-gray-800 bl-m-grid-1',
+    'bl-absolute bl-top-grid-0 bl-right-grid-0 bl-material-icons bl-small-icon bl-z-20 bl-text-gray-800 bl-m-grid-1',
   )(Div),
 
   ComponentSelectButton: addClasses(
@@ -147,9 +147,9 @@ export const ui: ComponentSelectorUI = {
   )(Button),
 
   ScalingHeader: addClasses('bl-w-full bl-cursor-pointer bl-justify-end bl-text-gray-900 bl-p-grid-2 bl-flex')(Div),
-  ScalingButtonFull: (props) => <span className="bl-material-icons"><span {...props}>view_stream</span></span>,
-  ScalingButtonHalf: (props) => <span className="bl-material-icons"><span {...props}>view_module</span></span>,
-  ScalingButtonQuarter: (props) => <span className="bl-material-icons"><span {...props}>view_comfy</span></span>,
+  ScalingButtonFull: (props) => <span className="bl-material-icons bl-small-icon"><span {...props}>view_stream</span></span>,
+  ScalingButtonHalf: (props) => <span className="bl-material-icons bl-small-icon"><span {...props}>view_module</span></span>,
+  ScalingButtonQuarter: (props) => <span className="bl-material-icons bl-small-icon"><span {...props}>view_comfy</span></span>,
 };
 
 const ComponentSelector: FC<ComponentSelectorProps> = props => (

--- a/packages/bodiless-richtext-ui/src/components/PreviewWrapper.tsx
+++ b/packages/bodiless-richtext-ui/src/components/PreviewWrapper.tsx
@@ -14,6 +14,6 @@
 
 import { Div, addClasses } from '@bodiless/fclasses';
 
-const PreviewWrapper = addClasses('bl-block bl-bg-black')(Div);
+const PreviewWrapper = addClasses('bl-block bl-bg-gray-900')(Div);
 
 export default PreviewWrapper;

--- a/packages/bodiless-ui/bodiless.tailwind.config.js
+++ b/packages/bodiless-ui/bodiless.tailwind.config.js
@@ -170,7 +170,6 @@ module.exports = {
           'font-family': 'Material Icons',
           'font-weight': 'normal',
           'font-style': 'normal',
-          color: '#ddd',
           padding: '2px',
           'font-size': '30px',
           'vertical-align': 'text-bottom',

--- a/packages/bodiless-ui/index.tailwind.css
+++ b/packages/bodiless-ui/index.tailwind.css
@@ -116,8 +116,8 @@
   cursor: auto;
 }
 
-.bl-material-icons.md-36 { font-size: 36px; }
-
+.bl-large-icon { font-size: 36px; }
+.bl-small-icon { font-size: 24px; }
 
 /**
  * Bodiless Resizable Styles

--- a/packages/bodiless-ui/src/elements.tsx
+++ b/packages/bodiless-ui/src/elements.tsx
@@ -147,7 +147,7 @@ export const SubmitButton: FC<HTMLProps<HTMLButtonElement> & StylableProps> = pr
 
 export const ToolbarIcon = flow(
   removeClasses('bl-p-grid-1'),
-  addClasses('bl-w-grid-8 bl-h-grid-8 md-36'),
+  addClasses('bl-w-grid-8 bl-h-grid-8 bl-large-icon'),
 )(Icon);
 
 export const ToolbarButton = flow(


### PR DESCRIPTION
* Defined Icon size more clearly and applied to appropriate cases
* Removed icon color in material-icons styling
* Switch preview of RTE in component picker to same background in real-use