### PR TITLE
fix(bodiless-psh): hide git credential on platform.sh

### DIFF
--- a/packages/bodiless-psh/resources/edit/platform.sh
+++ b/packages/bodiless-psh/resources/edit/platform.sh
@@ -146,6 +146,7 @@ full_deploy () {
     ${CMD_GIT} -c credential.helper="!f() { echo username=${APP_GIT_USER}; echo password=${APP_GIT_PW}; }; f" clone -b ${PLATFORM_BRANCH} ${APP_GIT_REMOTE_URL} ${ROOT_DIR}
     cd ${ROOT_DIR}
   fi
+  git_store_credential
   ${CMD_GIT} config user.email "${APP_GIT_USER_EMAIL}"
   ${CMD_GIT} config user.name "${APP_GIT_USER}"
 }
@@ -158,6 +159,21 @@ init_npmrc () {
     bash -c 'echo NPM Auth token is ${APP_NPM_AUTH:0:50}...'
     echo "$APP_NPM_NAMESPACE:registry=https:${APP_NPM_REGISTRY}" >> .npmrc
     echo "${APP_NPM_REGISTRY}:_authToken=${APP_NPM_AUTH}" >> .npmrc
+  fi
+}
+
+git_store_credential () {
+  # process credential store only for http based url
+  if  [[ ${APP_GIT_REMOTE_URL} =~ ^http ]] ;
+  then
+    # get host name
+    HOST=$(echo ${APP_GIT_REMOTE_URL} | awk -F/ '{print $3}')
+    # remove user info, if any
+    HOST="${HOST#*:*@}"
+    echo 'https://'${APP_GIT_USER}':'${APP_GIT_PW}'@'${HOST} > ${GIT_STORE_CREDENTIAL}
+    # set owner permission only
+    chmod 600 ${GIT_STORE_CREDENTIAL}
+    git config --local credential.helper 'store --file='${GIT_STORE_CREDENTIAL}
   fi
 }
 

--- a/packages/bodiless-psh/resources/edit/platform.sh
+++ b/packages/bodiless-psh/resources/edit/platform.sh
@@ -20,7 +20,7 @@ fi
 
 # Expects the following env variables:
 # APP_VOLUME - the absolute path of the writable volume
-# APP_GIT_REMOTE_URL - the path to the bitbucket git repository
+# APP_GIT_REMOTE_URL - the path to the git repository
 # APP_GIT_USER - the user for git operations
 # APP_GIT_PW - the password for git operations
 # PLATFORM_APP_DIR - the absolute path to the application directory. provided by platform.sh
@@ -30,6 +30,7 @@ CMD_GIT=/usr/bin/git
 TMP_DIR=${APP_VOLUME}/../tmp
 ROOT_DIR=${APP_VOLUME}/root
 NPM_CACHE_DIR=${APP_VOLUME}/.npm
+GIT_STORE_CREDENTIAL=${APP_VOLUME}/.credential
 
 invoke () {
   if [[ $(type $1 2>&1) =~ "function" ]]; then

--- a/sites/test-site/edit/platform.sh
+++ b/sites/test-site/edit/platform.sh
@@ -146,6 +146,7 @@ full_deploy () {
     ${CMD_GIT} -c credential.helper="!f() { echo username=${APP_GIT_USER}; echo password=${APP_GIT_PW}; }; f" clone -b ${PLATFORM_BRANCH} ${APP_GIT_REMOTE_URL} ${ROOT_DIR}
     cd ${ROOT_DIR}
   fi
+  git_store_credential
   ${CMD_GIT} config user.email "${APP_GIT_USER_EMAIL}"
   ${CMD_GIT} config user.name "${APP_GIT_USER}"
 }
@@ -158,6 +159,21 @@ init_npmrc () {
     bash -c 'echo NPM Auth token is ${APP_NPM_AUTH:0:50}...'
     echo "$APP_NPM_NAMESPACE:registry=https:${APP_NPM_REGISTRY}" >> .npmrc
     echo "${APP_NPM_REGISTRY}:_authToken=${APP_NPM_AUTH}" >> .npmrc
+  fi
+}
+
+git_store_credential () {
+  # process credential store only for http based url
+  if  [[ ${APP_GIT_REMOTE_URL} =~ ^http ]] ;
+  then
+    # get host name
+    HOST=$(echo ${APP_GIT_REMOTE_URL} | awk -F/ '{print $3}')
+    # remove user info, if any
+    HOST="${HOST#*:*@}"
+    echo 'https://'${APP_GIT_USER}':'${APP_GIT_PW}'@'${HOST} > ${GIT_STORE_CREDENTIAL}
+    # set owner permission only
+    chmod 600 ${GIT_STORE_CREDENTIAL}
+    git config --local credential.helper 'store --file='${GIT_STORE_CREDENTIAL}
   fi
 }
 

--- a/sites/test-site/edit/platform.sh
+++ b/sites/test-site/edit/platform.sh
@@ -20,7 +20,7 @@ fi
 
 # Expects the following env variables:
 # APP_VOLUME - the absolute path of the writable volume
-# APP_GIT_REMOTE_URL - the path to the bitbucket git repository
+# APP_GIT_REMOTE_URL - the path to the git repository
 # APP_GIT_USER - the user for git operations
 # APP_GIT_PW - the password for git operations
 # PLATFORM_APP_DIR - the absolute path to the application directory. provided by platform.sh
@@ -30,6 +30,7 @@ CMD_GIT=/usr/bin/git
 TMP_DIR=${APP_VOLUME}/../tmp
 ROOT_DIR=${APP_VOLUME}/root
 NPM_CACHE_DIR=${APP_VOLUME}/.npm
+GIT_STORE_CREDENTIAL=${APP_VOLUME}/.credential
 
 invoke () {
   if [[ $(type $1 2>&1) =~ "function" ]]; then


### PR DESCRIPTION
<!--
  Before issuing a pull request:

  - Please read our contribution guidelines (https://github.com/johnsonandjohnson/Bodiless-JS/blob/main/packages/bodiless-documentation/doc/Development/Contributing.md), especially the section on Pull Requests.
  - Please first create an issue (https://github.com/johnsonandjohnson/Bodiless-JS/issues/new). All pull requests must be linked to an issue.
-->

<!--
  IMPORTANT
  
  The pull request title will become the commit message title at merge, and
  should adhere to Angular Commit Message Conventions. Please see (https://github.com/johnsonandjohnson/Bodiless-JS/blob/main/packages/bodiless-documentation/doc/Development/Contributing.md) for details and examples.
-->

## Changes
<!-- Brief description of the changes introduced by this PR -->

## Test Instructions
<!-- Detailed description of how this feature was (and should be) tested
  - Setup instructions (if any)?
  - List of test cases, with steps and expected results?
  - List
-->

## Related Issues
<!--
  Link to the issue that is fixed or resolved by this PR (if there is one)
  e.g. Fixes #1234, Closes #4567

  Link to an issue that is partially addressed by this PR (if there are any)
-->

<!-- IF THIS PR INTRODUCES A BREAKING CHANGE

BREAKING CHANGE: Describe the nature of the breaking change here.

More Details about the breaking change.
-->
