### PR TITLE
fix(test-site, GatsbyLink): There is a runtime error when clicking Logo after opening Email on /social-share/

### DIFF
--- a/sites/test-site/src/components/Layout/logo.tsx
+++ b/sites/test-site/src/components/Layout/logo.tsx
@@ -23,8 +23,8 @@ import {
   withDesign,
   addProps,
   flowHoc,
+  A,
 } from '@bodiless/fclasses';
-import { GatsbyLink } from '@bodiless/gatsby-theme-bodiless';
 import { asEditableImagePlain as asEditableImage } from '../Image';
 import { asEditableLink } from '../Elements.token';
 
@@ -39,7 +39,7 @@ export type Props = DesignableComponentsProps<LogoComponents> & HTMLProps<HTMLEl
 const logoComponents:LogoComponents = {
   SiteReturn: Div,
   SiteLogo: Img,
-  SiteLink: GatsbyLink,
+  SiteLink: A,
 };
 const LogoClean: FC<Props> = ({ components }) => {
   const {


### PR DESCRIPTION
…go after opening Email on /social-share/

<!--
  Before issuing a pull request:

  - Please read our contribution guidelines (https://github.com/johnsonandjohnson/Bodiless-JS/blob/main/packages/bodiless-documentation/doc/Development/Contributing.md), especially the section on Pull Requests.
  - Please first create an issue (https://github.com/johnsonandjohnson/Bodiless-JS/issues/new). All pull requests must be linked to an issue.
-->

<!--
  IMPORTANT
  
  The pull request title will become the commit message title at merge, and
  should adhere to Angular Commit Message Conventions. Please see (https://github.com/johnsonandjohnson/Bodiless-JS/blob/main/packages/bodiless-documentation/doc/Development/Contributing.md) for details and examples.
-->

## Changes
<!-- Brief description of the changes introduced by this PR -->

## Test Instructions
<!-- Detailed description of how this feature was (and should be) tested
  - Setup instructions (if any)?
  - List of test cases, with steps and expected results?
  - List
-->

## Related Issues
<!--
  Link to the issue that is fixed or resolved by this PR (if there is one)
  e.g. Fixes #1234, Closes #4567

  Link to an issue that is partially addressed by this PR (if there are any)
-->


fixes: #1601 

<!-- IF THIS PR INTRODUCES A BREAKING CHANGE

BREAKING CHANGE: Describe the nature of the breaking change here.

More Details about the breaking change.
-->
