### PR TITLE
fix(bodiless-backend): Fix image assets paths to be replaced on clone operation

### DIFF
--- a/packages/bodiless-backend/src/page.js
+++ b/packages/bodiless-backend/src/page.js
@@ -322,14 +322,20 @@ class Page {
                 const fileToBeUpdated = path.join(destinationPagePath, item);
                 // Make sure to not replace '/images/pages' part of the path
                 // .e.g if the source page path is '/images';
-                const imgAssetsPathRegExp = IMG_ASSETS_PATH.replace('\\', '\\\\\\\\');
-                const originPathRegExp = new RegExp(
-                  `(${imgAssetsPathRegExp}.*)${originPathCrossPlatform}`, 'g'
-                );
+                const imgAssetsPath = IMG_ASSETS_PATH.replace('\\', '\\\\\\\\');
+                // If homepage, originPathCrossPlatform will be empty, so this
+                // template string handles both cases:
+                // - '/images/pages' for homepage (/)
+                // - '/images/pages/example for others (/example)
+                const fromPath = `${imgAssetsPath}${originPathCrossPlatform}`;
+                // New path based on base path:
+                // - '/images/pages/example2'
+                const toPath = `${imgAssetsPath}${destinationPathCrossPlatform}`;
+
                 const options = {
                   files: fileToBeUpdated,
-                  from: originPathRegExp,
-                  to: match => match.replace(originPathRegExp, `$1${destinationPathCrossPlatform}`),
+                  from: fromPath,
+                  to: match => match.replace(fromPath, toPath),
                 };
                 return Page.updateFileContent(options);
               }),

--- a/packages/bodiless-page/src/types.ts
+++ b/packages/bodiless-page/src/types.ts
@@ -53,6 +53,7 @@ type PageMenuOptions = {
 };
 
 type PageClient = {
+  clonePage: (origin: string, destination: string) => AxiosPromise<any>;
   deletePage: (path: string) => AxiosPromise<any>;
   movePage: (origin: string, destination: string) => AxiosPromise<any>;
   savePage: (path: string, template?: string) => AxiosPromise<any>;


### PR DESCRIPTION
## Overview
There is an issue to clone the homepage in case there is an image uploaded to any components. This is happening because replacing function is not updating properly the page. We are refactoring the backend function to update the cloned assets to use simple template string instead of regex.

## Changes
- Replace regex with template strings to build the paths to replace/be replaced;
- Additionaly, we update bodiless page client type to include clone

## Test Instructions
N/A

## Related Issues
- #1608