### PR TITLE
fix(gatsby-theme-bodiless): Include gatsby-ssr in the package files

### DIFF
--- a/packages/gatsby-theme-bodiless/package.json
+++ b/packages/gatsby-theme-bodiless/package.json
@@ -23,6 +23,7 @@
     "gatsby-browser.js",
     "gatsby-config.js",
     "gatsby-node.js",
+    "gatsby-ssr.js",
     "queries.jsx",
     "Logger.js",
     "src/no-scroll-settings.json",


### PR DESCRIPTION
## Changes
Add gatsby-ssr.js file to files section in package.json. It will include the file in the published package.

## Test Instructions

## Related Issues
