### PR TITLE
ci: Release RC versions on prerelease

### DIFF
--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -35,7 +35,7 @@ jobs:
       # In order to disable common version line remove the --force-publish flag in lerna command below
       - name: Prerelease
         run: |
-          npx lerna version --conventional-commits --conventional-prerelease --preid=beta --include-merged-tags --force-publish --yes
+          npx lerna version --conventional-commits --conventional-prerelease --preid=rc --include-merged-tags --force-publish --yes
       - name: Enable branch protection
         uses: octokit/request-action@v2.x
         with:


### PR DESCRIPTION
To fix an issue where NPM was installing canary versions of Bodiless packages when using `^1.0.0-beta.X` on our dependencies, we will now release `rc` versions when running the pre-release action.

This means that, instead of releasing `1.0.0-beta.X` on our next pre-release, we will now release `1.0.0-rc.X`.

Note that `1.0.0-rc.1` is already out on the main branch, so we're already using `rc` releases on all our packages, and there's no further actions needed.