### PR TITLE
fix(psh): run build:doc and build:env-vars only for current site

### DIFF
--- a/edit/platform.custom.sh
+++ b/edit/platform.custom.sh
@@ -15,6 +15,6 @@
 finalize_deploy () {
   npm run bootstrap -- --ci
   npm run build:packages -- --concurrency 1
-  npm run build:env-vars -- --scope=@sites/APP_SITE_NAME
-  npm run build:doc -- --scope=@sites/APP_SITE_NAME
+  npm run build:env-vars -- --scope=@sites/${APP_SITE_NAME}
+  npm run build:doc -- --scope=@sites/${APP_SITE_NAME}
 }

--- a/edit/platform.custom.sh
+++ b/edit/platform.custom.sh
@@ -15,6 +15,6 @@
 finalize_deploy () {
   npm run bootstrap -- --ci
   npm run build:packages -- --concurrency 1
-  npm run build:env-vars --scope=@sites/APP_SITE_NAME
-  npm run build:doc --scope=@sites/APP_SITE_NAME
+  npm run build:env-vars -- --scope=@sites/APP_SITE_NAME
+  npm run build:doc -- --scope=@sites/APP_SITE_NAME
 }

--- a/edit/platform.custom.sh
+++ b/edit/platform.custom.sh
@@ -15,6 +15,6 @@
 finalize_deploy () {
   npm run bootstrap -- --ci
   npm run build:packages -- --concurrency 1
-  npm run build:env-vars
-  npm run build:doc
+  npm run build:env-vars --scope=@sites/APP_SITE_NAME
+  npm run build:doc --scope=@sites/APP_SITE_NAME
 }

--- a/edit/platform.sh
+++ b/edit/platform.sh
@@ -54,6 +54,8 @@ check_vars () {
     -o -z "${APP_GIT_PW}" \
     -o -z "${PLATFORM_APP_DIR}" \
     -o -z "${PLATFORM_BRANCH}" \
+    -o -z "${APP_SITE_NAME}" \
+    -o -z "${APP_SITE_DIR_NAME}" \
   ]; then
     echo Missing required environment variables.
     exit 1


### PR DESCRIPTION
## Changes
Prevent p.sh deploy script from building docs and vars for every site in sites folder.
Run it only for the site specified in APP_SITE_NAME.