### PR TITLE
docs(bodiless-ga4): Remove ref to env var

### DIFF
--- a/packages/bodiless-ga4/doc/GA4Activation.md
+++ b/packages/bodiless-ga4/doc/GA4Activation.md
@@ -63,7 +63,7 @@ Visit the `/sites/SITENAME/src/data/site` folder and update the following three 
     {
       resolve: 'gatsby-plugin-google-tagmanager',
       options: {
-        id: process.env.GOOGLE_TAGMANAGER_ID || 'GTM-XXXXXXX',
+        id: 'GTM-XXXXXXX',
         // The data layer — to be set before GTM is loaded — should
         // be an object or a function that is executed in the browser.
         // Defaults to null.

--- a/sites/minimal-demo/.env.site
+++ b/sites/minimal-demo/.env.site
@@ -21,14 +21,6 @@ SITE_URL='https://www.example.com/'
 # are always included in development builds.
 # GOOGLE_FONTS_ENABLED='1'
 
-# GTM is enabled by default.
-# To disable it - uncomment the following line
-# GOOGLE_TAGMANAGER_ENABLED='0'
-
-# GTM Activation
-# To set GTM ID modify line below and remove #.
-# GOOGLE_TAGMANAGER_ID='GTM-XXXXXXX'
-
 # Robots.txt plugin is enabled by default.
 # To disable it - set value to '0'
 ROBOTSTXT_ENABLED='1'


### PR DESCRIPTION
## Changes
Remove ref to env variable as it doesn't exist.

## Test Instructions
No testing needed.

