### PR TITLE
docs(vital-layout): Add API docs and update docs for vital-layout

### DIFF
--- a/packages/__vital__/src/shadow/@bodiless/vital-layout/Helmet.ts
+++ b/packages/__vital__/src/shadow/@bodiless/vital-layout/Helmet.ts
@@ -15,7 +15,7 @@ import { vitalHelmetBase, asHelmetToken } from '@bodiless/vital-layout';
 import { withLangDirProps } from '@bodiless/i18n';
 import { as, addProps } from '@bodiless/fclasses';
 
-const Default = asHelmetToken(vitalHelmetBase.Base, {
+const Default = asHelmetToken(vitalHelmetBase.Default, {
   Core: {
     LanguageHelmet: as(
       addProps({ 'data-shadowed-by': '__vital__Helmet' }),

--- a/packages/vital-layout/bodiless.docs.json
+++ b/packages/vital-layout/bodiless.docs.json
@@ -3,14 +3,14 @@
     "Components": {
       "VitalLayout": {
         "README.md": "./doc/README.md",
+        "Responsiveness.md": "./doc/Responsiveness.md",
+        "MenuToggler.md": "./doc/MenuToggler.md",
+        "SearchToggler.md": "./doc/SearchToggler.md",
+        "Logo.md": "./doc/Logo.md",
         "Footer.md": "./doc/Footer.md",
         "Header.md": "./doc/Header.md",
         "Helmet.md": "./doc/Helmet.md",
-        "Layout.md": "./doc/Layout.md",
-        "Logo.md": "./doc/Logo.md",
-        "MenuToggler.md": "./doc/MenuToggler.md",
-        "Responsiveness.md": "./doc/Responsiveness.md",
-        "SearchToggler.md": "./doc/Search.md"
+        "Layout.md": "./doc/Layout.md"
       }
     }
   }

--- a/packages/vital-layout/bodiless.docs.json
+++ b/packages/vital-layout/bodiless.docs.json
@@ -3,9 +3,6 @@
     "Components": {
       "VitalLayout": {
         "README.md": "./doc/README.md",
-        "Responsiveness.md": "./doc/Responsiveness.md",
-        "MenuToggler.md": "./doc/MenuToggler.md",
-        "SearchToggler.md": "./doc/SearchToggler.md",
         "Logo.md": "./doc/Logo.md",
         "Footer.md": "./doc/Footer.md",
         "Header.md": "./doc/Header.md",

--- a/packages/vital-layout/doc/Footer.md
+++ b/packages/vital-layout/doc/Footer.md
@@ -24,33 +24,6 @@ From a Site Builder perspective, Vital Footer is comprised of a token collection
 a Footer component (`FooterClean`). You can use the default Vital Footer token
 (`vitalFooter.Default`) as is, or you can recompose it to meet your site's requirements.
 
-### Usage
-
-Using the following code example as a guide, you can create a Footer using the Vital default tokens,
-and applying the correct node keys. Remember to apply the necessary imports to the file.
-
-```tsx
-const Footer = as(
-  // You can compose or create a new Footer token
-  // from scratch, but we'll use the default one here.
-  vitalFooter.Default,
-  // Apply a node to the footer so inner nodes
-  // are organized into its namespace.
-  withNode,
-  withNodeKey({ 'footer', nodeCollection: 'site' }),
-)(FooterClean);
-
-const Layout: FC = ({ children }) => (
-  <SiteWrapper>
-    <ContentWrapper>
-      {children}
-    </ContentWrapper>
-    <Footer />
-  </SiteWrapper>
-);
-export default Layout;
-```
-
 ### Customizing Footer
 
 #### Via Shadowing (*Preferred Method)
@@ -58,6 +31,10 @@ export default Layout;
 Define a Shadowing token collection as defined in [Shadow](../VitalElements/Shadow).
 
 File to shadow: `packages/{my-package}/src/shadow/@bodiless/vital-layout/Footer.ts`
+
+?> **API Documentation**: Visit the
+[Vital Footer Token Collection](../../../Development/API/@bodiless/vital-layout/interfaces/VitalFooter)
+for examples of shadowing.
 
 #### Via Extending
 
@@ -82,10 +59,13 @@ const BrandXFooter = asFooterToken({
 });
 ```
 
-This token is then applied to the Footer slot within Layout.
+This token is then applied to the Footer slot within Layout -- can be achieved
+by shadowing Layout, see
+[Vital Layout Token Collection](../../../Development/API/@bodiless/vital-layout/interfaces/VitalLayout?id=default)
 
 ## Architectural Details
 
-Vital Footer provides a `<footer>` element wrapper around its internal elements. To see how these
-elements are structured within the wrapper, please see:
-[`FooterClean.tsx`](https://github.com/johnsonandjohnson/Bodiless-JS/blob/main/packages/vital-layout/src/components/Footer/FooterClean.tsx ':target=_blank')
+Vital Footer provides a `<footer>` element wrapper around its internal elements.
+
+?> **View API documentation for details.**:
+[Vital Footer Components](../../../Development/API/@bodiless/vital-layout/interfaces/FooterComponents)

--- a/packages/vital-layout/doc/Header.md
+++ b/packages/vital-layout/doc/Header.md
@@ -19,39 +19,13 @@ By default, the editable components include:
 
 - Logo
 - Menu
+- Utility Menu
 
 ## Site Builder Details
 
 From a Site Builder perspective, Vital Header is comprised of a token collection (`vitalHeader`) and
 a Header component (`HeaderClean`). You can use the default Vital Header token
 (`vitalHeader.Default`) as is, or you can recompose it to meet your site's requirements.
-
-### Usage
-
-Using the following code example as a guide, you can create a Header using the Vital default tokens,
-and applying the correct node keys. Remember to apply the necessary imports to the file.
-
-```tsx
-const Header = as(
-  // You can compose or create a new header token
-  // from scratch, but we'll use the default one here.
-  vitalHeader.Default,
-  // Apply a node to the header so inner nodes
-  // are organized into its namespace.
-  withNode,
-  withNodeKey({ 'header', nodeCollection: 'site' }),
-)(HeaderClean);
-
-const Layout: FC = ({ children }) => (
-  <SiteWrapper>
-    <Header />
-    <ContentWrapper>
-      {children}
-    </ContentWrapper>
-  </SiteWrapper>
-);
-export default Layout;
-```
 
 ### Customizing Header
 
@@ -60,6 +34,10 @@ export default Layout;
 Define a Shadowing token collection as defined in [Shadow](../VitalElements/Shadow).
 
 File to shadow: `packages/{my-package}/src/shadow/@bodiless/vital-layout/Header.ts`
+
+?> **API Documentation**: Visit the
+[Vital Header Token Collection](../../../Development/API/@bodiless/vital-layout/interfaces/VitalHeader)
+for examples of shadowing.
 
 #### Via Extending
 
@@ -84,10 +62,13 @@ const BrandXHeader = asHeaderToken({
 });
 ```
 
-This token is then applied to the Header slot within Layout.
+This token is then applied to the Header slot within Layout -- can be achieved
+by shadowing Layout, see
+[Vital Layout Token Collection](../../../Development/API/@bodiless/vital-layout/interfaces/VitalLayout?id=default)
 
 ## Architectural Details
 
-Vital Header provides a `<header>` element wrapper around its internal elements. To see how these
-elements are structured within the wrapper, please see:
-[`HeaderClean.tsx`](https://github.com/johnsonandjohnson/Bodiless-JS/blob/main/packages/vital-layout/src/components/Header/HeaderClean.tsx)
+Vital Header provides a `<header>` element wrapper around its internal elements.
+
+?> **View API documentation for details.**:
+[Vital Header Components](../../../Development/API/@bodiless/vital-layout/interfaces/HeaderComponents)

--- a/packages/vital-layout/doc/Helmet.md
+++ b/packages/vital-layout/doc/Helmet.md
@@ -12,8 +12,7 @@ five individual slots for different types of data.
 - `LanguageHelmet`: Custom.
 - `HTMLHelmet`: Will apply attributes to the `<html>` element that wraps the page. Includes things
   such as direction, language, classes, etc.
-  <!-- TODO: Add description -->
-- `BodyHelmet`: ?
+- `BodyHelmet`: Will apply attributes to the `<body>` element that wraps the content.
 
 ## Content Editor Details
 
@@ -25,40 +24,19 @@ At the site or global regional/brand library level, you can use the Helmet Compo
 extend the existing component. Often times the Site Builder will want to add a site-specific element
 to the header.
 
-### Customizing
+### Customizing Via Shadowing (*Preferred Method)
 
-A custom Helmet token that is applied to all pages can be defined at the site/package level, and
-then applied to the Layout's specific helmet slot.
+Define a Shadowing token collection as defined in [Shadow](../VitalElements/Shadow).
 
-Within your site/package level components, the following component extends `vitalHelmet` with all
-its defaults, and then adds the additional classes to the `HTMLHelmet`:
+File to shadow: `packages/{my-package}/src/shadow/@bodiless/vital-layout/Helmet.ts`
 
-```js
-const Default = extend(vitalHelmet.Default, asHelmetToken({
-  Core: {
-    HTMLHelmet: 'text-gray-600',
-  },
-}));
-
-export const brandXHelmet = { Default };
-```
-
-—And applying in your Layout Helmet slot:
-
-```js
-const Default = asLayoutToken({
-  ...vitalLayout.Default,
-  Components: {
-    ...vitalLayout.Default.Components,
-    Helmet: brandXHelmet.Default,
-  },
-});
-```
-
-Alternatively, you can use custom Helmet tokens within templates, and then that data is only applied
-to the head of the pages created from that template.
+?> **API Documentation**: Visit the
+[Vital Layout Token Collection](../../../Development/API/@bodiless/vital-layout/interfaces/VitalHelmet)
+for examples of shadowing.
 
 ## Architectural Details
 
-Vital Helmet is a wrapper around a group of slots for specific purposes:
-[`HelmetClean.tsx`](https://github.com/johnsonandjohnson/Bodiless-JS/blob/main/packages/vital-layout/src/components/Helmet/HelmetClean.tsx).
+Vital Helmet is a wrapper around a group of slots for specific purposes.
+
+?> **View API documentation for details.**:
+[Vital Helmet Components](../../../Development/API/@bodiless/vital-layout/interfaces/HelmetComponents)

--- a/packages/vital-layout/doc/Layout.md
+++ b/packages/vital-layout/doc/Layout.md
@@ -39,26 +39,34 @@ or, if new, stub out the component and render a text placeholder — you can ret
 component later in the site build. In the beginning of your site build, focus on the general
 structure of header, footer, etc. here, and leave the details for a later step in the process.
 
-### Skip To Main Content
-
-The _Skip To Main Content_ is an accessibility feature defined in the Behavior domain that provides
-a hidden link at the top of the page that links to an anchor that is placed on the container. It
-becomes visible when the user visits the site and starts interacting with their keyboard's Tab key.
-
 ### Customizing Via Shadowing (*Preferred Method)
 
 Define a Shadowing token collection as defined in [Shadow](../VitalElements/Shadow).
 
 File to shadow: `packages/{my-package}/src/shadow/@bodiless/vital-layout/Layout.ts`
 
-### Skip To Main Content Customization
+?> **API Documentation**: Visit the
+[Vital Layout Token Collection](../../../Development/API/@bodiless/vital-layout/interfaces/VitalLayout)
+for examples of shadowing.
+
+### Skip To Main Content
+
+The _Skip To Main Content_ is an accessibility feature defined in the Behavior domain that provides
+a hidden link at the top of the page that links to an anchor that is placed on the container. It
+becomes visible when the user visits the site and starts interacting with their keyboard's Tab key.
+#### Skip To Main Content Customization
 
 - If you wish to override the language of the link, set the children text via `addProps()`.
 - If you wish to change where the Skip to Main Content link is, set a new anchor on the appropriate
   slot, and change the href via `addProps()`.
 
+?> **API Documentation Example**: Visit the
+[Vital Layout Token Collection](../../../Development/API/@bodiless/vital-layout/interfaces/VitalLayout?id=default)
+for example of overriding Skip to Main Content.
+
 ## Architectural Details
 
-Vital Layout provides a Layout structure around the core components of the page. To see how these
-elements are structured within the wrapper, please see:
-[`LayoutClean.tsx`](https://github.com/johnsonandjohnson/Bodiless-JS/blob/main/packages/vital-layout/src/components/Layout/LayoutClean.tsx).
+Vital Layout provides a Layout structure around the core components of the page.
+
+?> **API Documentation**:
+[Vital Layout Components](../../../Development/API/@bodiless/vital-layout/interfaces/LayoutComponents)

--- a/packages/vital-layout/doc/Logo.md
+++ b/packages/vital-layout/doc/Logo.md
@@ -27,7 +27,11 @@ Define a Shadowing token collection as defined in [Shadow](../VitalElements/Shad
 
 File to shadow: `packages/{my-package}/src/shadow/@bodiless/vital-layout/Logo.ts`
 
+?> **API Documentation**: Visit the
+[Vital Logo Token Collection](../../../Development/API/@bodiless/vital-layout/interfaces/VitalLogo)
+for examples of shadowing.
+
 ## Architectural Details
 
-To see how these elements are structured within the wrapper, please see:
-[`LogoClean.tsx`](https://github.com/johnsonandjohnson/Bodiless-JS/blob/main/packages/vital-layout/src/components/Logo/LogoClean.tsx).
+?> **View API documentation for details.**:
+[Vital Logo Components](../../../Development/API/@bodiless/vital-layout/interfaces/LogoComponents)

--- a/packages/vital-layout/doc/MenuToggler.md
+++ b/packages/vital-layout/doc/MenuToggler.md
@@ -1,3 +1,0 @@
-# Vital Menu Toggler Component
-
-TBD

--- a/packages/vital-layout/doc/README.md
+++ b/packages/vital-layout/doc/README.md
@@ -12,8 +12,8 @@ components:
 - [Vital Header](./Header)
 - [Vital Footer](./Footer)
 - [Vital Logo](./Logo)
-- [Vital Menu Toggler](./MenuToggler)
-- [Vital Search Toggler](./SearchToggler)
+- [Vital Menu Toggler](../VitalNavigation/BurgerMenu)
+- Vital Search Toggler
 
 ?> **API Documentation**: visit
 [Vital Layout](../../../Development/API/@bodiless/vital-layout/README)

--- a/packages/vital-layout/doc/README.md
+++ b/packages/vital-layout/doc/README.md
@@ -1,7 +1,7 @@
 # Vital Layout Components
 
 The Vital Layout Package provides a set of components & tokens to compose the
-overall layout of a page. For more information on each componenent, visit the
+overall layout of a page. For more information on each component, visit the
 individual component documentation or the API documentation.
 
 The Vital Layout (`@bodiless/vital-layout`) package is composed of the following

--- a/packages/vital-layout/doc/README.md
+++ b/packages/vital-layout/doc/README.md
@@ -1,6 +1,11 @@
 # Vital Layout Components
 
-The Vital Layout (`@bodiless/vital-layout`) package is composed of the following components:
+The Vital Layout Package provides a set of components & tokens to compose the
+overall layout of a page. For more information on each componenent, visit the
+individual component documentation or the API documentation.
+
+The Vital Layout (`@bodiless/vital-layout`) package is composed of the following
+components:
 
 - [Vital Layout](./Layout)
 - [Vital Helmet](./Helmet)
@@ -9,3 +14,9 @@ The Vital Layout (`@bodiless/vital-layout`) package is composed of the following
 - [Vital Logo](./Logo)
 - [Vital Menu Toggler](./MenuToggler)
 - [Vital Search Toggler](./SearchToggler)
+
+?> **API Documentation**: visit
+[Vital Layout](../../../Development/API/@bodiless/vital-layout/README)
+
+Layout components often define have responsive behaviors, for more information
+visit [here for more details](./Responsiveness).

--- a/packages/vital-layout/doc/Search.md
+++ b/packages/vital-layout/doc/Search.md
@@ -1,3 +1,0 @@
-# Vital Search Component
-
-TBD

--- a/packages/vital-layout/doc/SearchToggler.md
+++ b/packages/vital-layout/doc/SearchToggler.md
@@ -1,0 +1,3 @@
+# Vital Search Toggler Component
+
+TBD

--- a/packages/vital-layout/doc/SearchToggler.md
+++ b/packages/vital-layout/doc/SearchToggler.md
@@ -1,3 +1,0 @@
-# Vital Search Toggler Component
-
-TBD

--- a/packages/vital-layout/package.json
+++ b/packages/vital-layout/package.json
@@ -22,11 +22,12 @@
     "access": "public"
   },
   "scripts": {
-    "build": "run-p build:lib",
+    "build": "run-s build:lib copy build:api-doc",
     "build:api-doc": "typedoc --options ../../typedoc.js --out doc/api src",
     "build:lib": "tsc -p ./tsconfig.json",
     "build:watch": "npm run build:lib -- --watch",
-    "clean": "rimraf \"lib/*\" && rimraf tsconfig.tsbuildinfo && rimraf \"doc/api\""
+    "clean": "rimraf \"lib/*\" && rimraf tsconfig.tsbuildinfo && rimraf \"doc/api\"",
+    "copy": "copyfiles -u 1 \"./src/**/*.{css,png}\" \"./lib/\""
   },
   "dependencies": {
     "@bodiless/cli": "^1.0.0-rc.12",

--- a/packages/vital-layout/src/components/Footer/CopyrightRow/CopyrightRowClean.tsx
+++ b/packages/vital-layout/src/components/Footer/CopyrightRow/CopyrightRowClean.tsx
@@ -39,13 +39,15 @@ const CopyrightRowCleanBase: FC<CopyrightRowProps> = ({ components: C, ...rest }
   </C.Wrapper>
 );
 
+const CopyrightRowCleanDesignable = designable(copyrightRowComponents, 'CopyrightRow')(CopyrightRowCleanBase);
 /**
- * A clean copyright row to be used in footer following vital design
+ * A clean static copyright row to be used in footer following vital design
+ * with copyright & social links.
  *
  * @category Component
  *
  */
-const CopyrightRowClean = designable(copyrightRowComponents, 'CopyrightRow')(CopyrightRowCleanBase);
+const CopyrightRowClean = withoutHydration()(CopyrightRowCleanDesignable);
 
 /**
  * A token modifier that respects the CopyRightRow Compoments.
@@ -58,4 +60,4 @@ export const asCopyrightRowToken = asVitalTokenSpec<CopyrightRowComponents>();
 const copyrightRowToken = asCopyrightRowToken();
 export type CopyrightRowToken = typeof copyrightRowToken;
 
-export default withoutHydration()(CopyrightRowClean);
+export default CopyrightRowClean;

--- a/packages/vital-layout/src/components/Footer/CopyrightRow/CopyrightRowClean.tsx
+++ b/packages/vital-layout/src/components/Footer/CopyrightRow/CopyrightRowClean.tsx
@@ -40,10 +40,22 @@ const CopyrightRowCleanBase: FC<CopyrightRowProps> = ({ components: C, ...rest }
 );
 
 /**
- * A clean copyright row to be used in footer
+ * A clean copyright row to be used in footer following vital design
+ *
+ * @category Component
+ *
  */
 const CopyrightRowClean = designable(copyrightRowComponents, 'CopyrightRow')(CopyrightRowCleanBase);
 
+/**
+ * A token modifier that respects the CopyRightRow Compoments.
+ *
+ * @category Token Collection
+ */
 export const asCopyrightRowToken = asVitalTokenSpec<CopyrightRowComponents>();
+
+// These are used in defining the VitalCopyrightRow interface.
+const copyrightRowToken = asCopyrightRowToken();
+export type CopyrightRowToken = typeof copyrightRowToken;
 
 export default withoutHydration()(CopyrightRowClean);

--- a/packages/vital-layout/src/components/Footer/CopyrightRow/CopyrightRowClean.tsx
+++ b/packages/vital-layout/src/components/Footer/CopyrightRow/CopyrightRowClean.tsx
@@ -50,7 +50,7 @@ const CopyrightRowCleanDesignable = designable(copyrightRowComponents, 'Copyrigh
 const CopyrightRowClean = withoutHydration()(CopyrightRowCleanDesignable);
 
 /**
- * A token modifier that respects the CopyRightRow Compoments.
+ * A token modifier that respects the CopyRightRow Components.
  *
  * @category Token Collection
  */

--- a/packages/vital-layout/src/components/Footer/CopyrightRow/index.static.ts
+++ b/packages/vital-layout/src/components/Footer/CopyrightRow/index.static.ts
@@ -13,8 +13,8 @@
  */
 
 import {
-  StaticBlock as CopyrightRowClean,
+  StaticBlock as CopyrightRowStatic,
   staticTokenCollection as vitalCopyrightRow,
 } from '@bodiless/hydration';
 
-export { CopyrightRowClean, vitalCopyrightRow };
+export { CopyrightRowStatic, vitalCopyrightRow };

--- a/packages/vital-layout/src/components/Footer/CopyrightRow/index.ts
+++ b/packages/vital-layout/src/components/Footer/CopyrightRow/index.ts
@@ -12,7 +12,16 @@
  * limitations under the License.
  */
 
+import vitalCopyrightRowBaseOrig, { VitalCopyrightRow } from './tokens/vitalCopyrightRow';
+
+/**
+  * Use this version of the vital copyrightrow tokens when extending or shadowing.
+  * @category Token Collection
+  * @see [[vitalCopyrightRow]]
+  */
+const vitalCopyrightRowBase = vitalCopyrightRowBaseOrig;
+
 export { asCopyrightRowToken } from './CopyrightRowClean';
 export type { CopyrightRowComponents, CopyrightRowProps } from './types';
-export { default as vitalCopyrightRowBase } from './tokens/vitalCopyrightRow';
+export { vitalCopyrightRowBase, VitalCopyrightRow };
 export * from './index.bl-edit';

--- a/packages/vital-layout/src/components/Footer/CopyrightRow/tokens/vitalCopyrightRow.ts
+++ b/packages/vital-layout/src/components/Footer/CopyrightRow/tokens/vitalCopyrightRow.ts
@@ -20,6 +20,7 @@ import {
 import { addProps, as, replaceWith } from '@bodiless/fclasses';
 import { vitalLink } from '@bodiless/vital-link';
 import { asCopyrightRowToken } from '../CopyrightRowClean';
+import type { CopyrightRowToken } from '../CopyrightRowClean';
 import { vitalSocialLinks } from '../../SocialLinks';
 
 const Copyright = asVitalTokenSpec()({
@@ -84,8 +85,40 @@ const Default = asCopyrightRowToken({
   ...Base,
 });
 
-export default {
+/**
+ * Tokens for the vital Copyright Row which consists of copyright & social links.
+ *
+ * @category Token Collection
+ * @see [[CopyrightRowClean]]
+ */
+export interface VitalCopyrightRow {
+  /**
+   * Base applies the following:
+   * - Vital Styled Copyright editor on left
+   * - Social Links on right
+   */
+  Base: CopyrightRowToken,
+  /**
+   * Inherits Base
+   */
+  Default: CopyrightRowToken,
+  /**
+   * Copyright only
+   */
+  CopyrightNoSocialLinks: CopyrightRowToken,
+}
+
+/**
+ * Tokens for Vital Copyright Row
+ *
+ * @category Token Collection
+ * @see [[VitalCopyrightRow]]
+ * @see [[CopyrightRowClean]]
+ */
+const vitalCopyrightRow: VitalCopyrightRow = {
   Base,
   Default,
   CopyrightNoSocialLinks,
 };
+
+export default vitalCopyrightRow;

--- a/packages/vital-layout/src/components/Footer/CopyrightRow/types.ts
+++ b/packages/vital-layout/src/components/Footer/CopyrightRow/types.ts
@@ -12,15 +12,35 @@
  * limitations under the License.
  */
 
-import { ComponentOrTag, DesignableComponentsProps } from '@bodiless/fclasses';
+import { ComponentOrTag, DesignableComponents, DesignableComponentsProps } from '@bodiless/fclasses';
 
-type CopyrightRowComponents = {
+/**
+ * Type of the design element in the VitalDS `Copyright Row` component which
+ * consists of Copyright & Social Links
+ * @category Component
+ */
+interface CopyrightRowComponents extends DesignableComponents {
+  /**
+   * Wrapper for Copyright Row component
+   */
   Wrapper: ComponentOrTag<any>,
+  /**
+   * Wrapper for the Copyright
+   */
   CopyrightWrapper: ComponentOrTag<any>,
+  /**
+   * Used for the copyright
+   */
   Copyright: ComponentOrTag<any>,
+  /**
+   * Wrapper for the Social Links
+   */
   SocialLinksWrapper: ComponentOrTag<any>,
+  /**
+   * Used for the social links
+   */
   SocialLinks: ComponentOrTag<any>,
-};
+}
 
 type CopyrightRowProps = DesignableComponentsProps<CopyrightRowComponents>;
 

--- a/packages/vital-layout/src/components/Footer/CopyrightRow/types.ts
+++ b/packages/vital-layout/src/components/Footer/CopyrightRow/types.ts
@@ -16,7 +16,9 @@ import { ComponentOrTag, DesignableComponents, DesignableComponentsProps } from 
 
 /**
  * Type of the design element in the VitalDS `Copyright Row` component which
- * consists of Copyright & Social Links
+ * consists of:
+ * - Editable Copyright
+ * - Social Links
  * @category Component
  */
 interface CopyrightRowComponents extends DesignableComponents {

--- a/packages/vital-layout/src/components/Footer/FooterClean.tsx
+++ b/packages/vital-layout/src/components/Footer/FooterClean.tsx
@@ -65,7 +65,7 @@ const FooterCleanBase: FC<FooterProps> = ({ components: C, ...rest }) => (
 const FooterClean = designable(footerComponents, 'Footer')(FooterCleanBase);
 
 /**
- * A token modifier that respects the Footer Compoments.
+ * A token modifier that respects the Footer Components.
  *
  * @category Token Collection
  */

--- a/packages/vital-layout/src/components/Footer/FooterClean.tsx
+++ b/packages/vital-layout/src/components/Footer/FooterClean.tsx
@@ -58,9 +58,21 @@ const FooterCleanBase: FC<FooterProps> = ({ components: C, ...rest }) => (
 
 /**
  * A clean footer to be used in pages layouts.
+ *
+ * @category Component
+ *
  */
 const FooterClean = designable(footerComponents, 'Footer')(FooterCleanBase);
 
+/**
+ * A token modifier that respects the Footer Compoments.
+ *
+ * @category Token Collection
+ */
 export const asFooterToken = asVitalTokenSpec<FooterComponents>();
+
+// These are used in defining the VitalFooter interface.
+const footerToken = asFooterToken();
+export type FooterToken = typeof footerToken;
 
 export default FooterClean;

--- a/packages/vital-layout/src/components/Footer/FooterClean.tsx
+++ b/packages/vital-layout/src/components/Footer/FooterClean.tsx
@@ -57,7 +57,7 @@ const FooterCleanBase: FC<FooterProps> = ({ components: C, ...rest }) => (
 );
 
 /**
- * A clean footer to be used in pages layouts.
+ * A clean footer to be used in pages layouts following vital design.
  *
  * @category Component
  *

--- a/packages/vital-layout/src/components/Footer/Rewards/RewardsClean.tsx
+++ b/packages/vital-layout/src/components/Footer/Rewards/RewardsClean.tsx
@@ -61,7 +61,7 @@ const RewardsCleanBase: FC<RewardsProps> = ({ components: C, ...rest }) => (
 const RewardsClean = designable(rewardsComponents, 'Rewards')(RewardsCleanBase);
 
 /**
- * A token modifier that respects the Rewards Compoments.
+ * A token modifier that respects the Rewards Components.
  *
  * @category Token Collection
  */

--- a/packages/vital-layout/src/components/Footer/Rewards/RewardsClean.tsx
+++ b/packages/vital-layout/src/components/Footer/Rewards/RewardsClean.tsx
@@ -52,7 +52,10 @@ const RewardsCleanBase: FC<RewardsProps> = ({ components: C, ...rest }) => (
 /**
  * A clean rewards placeholder
  *
+ * RECOMMEND TO NOT EXTEND/OVERRIDE and marked as deprecated.
+ *
  * @category Component
+ * @deprecated
  *
  */
 const RewardsClean = designable(rewardsComponents, 'Rewards')(RewardsCleanBase);

--- a/packages/vital-layout/src/components/Footer/Rewards/RewardsClean.tsx
+++ b/packages/vital-layout/src/components/Footer/Rewards/RewardsClean.tsx
@@ -49,9 +49,24 @@ const RewardsCleanBase: FC<RewardsProps> = ({ components: C, ...rest }) => (
   </C.Wrapper>
 );
 
+/**
+ * A clean rewards placeholder
+ *
+ * @category Component
+ *
+ */
 const RewardsClean = designable(rewardsComponents, 'Rewards')(RewardsCleanBase);
 
+/**
+ * A token modifier that respects the Rewards Compoments.
+ *
+ * @category Token Collection
+ */
 const asRewardsToken = asVitalTokenSpec<RewardsComponents>();
+
+// These are used in defining the VitalRewards interface.
+const rewardsToken = asRewardsToken();
+export type RewardsToken = typeof rewardsToken;
 
 export {
   RewardsClean,

--- a/packages/vital-layout/src/components/Footer/Rewards/index.ts
+++ b/packages/vital-layout/src/components/Footer/Rewards/index.ts
@@ -14,8 +14,17 @@
 
 // @TODO: As Rewards is implemented, move it outside Footer component into
 // a more appropriate place.
-// Also requires component structure reorganization for new static pattern.
+import vitalRewardsBaseOrig, { VitalRewards } from './tokens/vitalRewards';
+
+/**
+ * Use this version of the vital rewards tokens when extending or shadowing.
+ * @category Token Collection
+ * @see [[vitalRewards]]
+ */
+const vitalRewardsBase = vitalRewardsBaseOrig;
+
 export { RewardsClean, asRewardsToken } from './RewardsClean';
 export { default as vitalRewards } from './tokens';
-export { default as vitalRewardsBase } from './tokens/vitalRewards';
 export type { RewardsComponents, RewardsProps } from './types';
+
+export { vitalRewardsBase, VitalRewards };

--- a/packages/vital-layout/src/components/Footer/Rewards/tokens/vitalRewards.ts
+++ b/packages/vital-layout/src/components/Footer/Rewards/tokens/vitalRewards.ts
@@ -19,6 +19,7 @@ import {
   withProps,
 } from '@bodiless/fclasses';
 import { asRewardsToken } from '../RewardsClean';
+import type { RewardsToken } from '../RewardsClean';
 
 /*
  * @TODO
@@ -105,7 +106,33 @@ const Default = asRewardsToken({
   ...Base,
 });
 
-export default {
+/**
+ * Tokens for the vital Rewards PLACEHOLDER
+ *
+ * @category Token Collection
+ * @see [[RewardsClean]]
+ */
+export interface VitalRewards {
+  /**
+   * Base Styled PLACEHOLDER
+   */
+  Base: RewardsToken,
+  /**
+   * Inherits Base
+   */
+  Default: RewardsToken,
+}
+
+/**
+ * Tokens for Vital Copyright Row
+ *
+ * @category Token Collection
+ * @see [[VitalRewards]]
+ * @see [[RewardsClean]]
+ */
+const vitalRewards: VitalRewards = {
   Base,
   Default,
 };
+
+export default vitalRewards;

--- a/packages/vital-layout/src/components/Footer/Rewards/types.ts
+++ b/packages/vital-layout/src/components/Footer/Rewards/types.ts
@@ -15,9 +15,11 @@
 import { ComponentOrTag, DesignableComponents, DesignableComponentsProps } from '@bodiless/fclasses';
 
 /**
- * Type of the design element in the VitalDS `Rewards` component
- * This is a Stub component that renders a placeholder
+ * Type of the design element in the VitalDS `Rewards` component.
+ * This is a Stub component that renders a placeholder.
+ *
  * RECOMMEND TO NOT USE and marked as deprecated
+ *
  * @category Component
  * @deprecated
  */

--- a/packages/vital-layout/src/components/Footer/Rewards/types.ts
+++ b/packages/vital-layout/src/components/Footer/Rewards/types.ts
@@ -12,9 +12,16 @@
  * limitations under the License.
  */
 
-import { ComponentOrTag, DesignableComponentsProps } from '@bodiless/fclasses';
+import { ComponentOrTag, DesignableComponents, DesignableComponentsProps } from '@bodiless/fclasses';
 
-type RewardsComponents = {
+/**
+ * Type of the design element in the VitalDS `Rewards` component
+ * This is a Stub component that renders a placeholder
+ * RECOMMEND TO NOT USE and marked as deprecated
+ * @category Component
+ * @deprecated
+ */
+interface RewardsComponents extends DesignableComponents {
   Wrapper: ComponentOrTag<any>,
   Brand: ComponentOrTag<any>,
   Title: ComponentOrTag<any>,
@@ -24,7 +31,7 @@ type RewardsComponents = {
   FormTextEmail: ComponentOrTag<any>,
   FormButton: ComponentOrTag<any>,
   Footnote: ComponentOrTag<any>,
-};
+}
 
 type RewardsProps = DesignableComponentsProps<RewardsComponents>;
 

--- a/packages/vital-layout/src/components/Footer/SocialLinks/SocialLinksClean.tsx
+++ b/packages/vital-layout/src/components/Footer/SocialLinks/SocialLinksClean.tsx
@@ -52,7 +52,7 @@ const SocialLinksCleanBase: FC<SocialLinksProps> = ({ components: C, ...rest }) 
 const SocialLinksClean = designable(socialLinksComponents, 'SocialLinks')(SocialLinksCleanBase);
 
 /**
- * A token modifier that respects the Social Links Compoments.
+ * A token modifier that respects the Social Links Components.
  *
  * @category Token Collection
  */

--- a/packages/vital-layout/src/components/Footer/SocialLinks/SocialLinksClean.tsx
+++ b/packages/vital-layout/src/components/Footer/SocialLinks/SocialLinksClean.tsx
@@ -39,11 +39,23 @@ const SocialLinksCleanBase: FC<SocialLinksProps> = ({ components: C, ...rest }) 
   </C.Wrapper>
 );
 
+/**
+ * A clean social links placeholder
+ *
+ * @category Component
+ *
+ */
 const SocialLinksClean = designable(socialLinksComponents, 'SocialLinks')(SocialLinksCleanBase);
 
+/**
+ * A token modifier that respects the Social Links Compoments.
+ *
+ * @category Token Collection
+ */
 const asSocialLinksToken = asVitalTokenSpec<SocialLinksComponents>();
 
-export {
-  SocialLinksClean,
-  asSocialLinksToken,
-};
+// These are used in defining the VitalSocialLinks interface.
+const socialLinksToken = asSocialLinksToken();
+export type SocialLinksToken = typeof socialLinksToken;
+
+export { SocialLinksClean, asSocialLinksToken };

--- a/packages/vital-layout/src/components/Footer/SocialLinks/SocialLinksClean.tsx
+++ b/packages/vital-layout/src/components/Footer/SocialLinks/SocialLinksClean.tsx
@@ -42,7 +42,11 @@ const SocialLinksCleanBase: FC<SocialLinksProps> = ({ components: C, ...rest }) 
 /**
  * A clean social links placeholder
  *
+ * RECOMMEND TO NOT EXTEND/OVERRIDE and marked as deprecated.
+ * In future it will move to its own package and be a list of icons.
+ *
  * @category Component
+ * @deprecated
  *
  */
 const SocialLinksClean = designable(socialLinksComponents, 'SocialLinks')(SocialLinksCleanBase);

--- a/packages/vital-layout/src/components/Footer/SocialLinks/index.ts
+++ b/packages/vital-layout/src/components/Footer/SocialLinks/index.ts
@@ -15,6 +15,17 @@
 // @TODO: As Social Links are implemented, move them outside Footer component into
 // a more appropriate place.
 // Also requires component structure reorganization for new static pattern.
+import vitalSocialLinksBaseOrig, { VitalSocialLinks } from './tokens/vitalSocialLinks';
+
+/**
+ * Use this version of the vital sociallinks tokens when extending or shadowing.
+ * @category Token Collection
+ * @see [[vitalSocialLinks]]
+ */
+const vitalSocialLinksBase = vitalSocialLinksBaseOrig;
+
 export { SocialLinksClean, asSocialLinksToken } from './SocialLinksClean';
 export { default as vitalSocialLinks } from './tokens';
 export type { SocialLinksComponents, SocialLinksProps } from './types';
+
+export { vitalSocialLinksBase, VitalSocialLinks };

--- a/packages/vital-layout/src/components/Footer/SocialLinks/tokens/vitalSocialLinks.ts
+++ b/packages/vital-layout/src/components/Footer/SocialLinks/tokens/vitalSocialLinks.ts
@@ -17,6 +17,7 @@ import {
   startWith,
 } from '@bodiless/fclasses';
 import { asSocialLinksToken } from '../SocialLinksClean';
+import type { SocialLinksToken } from '../SocialLinksClean';
 
 const Base = asSocialLinksToken({
   Components: {
@@ -33,7 +34,33 @@ const Default = asSocialLinksToken({
   ...Base,
 });
 
-export default {
+/**
+ * Tokens for the vital Social Links
+ *
+ * @category Token Collection
+ * @see [[SocialLinksClean]]
+ */
+export interface VitalSocialLinks {
+  /**
+   * Base applies styling to have social links in row at specific size
+   */
+  Base: SocialLinksToken,
+  /**
+   * Inherits Base
+   */
+  Default: SocialLinksToken,
+}
+
+/**
+ * Tokens for Vital Social Links
+ *
+ * @category Token Collection
+ * @see [[VitalSocialLinks]]
+ * @see [[SocialLinksClean]]
+ */
+const vitalSocialLinks: VitalSocialLinks = {
   Base,
   Default,
 };
+
+export default vitalSocialLinks;

--- a/packages/vital-layout/src/components/Footer/SocialLinks/tokens/vitalSocialLinks.ts
+++ b/packages/vital-layout/src/components/Footer/SocialLinks/tokens/vitalSocialLinks.ts
@@ -42,7 +42,7 @@ const Default = asSocialLinksToken({
  */
 export interface VitalSocialLinks {
   /**
-   * Base applies styling to have social links in row at specific size
+   * Base applies styling to have social links in a row at specific size
    */
   Base: SocialLinksToken,
   /**

--- a/packages/vital-layout/src/components/Footer/SocialLinks/types.ts
+++ b/packages/vital-layout/src/components/Footer/SocialLinks/types.ts
@@ -12,15 +12,36 @@
  * limitations under the License.
  */
 
-import { ComponentOrTag, DesignableComponentsProps } from '@bodiless/fclasses';
+import { ComponentOrTag, DesignableComponents, DesignableComponentsProps } from '@bodiless/fclasses';
 
-type SocialLinksComponents = {
+/**
+  * Type of the design element in the VitalDS `Social Links` component which
+  * consists of linkable icons.  This is Stub component that renders
+  * Facebook/Instagram/Youtube links.
+  * @category Component
+  */
+interface SocialLinksComponents extends DesignableComponents {
+  /**
+   * Wrapper around social links component
+   */
   Wrapper: ComponentOrTag<any>,
+  /**
+   * Inner wrapper used for styling
+   */
   InnerWrapper: ComponentOrTag<any>,
+  /**
+   * Used for Facebook social link
+   */
   IconFacebook: ComponentOrTag<any>,
+  /**
+   * Used for Instagram social link
+   */
   IconInstagram: ComponentOrTag<any>,
+  /**
+   * Used for Youtube social link
+   */
   IconYouTube: ComponentOrTag<any>,
-};
+}
 
 type SocialLinksProps = DesignableComponentsProps<SocialLinksComponents>;
 

--- a/packages/vital-layout/src/components/Footer/SocialLinks/types.ts
+++ b/packages/vital-layout/src/components/Footer/SocialLinks/types.ts
@@ -18,7 +18,12 @@ import { ComponentOrTag, DesignableComponents, DesignableComponentsProps } from 
   * Type of the design element in the VitalDS `Social Links` component which
   * consists of linkable icons.  This is Stub component that renders
   * Facebook/Instagram/Youtube links.
+  *
+  * RECOMMEND TO NOT EXTEND/OVERRIDE and marked as deprecated.
+  * In future it will move to its own package and be a list of icons.
+  *
   * @category Component
+  * @deprecated
   */
 interface SocialLinksComponents extends DesignableComponents {
   /**

--- a/packages/vital-layout/src/components/Footer/index.ts
+++ b/packages/vital-layout/src/components/Footer/index.ts
@@ -12,10 +12,21 @@
  * limitations under the License.
  */
 
+import vitalFooterBaseOrig, { VitalFooter } from './tokens/vitalFooter';
+
+/**
+ * Use this version of the vital footer tokens when extending or shadowing.
+ * @category Token Collection
+ * @see [[vitalFooter]]
+ */
+const vitalFooterBase = vitalFooterBaseOrig;
+
 export { default as FooterClean, asFooterToken } from './FooterClean';
 export { default as vitalFooter } from './tokens';
 export type { FooterComponents, FooterProps } from './types';
-export { default as vitalFooterBase } from './tokens/vitalFooter';
 
 export * from './Rewards';
 export * from './CopyrightRow';
+export * from './SocialLinks';
+
+export { vitalFooterBase, VitalFooter };

--- a/packages/vital-layout/src/components/Footer/tokens/vitalFooter.ts
+++ b/packages/vital-layout/src/components/Footer/tokens/vitalFooter.ts
@@ -20,7 +20,7 @@ import {
 } from '@bodiless/fclasses';
 import { vitalRewards, RewardsClean } from '../Rewards';
 import { vitalCopyrightRow } from '../CopyrightRow';
-import { asFooterToken } from '../FooterClean';
+import { asFooterToken, FooterToken } from '../FooterClean';
 
 const Base = asFooterToken({
   Components: {
@@ -91,9 +91,45 @@ const FooterWithRewards = asFooterToken(Base, {
   ...WithRewardsExpanding2XL,
 });
 
-export default {
+/**
+ * Tokens for the vital footer
+ *
+ * @category Token Collection
+ * @see [[FooterClean]]
+ */
+export interface VitalFooter {
+  /**
+   * Base applies the following:
+   * - Footer Menu
+   * - Copyright row (with copyright editor & social links)
+   */
+  Base: FooterToken,
+  /**
+   * Inherits from Base
+   */
+  Default: FooterToken,
+  /**
+   * Token that extends base with to move rewards above footer on 2xl responsive viewports
+   */
+  FooterWithRewards: FooterToken,
+  /**
+   * An extendable token to move rewards above footer on 2xl responsive viewports
+   */
+  WithRewardsExpanding2XL: FooterToken,
+}
+
+/**
+ * Tokens for Vital Footer
+ *
+ * @category Token Collection
+ * @see [[VitalFooter]]
+ * @see [[FooterClean]]
+ */
+const vitalFooter: VitalFooter = {
   Base,
   Default,
   FooterWithRewards,
   WithRewardsExpanding2XL,
 };
+
+export default vitalFooter;

--- a/packages/vital-layout/src/components/Footer/tokens/vitalFooter.ts
+++ b/packages/vital-layout/src/components/Footer/tokens/vitalFooter.ts
@@ -106,6 +106,27 @@ export interface VitalFooter {
   Base: FooterToken,
   /**
    * Inherits from Base
+   * @example Will remove Menu components
+   * ```js
+   * import { vitalFooterBase, asFooterToken, } from '@bodiless/vital-layout';
+   * import { replaceWith } from '@bodiless/fclasses';
+   *
+   * const Default = asFooterToken({
+   *   ...vitalFooterBase.Default,
+   *   Components: {
+   *     ...vitalFooterBase.Default.Components,
+   *     FooterMenuWrapper: replaceWith(() => null),
+   *     FooterMenu: replaceWith(() => null),
+   *     MenuRow: replaceWith(() => null),
+   *   },
+   * }),
+   *
+   * export default {
+   *   ...vitalFooterBase,
+   *   Default,
+   * };
+   * ```
+   *
    */
   Default: FooterToken,
   /**

--- a/packages/vital-layout/src/components/Footer/types.ts
+++ b/packages/vital-layout/src/components/Footer/types.ts
@@ -15,7 +15,15 @@
 import { ComponentOrTag, DesignableComponents, DesignableComponentsProps } from '@bodiless/fclasses';
 
 /**
- * Type of the design element in the VitalDS `Footer` component.
+ * Type of the design element in the VitalDS `Footer` component which
+ * consists of:
+ * - Two columns:
+ *   - First column is Rewards which can be displayed above footer on larger viewports
+ *   - Second column as Menus where each menu is in its own column
+ * - CopyrightRow: which can go in under columns (CopyrightRowOutsideColumns)
+ *   or in second column (CopyrightRow) and consists of:
+ *   - Copyright Editor
+ *   - Social Links
  *
  * @category Component
  */

--- a/packages/vital-layout/src/components/Footer/types.ts
+++ b/packages/vital-layout/src/components/Footer/types.ts
@@ -12,21 +12,60 @@
  * limitations under the License.
  */
 
-import { ComponentOrTag, DesignableComponentsProps } from '@bodiless/fclasses';
+import { ComponentOrTag, DesignableComponents, DesignableComponentsProps } from '@bodiless/fclasses';
 
-type FooterComponents = {
+/**
+ * Type of the design element in the VitalDS `Footer` component.
+ *
+ * @category Component
+ */
+interface FooterComponents extends DesignableComponents {
+  /**
+   * Wrapper around entire Footer
+   */
   Wrapper: ComponentOrTag<any>,
+  /**
+   * Container to hold the specific footer components
+   */
   Container: ComponentOrTag<any>,
+  /**
+   * Wrapper for the a container in the first column
+   */
   Column1Wrapper: ComponentOrTag<any>,
+  /**
+   * Wrapper for the a container in the second column
+   */
   Column2Wrapper: ComponentOrTag<any>,
+  /**
+   * Used for the menus
+   */
   MenuRow: ComponentOrTag<any>,
+  /**
+   * Used for Copyright in the second column
+   */
   CopyrightRow: ComponentOrTag<any>,
+  /**
+   * Used for Copyright after the columns
+   * By Default this a Fragment and not rendered
+   */
   CopyrightRowOutsideColumns: ComponentOrTag<any>,
+  /**
+   * Wrapper for the Rewards
+   */
   RewardsWrapper: ComponentOrTag<any>,
+  /**
+   * Used for Rewards/Special component and is in the first column
+   */
   Rewards: ComponentOrTag<any>,
+  /**
+   * Wrapper around footer menus.
+   */
   FooterMenuWrapper: ComponentOrTag<any>,
+  /**
+   * Used for the footer menus.
+   */
   FooterMenu: ComponentOrTag<any>,
-};
+}
 
 type FooterProps = DesignableComponentsProps<FooterComponents>;
 

--- a/packages/vital-layout/src/components/Header/HeaderClean.tsx
+++ b/packages/vital-layout/src/components/Header/HeaderClean.tsx
@@ -104,7 +104,7 @@ const HeaderClean = designable(headerComponents, 'Header')(HeaderCleanBase);
 const HeaderStatic = withoutHydration()(HeaderClean);
 
 /**
- * A token modifier that respects the Header Compoments.
+ * A token modifier that respects the Header Components.
  *
  * @category Token Collection
  */

--- a/packages/vital-layout/src/components/Header/HeaderClean.tsx
+++ b/packages/vital-layout/src/components/Header/HeaderClean.tsx
@@ -88,12 +88,31 @@ const HeaderCleanBase: FC<HeaderProps> = ({ components: C, ...rest }) => (
 );
 
 /**
- * A clean header to be used in pages layouts.
+ * A clean header to be used in pages layouts following vital design
+ *
+ * @category Component
+ *
  */
 const HeaderClean = designable(headerComponents, 'Header')(HeaderCleanBase);
+
+/**
+ * Use this version of the card when all components are static.
+ *
+ * @category Component
+ *
+ */
 const HeaderStatic = withoutHydration()(HeaderClean);
 
+/**
+ * A token modifier that respects the Header Compoments.
+ *
+ * @category Token Collection
+ */
 const asHeaderToken = asVitalTokenSpec<HeaderComponents>();
+
+// These are used in defining the VitalHeader interface.
+const headerToken = asHeaderToken();
+export type HeaderToken = typeof headerToken;
 
 export default HeaderClean;
 

--- a/packages/vital-layout/src/components/Header/HeaderClean.tsx
+++ b/packages/vital-layout/src/components/Header/HeaderClean.tsx
@@ -88,7 +88,7 @@ const HeaderCleanBase: FC<HeaderProps> = ({ components: C, ...rest }) => (
 );
 
 /**
- * A clean header to be used in pages layouts following vital design
+ * A clean header to be used in pages layouts following vital design.
  *
  * @category Component
  *
@@ -96,7 +96,7 @@ const HeaderCleanBase: FC<HeaderProps> = ({ components: C, ...rest }) => (
 const HeaderClean = designable(headerComponents, 'Header')(HeaderCleanBase);
 
 /**
- * Use this version of the card when all components are static.
+ * Use this version of the header when all components are static.
  *
  * @category Component
  *

--- a/packages/vital-layout/src/components/Header/index.ts
+++ b/packages/vital-layout/src/components/Header/index.ts
@@ -12,7 +12,17 @@
  * limitations under the License.
  */
 
-export { default as HeaderClean, asHeaderToken } from './HeaderClean';
-export { default as vitalHeaderBase } from './tokens/vitalHeader';
+import vitalHeaderBaseOrig, { VitalHeader } from './tokens/vitalHeader';
+
+/**
+ * Use this version of the vital helmet tokens when extending or shadowing.
+ * @category Token Collection
+ * @see [[vitalHeader]]
+ */
+const vitalHeaderBase = vitalHeaderBaseOrig;
+
+export { default as HeaderClean, asHeaderToken, HeaderStatic } from './HeaderClean';
 export { default as vitalHeader } from './tokens';
 export type { HeaderComponents, HeaderProps } from './types';
+
+export { vitalHeaderBase, VitalHeader };

--- a/packages/vital-layout/src/components/Header/tokens/vitalHeader.ts
+++ b/packages/vital-layout/src/components/Header/tokens/vitalHeader.ts
@@ -31,11 +31,9 @@ import { vitalSearchMenu, vitalSearchToggler, asSearchMenuToggler } from '@bodil
 import { vitalButtons } from '@bodiless/vital-buttons';
 import { vitalLogo } from '../../Logo';
 import { asHeaderToken } from '../HeaderClean';
+import type { HeaderToken } from '../HeaderClean';
 import BurgerIcon from '../assets/BurgerIcon';
 
-/**
- * Token that defines a basic header.
- */
 const Base = asHeaderToken({
   Core: {
     MenuToggler: asBurgerMenuToggler,
@@ -98,7 +96,38 @@ const Default = asHeaderToken({
   ...Base,
 });
 
-const vitalHeader = {
+/**
+ * Tokens for the vital header
+ *
+ * @category Token Collection
+ * @see [[HeaderClean]]
+ */
+export interface VitalHeader {
+  /**
+   * Base applies the following as defaults:
+   * - Logo
+   * - Togglers: BurgerMenu, Search
+   * - Defines the components: Logo, Menu, BurgerMenu, Search, WhereToBuy
+   */
+  Base: HeaderToken,
+  /**
+   * Inherits Base
+   */
+  Default: HeaderToken,
+  /**
+   * Extendable token that adds language selector
+   */
+  WithLanguageSelector: HeaderToken,
+}
+
+/**
+ * Tokens for Vital Header
+ *
+ * @category Token Collection
+ * @see [[VitalHeader]]
+ * @see [[HeaderClean]]
+ */
+const vitalHeader: VitalHeader = {
   Base,
   Default,
   WithLanguageSelector,

--- a/packages/vital-layout/src/components/Header/tokens/vitalHeader.ts
+++ b/packages/vital-layout/src/components/Header/tokens/vitalHeader.ts
@@ -112,6 +112,28 @@ export interface VitalHeader {
   Base: HeaderToken,
   /**
    * Inherits Base
+   *
+   * @example Will remove Search components & Where to Buy components
+   * ```js
+   * import { vitalHeaderBase, asHeaderToken, } from '@bodiless/vital-layout';
+   * import { replaceWith } from '@bodiless/fclasses';
+   *
+   * const Default = asHeaderToken({
+   *   ...vitalHeaderBase.Default,
+   *   Components: {
+   *     ...vitalHeaderBase.Default.Components,
+   *     DesktopSearch: replaceWith(() => null),
+   *     MobileSearch: replaceWith(() => null),
+   *     WhereToBuy: replaceWith(() => null),
+   *     SearchToggler: replaceWith(() => null),
+   *   },
+   * }),
+   *
+   * export default {
+   *   ...vitalHeaderBase,
+   *   Default,
+   * };
+   * ```
    */
   Default: HeaderToken,
   /**

--- a/packages/vital-layout/src/components/Header/types.ts
+++ b/packages/vital-layout/src/components/Header/types.ts
@@ -16,7 +16,15 @@ import { HTMLProps } from 'react';
 import { ComponentOrTag, DesignableComponents, DesignableComponentsProps } from '@bodiless/fclasses';
 
 /**
- * Type of the design element in the VitalDS `Header` component.
+ * Type of the design element in the VitalDS `Header` component which consists of:
+ * - Logo
+ * - Menu
+ * - Burger Menu toggler (on mobile)
+ * - LanguageeSelector
+ * - Search (mobile & desktop slots)
+ * - Search toggler (on mobile)
+ * - Utility Menu (second menu)
+ * - Where to Buy
  *
  * @category Component
  */

--- a/packages/vital-layout/src/components/Header/types.ts
+++ b/packages/vital-layout/src/components/Header/types.ts
@@ -13,29 +13,94 @@
  */
 
 import { HTMLProps } from 'react';
-import { ComponentOrTag, DesignableComponentsProps } from '@bodiless/fclasses';
+import { ComponentOrTag, DesignableComponents, DesignableComponentsProps } from '@bodiless/fclasses';
 
-export type HeaderComponents = {
+/**
+ * Type of the design element in the VitalDS `Header` component.
+ *
+ * @category Component
+ */
+export interface HeaderComponents extends DesignableComponents {
+  /**
+   * Wrapper around entire header
+   */
   Wrapper: ComponentOrTag<any>,
+  /**
+   * Container to hold the specific header components
+   */
   Container: ComponentOrTag<any>,
+  /**
+   * Container to hold the menu components
+   */
   MenuContainer: ComponentOrTag<any>,
+  /**
+   * Wrapper around menu toggler
+   */
   MenuTogglerWrapper: ComponentOrTag<any>,
+  /**
+   * Used for icon/link to open menu on smaller breakpoints
+   */
   MenuToggler: ComponentOrTag<any>,
+  /**
+   * Wrapper around menu
+   */
   MenuWrapper: ComponentOrTag<any>,
+  /**
+   * Used for the desktop menu
+   */
   Menu: ComponentOrTag<any>,
+  /**
+   * Wrapper around burger menu toggler
+   */
   BurgerMenuWrapper: ComponentOrTag<any>,
+  /**
+   * Used for burger menu on smaller breakpoints.
+   */
   BurgerMenu: ComponentOrTag<any>,
+  /**
+   * Used for logo
+   */
   Logo: ComponentOrTag<any>,
+  /**
+   * Wrapper container fo user interactions in header
+   */
   ActionMenuContainer: ComponentOrTag<any>,
+  /**
+   * Wrapper around utility menu
+   */
   UtilityMenuWrapper: ComponentOrTag<any>,
+  /**
+   * Used for secondary/utility menu
+   */
   UtilityMenu: ComponentOrTag<any>,
+  /**
+   * Wrapper around language selector
+   */
   LanguageSelectorWrapper: ComponentOrTag<any>,
+  /**
+   * Used for language selector link/select
+   */
   LanguageSelector: ComponentOrTag<any>,
+  /**
+   * Wrapper around where to buy toggler
+   */
   WhereToBuyWrapper: ComponentOrTag<any>,
+  /**
+   * Used for a Link to Where to buy
+   */
   WhereToBuy: ComponentOrTag<any>,
+  /**
+   * Used for a search box on desktop
+   */
   DesktopSearch: ComponentOrTag<any>,
+  /**
+   * Used to show mobile search box
+   */
   MobileSearch: ComponentOrTag<any>,
+  /**
+   * Used for the link/toggle on smaller devices to show search box
+   */
   SearchToggler: ComponentOrTag<any>,
-};
+}
 
 export type HeaderProps = DesignableComponentsProps<HeaderComponents> & HTMLProps<HTMLElement>;

--- a/packages/vital-layout/src/components/Helmet/HelmetClean.tsx
+++ b/packages/vital-layout/src/components/Helmet/HelmetClean.tsx
@@ -74,14 +74,21 @@ const helmetComponents: HelmetComponents = {
 /**
  * A designable component which can be used to add different elements to the
  * head section, html or body tags.
+ *
+ * @category Component
+ *
  */
 const HelmetClean = designable(helmetComponents, 'Helmet')(HelmetBase);
 
 export default HelmetClean;
 
 /**
- * Use this to define a token applicable to the VitalDS `HelmetClean` component.
+ * A token modifier that respects the Helmet Compoments.
  *
- * @see HelmetClean
+ * @category Token Collection
  */
 export const asHelmetToken = asVitalTokenSpec<HelmetComponents>();
+
+// These are used in defining the VitalLayout interface.
+const helmetToken = asHelmetToken();
+export type HelmetToken = typeof helmetToken;

--- a/packages/vital-layout/src/components/Helmet/HelmetClean.tsx
+++ b/packages/vital-layout/src/components/Helmet/HelmetClean.tsx
@@ -83,7 +83,7 @@ const HelmetClean = designable(helmetComponents, 'Helmet')(HelmetBase);
 export default HelmetClean;
 
 /**
- * A token modifier that respects the Helmet Compoments.
+ * A token modifier that respects the Helmet Components.
  *
  * @category Token Collection
  */

--- a/packages/vital-layout/src/components/Helmet/index.ts
+++ b/packages/vital-layout/src/components/Helmet/index.ts
@@ -12,7 +12,17 @@
  * limitations under the License.
  */
 
-export { default as vitalHelmetBase } from './tokens/vitalHelmet';
+import vitalHelmetBaseOrig, { VitalHelmet } from './tokens/vitalHelmet';
+
+/**
+ * Use this version of the vital helmet tokens when extending or shadowing.
+ * @category Token Collection
+ * @see [[vitalHelmet]]
+ */
+const vitalHelmetBase = vitalHelmetBaseOrig;
+
 export { default as vitalHelmet } from './tokens';
 export { default as HelmetClean, asHelmetToken } from './HelmetClean';
 export { HelmetComponents, HelmetProps } from './types';
+
+export { vitalHelmetBase, VitalHelmet };

--- a/packages/vital-layout/src/components/Helmet/tokens/vitalHelmet.ts
+++ b/packages/vital-layout/src/components/Helmet/tokens/vitalHelmet.ts
@@ -26,6 +26,9 @@ const Base = asHelmetToken({
     // LanguageHelmet: TBD,
     GA4Helmet: replaceWith(DefaultPageGA4DataLayerHelmet),
   },
+});
+
+const Default = asHelmetToken(Base, {
   Theme: {
     HTMLHelmet: as(
       'font-DMSans',
@@ -35,11 +38,7 @@ const Base = asHelmetToken({
   }
 });
 
-const Default = asHelmetToken({
-  ...Base,
-});
-
-const WithDesktopStatickBody = asHelmetToken({
+const WithDesktopStaticBody = asHelmetToken({
   Layout: {
     BodyHelmet: 'lg:static',
   },
@@ -63,13 +62,34 @@ export interface VitalHelmet {
    */
   Base: HelmetToken,
   /**
-   * Inherits from Base
+   * Inherits from Base and adds in vitalds theming
+   *
+   * @example Sets the html `lang` and changes the html font & color for entire page
+   * ```js
+   * import { vitalHelmetBase, asHelmetToken } from '@bodiless/vital-layout';
+   * import { withLangDirProps } from '@bodiless/i18n';
+   * import { as, addProps } from '@bodiless/fclasses';
+   *
+   * const Default = asHelmetToken(vitalHelmetBase.Base, {
+   *   Core: {
+   *     LanguageHelmet: withLangDirProps,
+   *   },
+   *   Theme: {
+   *     HTMLHelmet: 'font-Inter text-gray-600',
+   *   },
+   * });
+   *
+   * export default {
+   *   ...vitalHelmetBase,
+   *   Default,
+   * };
+   * ```
    */
   Default: HelmetToken,
   /**
-   * WithDesktopStatickBody token applies static position on body.
+   * WithDesktopStaticBody token applies static position on body.
    */
-  WithDesktopStatickBody: HelmetToken,
+  WithDesktopStaticBody: HelmetToken,
   /**
    * WithFixedBody token applies fixed position on body to prevent scrolling.
    */
@@ -86,7 +106,7 @@ export interface VitalHelmet {
 const vitalHelmet: VitalHelmet = {
   Base,
   Default,
-  WithDesktopStatickBody,
+  WithDesktopStaticBody,
   WithFixedBody,
 };
 

--- a/packages/vital-layout/src/components/Helmet/tokens/vitalHelmet.ts
+++ b/packages/vital-layout/src/components/Helmet/tokens/vitalHelmet.ts
@@ -16,6 +16,7 @@ import { vitalMetaHelmet } from '@bodiless/vital-meta';
 import { as, replaceWith } from '@bodiless/fclasses';
 import { DefaultPageGA4DataLayerHelmet } from '@bodiless/ga4';
 import { asHelmetToken } from '../HelmetClean';
+import type { HelmetToken } from '../HelmetClean';
 // eslint-disable-next-line import/order
 
 const Base = asHelmetToken({
@@ -38,27 +39,55 @@ const Default = asHelmetToken({
   ...Base,
 });
 
-/**
- * WithDesktopStatickBody token applies static position on body.
- */
 const WithDesktopStatickBody = asHelmetToken({
   Layout: {
     BodyHelmet: 'lg:static',
   },
 });
 
-/**
- * WithFixedBody token applies fixed position on body to prevent scrolling.
- */
 const WithFixedBody = asHelmetToken({
   Layout: {
     BodyHelmet: 'fixed',
   },
 });
 
-export default {
+/**
+ * Tokens for the vital helmet
+ *
+ * @category Token Collection
+ * @see [[HelmetClean]]
+ */
+export interface VitalHelmet {
+  /**
+   * Base applies the SEO, Share, GA4 helmets
+   */
+  Base: HelmetToken,
+  /**
+   * Inherits from Base
+   */
+  Default: HelmetToken,
+  /**
+   * WithDesktopStatickBody token applies static position on body.
+   */
+  WithDesktopStatickBody: HelmetToken,
+  /**
+   * WithFixedBody token applies fixed position on body to prevent scrolling.
+   */
+  WithFixedBody: HelmetToken,
+}
+
+/**
+ * Tokens for Vital Helmet
+ *
+ * @category Token Collection
+ * @see [[VitalHelmet]]
+ * @see [[HelmetClean]]
+ */
+const vitalHelmet: VitalHelmet = {
   Base,
   Default,
   WithDesktopStatickBody,
   WithFixedBody,
 };
+
+export default vitalHelmet;

--- a/packages/vital-layout/src/components/Helmet/types.ts
+++ b/packages/vital-layout/src/components/Helmet/types.ts
@@ -15,7 +15,8 @@
 import { ComponentOrTag, DesignableComponents, DesignableComponentsProps } from '@bodiless/fclasses';
 
 /**
- * Type of the design element in the VitalDS `Helmet` component.
+ * Type of the design element in the VitalDS `Helmet` component which consists of Helmet
+ * slots for Meta data, adding tags to HTML, Body, and adding analytics data.
  *
  * @category Component
  */

--- a/packages/vital-layout/src/components/Helmet/types.ts
+++ b/packages/vital-layout/src/components/Helmet/types.ts
@@ -12,12 +12,14 @@
  * limitations under the License.
  */
 
-import { ComponentOrTag, DesignableComponentsProps } from '@bodiless/fclasses';
+import { ComponentOrTag, DesignableComponents, DesignableComponentsProps } from '@bodiless/fclasses';
 
 /**
  * Type of the design element in the VitalDS `Helmet` component.
+ *
+ * @category Component
  */
-export type HelmetComponents = {
+export interface HelmetComponents extends DesignableComponents {
   /**
    * Used to add hreflang alternate links.
    */
@@ -46,6 +48,6 @@ export type HelmetComponents = {
    * Used to add arbitrary attributes or classes to the BODY tag.
    */
   BodyHelmet: ComponentOrTag<any>,
-};
+}
 
 export type HelmetProps = DesignableComponentsProps<HelmetComponents>;

--- a/packages/vital-layout/src/components/Layout/LayoutClean.tsx
+++ b/packages/vital-layout/src/components/Layout/LayoutClean.tsx
@@ -83,8 +83,23 @@ export const LayoutCleanBase: FC<LayoutProps> = (layoutProps: LayoutProps) => {
   );
 };
 
-export const LayoutClean = designable(layoutComponents, 'Layout')(LayoutCleanBase);
+/**
+ * This is the base component for layout.
+ *
+ * @category Component
+ *
+ */
+const LayoutClean = designable(layoutComponents, 'Layout')(LayoutCleanBase);
 
+/**
+ * A token modifier that respects the Layout Compoments.
+ *
+ * @category Token Collection
+ */
 const asLayoutToken = asVitalTokenSpec<LayoutComponents>();
 
-export { asLayoutToken };
+// These are used in defining the VitalLayout interface.
+const layoutToken = asLayoutToken();
+export type LayoutToken = typeof layoutToken;
+
+export { LayoutClean, asLayoutToken };

--- a/packages/vital-layout/src/components/Layout/LayoutClean.tsx
+++ b/packages/vital-layout/src/components/Layout/LayoutClean.tsx
@@ -92,7 +92,7 @@ export const LayoutCleanBase: FC<LayoutProps> = (layoutProps: LayoutProps) => {
 const LayoutClean = designable(layoutComponents, 'Layout')(LayoutCleanBase);
 
 /**
- * A token modifier that respects the Layout Compoments.
+ * A token modifier that respects the Layout Components.
  *
  * @category Token Collection
  */

--- a/packages/vital-layout/src/components/Layout/index.ts
+++ b/packages/vital-layout/src/components/Layout/index.ts
@@ -12,7 +12,17 @@
  * limitations under the License.
  */
 
+import vitalLayoutBaseOrig, { VitalLayout } from './tokens/vitalLayout';
+
+/**
+ * Use this version of the vital layout tokens when extending or shadowing.
+ * @category Token Collection
+ * @see [[vitalLayout]]
+ */
+const vitalLayoutBase = vitalLayoutBaseOrig;
+
 export { LayoutClean, asLayoutToken } from './LayoutClean';
 export { default as vitalLayout } from './tokens';
 export type { LayoutComponents, LayoutProps } from './types';
-export { default as vitalLayoutBase } from './tokens/vitalLayout';
+
+export { vitalLayoutBase, VitalLayout };

--- a/packages/vital-layout/src/components/Layout/tokens/constants.ts
+++ b/packages/vital-layout/src/components/Layout/tokens/constants.ts
@@ -13,6 +13,12 @@
  */
 
 export enum LayoutIds {
+  /**
+   * Header ID
+   */
   HeaderContent = 'header-content',
+  /**
+   * Content ID, used by Skip To Main content.
+   */
   Content = 'main-content',
 }

--- a/packages/vital-layout/src/components/Layout/tokens/vitalLayout.ts
+++ b/packages/vital-layout/src/components/Layout/tokens/vitalLayout.ts
@@ -22,15 +22,13 @@ import {
 } from '@bodiless/fclasses';
 import { WithStructuredDataProvider } from '@bodiless/schema-org';
 import { asLayoutToken } from '../LayoutClean';
+import type { LayoutToken } from '../LayoutClean';
 import { vitalFooter } from '../../Footer';
 import { vitalHeader } from '../../Header';
 import { vitalHelmet } from '../../Helmet';
 import { LayoutIds } from './constants';
 import { StyleGuide } from './StyleGuide';
 
-/**
- * Token that defines a basic layout.
- */
 const Base = asLayoutToken({
   Core: {
     _: as(withBurgerMenuProvider, withBreadcrumbStore),
@@ -76,8 +74,38 @@ const Default = asLayoutToken(Base, {
   },
 });
 
-export default {
+/**
+ * Tokens for the vital layout
+ *
+ * @category Token Collection
+ * @see [[LayoutClean]]
+ */
+export interface VitalLayout {
+  /**
+   * Base that defines the default layout.
+   */
+  Base: LayoutToken,
+  /**
+   * Inherits from Base & assigns the components vitalHeader.Default & vitalFooter.FootWithRewards
+   */
+  Default: LayoutToken,
+  /**
+   * Special layout to demonstrate components.  Only used for testing purposing.
+   */
+  StyleGuide: LayoutToken,
+}
+
+/**
+ * Tokens for Vital Layout
+ *
+ * @category Token Collection
+ * @see [[VitalLayout]]
+ * @see [[LayoutClean]]
+ */
+const vitalLayout: VitalLayout = {
   Base,
   Default,
   StyleGuide,
 };
+
+export default vitalLayout;

--- a/packages/vital-layout/src/components/Layout/tokens/vitalLayout.ts
+++ b/packages/vital-layout/src/components/Layout/tokens/vitalLayout.ts
@@ -52,7 +52,7 @@ const Base = asLayoutToken({
   Layout: {
     Helmet: flowIf(
       not(useIsBurgerMenuHidden),
-    )(as(vitalHelmet.WithFixedBody, vitalHelmet.WithDesktopStatickBody)),
+    )(as(vitalHelmet.WithFixedBody, vitalHelmet.WithDesktopStaticBody)),
   },
   Theme: {
     OuterContainer: 'flex flex-col h-screen',
@@ -87,6 +87,46 @@ export interface VitalLayout {
   Base: LayoutToken,
   /**
    * Inherits from Base & assigns the components vitalHeader.Default & vitalFooter.FootWithRewards
+   *
+   * @example Override default to use custom Footer.
+   * ```js
+   * import { asLayoutToken, vitalHeader, vitalLayoutBase } from '@bodiless/vital-layout';
+   * import asMyFooter from '../../../components/Footer';
+   *
+   * const Default = asLayoutToken(vitalLayoutBase.Base, {
+   *   Components: {
+   *     Header: vitalHeader.Default,
+   *     Footer: asMyFooter,
+   *   },
+   * });
+   *
+   * export default {
+   *   ...vitalLayoutBase,
+   *   Default,
+   * };
+   * ```
+   *
+   * @example override the Skip To Main content with language specific
+   * ```js
+   * import { vitalLayoutBase, asLayoutToken } from '@bodiless/vital-layout';
+   * import { addProps, as } from '@bodiless/fclasses';
+   *
+   * const Default = asLayoutToken(vitalLayoutBase.Default, {
+   *   Behavior: {
+   *     SkipToMainContent: as(
+   *       addProps({
+   *         children: 'Passer au contenu principal',
+   *       }),
+   *     ),
+   *   },
+   * });
+   *
+   * export default {
+   *   ...vitalLayoutBase,
+   *   Default,
+   * };
+   * ```
+   *
    */
   Default: LayoutToken,
   /**

--- a/packages/vital-layout/src/components/Layout/types.ts
+++ b/packages/vital-layout/src/components/Layout/types.ts
@@ -13,20 +13,62 @@
  */
 
 import { HTMLProps } from 'react';
-import { ComponentOrTag, DesignableComponentsProps } from '@bodiless/fclasses';
+import { ComponentOrTag, DesignableComponents, DesignableComponentsProps } from '@bodiless/fclasses';
 
-export type LayoutComponents = {
+/**
+ * Design keys available for the Vital Layout.
+ *
+ * @category Component
+ */
+export interface LayoutComponents extends DesignableComponents {
+  /**
+   * The OuterContainer wrapper of the layout.  By default this is Div.
+   */
   OuterContainer: ComponentOrTag<any>,
+  /**
+   * Accessibility slot to render a skip to content link as top most element.
+   */
   SkipToMainContent: ComponentOrTag<any>,
+  /**
+   * Helmet slot to append additional items to helmet of layout.
+   */
   Helmet: ComponentOrTag<any>,
+  /**
+   * Header slot is a component often holding holding logo/menu.
+   */
   Header: ComponentOrTag<any>,
+  /**
+   * Header wrapper.  By default this is Fragment and not rendered.
+   * Useful if you need to add additional styling to apply to entire header.
+   */
   HeaderWrapper: ComponentOrTag<any>,
+  /**
+   * Footer slot is a component often displaying secondary menu & copyright.
+   */
   Footer: ComponentOrTag<any>,
+  /**
+   * Footer wrapper.  By default this is Fragment and not rendered.
+   * Useful if you need to add additional styling to apply to entire footer.
+   */
   FooterWrapper: ComponentOrTag<any>,
+  /**
+   * Container slot is for the content/template of the page.
+   */
   Container: ComponentOrTag<any>,
+  /**
+   * The ContainerWrapper wrapper of the layout.  By default this is Div.
+   */
   ContainerWrapper: ComponentOrTag<any>,
+  /**
+   * PageTopper slot - a slot that renders below header and before Container.
+   * By default this is Fragment and not rendered.
+   */
   PageTopper: ComponentOrTag<any>,
+  /**
+   * Pagetopper slot - a slot that renders after Container and above Footer.
+   * By default this is Fragment and not rendered.
+   */
   PageCloser: ComponentOrTag<any>,
-};
+}
 
 export type LayoutProps = DesignableComponentsProps<LayoutComponents> & HTMLProps<HTMLElement>;

--- a/packages/vital-layout/src/components/Layout/types.ts
+++ b/packages/vital-layout/src/components/Layout/types.ts
@@ -16,7 +16,12 @@ import { HTMLProps } from 'react';
 import { ComponentOrTag, DesignableComponents, DesignableComponentsProps } from '@bodiless/fclasses';
 
 /**
- * Design keys available for the Vital Layout.
+ * Design keys available for the Vital Layout which consists of
+ * - Helmet
+ * - Skip to main content
+ * - Header & Footer
+ * - Page Topper & Closer
+ * - Content Container
  *
  * @category Component
  */

--- a/packages/vital-layout/src/components/Logo/LogoClean.tsx
+++ b/packages/vital-layout/src/components/Logo/LogoClean.tsx
@@ -68,7 +68,7 @@ const LogoBase: FC<LogoProps> = ({ components: C }) => (
 );
 
 /**
- * A token modifier that respects the Logo Compoments.
+ * A token modifier that respects the Logo Components.
  *
  * @category Token Collection
  */

--- a/packages/vital-layout/src/components/Logo/LogoClean.tsx
+++ b/packages/vital-layout/src/components/Logo/LogoClean.tsx
@@ -28,7 +28,7 @@ import {
 } from '@bodiless/vital-elements';
 
 /**
- * Type of the design element in the VitalDS `Footer` component.
+ * Type of the design element in the VitalDS `Logo` component which consists of Linkable Image.
  *
  * @category Component
  */

--- a/packages/vital-layout/src/components/Logo/LogoClean.tsx
+++ b/packages/vital-layout/src/components/Logo/LogoClean.tsx
@@ -16,6 +16,7 @@ import React, { FC, HTMLProps } from 'react';
 
 import {
   A,
+  DesignableComponents,
   DesignableComponentsProps,
   Span,
   Img,
@@ -26,11 +27,25 @@ import {
   asVitalTokenSpec,
 } from '@bodiless/vital-elements';
 
-export type LogoComponents = {
+/**
+ * Type of the design element in the VitalDS `Footer` component.
+ *
+ * @category Component
+ */
+export interface LogoComponents extends DesignableComponents {
+  /**
+   * Wrapper for the Logo
+   */
   Wrapper: ComponentOrTag<any>,
+  /**
+   * Used for the image of the logo
+   */
   Image: ComponentOrTag<any>,
+  /**
+   * Used for the link of the logo
+   */
   Link: ComponentOrTag<any>,
-};
+}
 
 type LogoProps = DesignableComponentsProps<LogoComponents> & HTMLProps<HTMLElement>;
 
@@ -53,14 +68,22 @@ const LogoBase: FC<LogoProps> = ({ components: C }) => (
 );
 
 /**
- * Crete a logo token.
+ * A token modifier that respects the Logo Compoments.
+ *
+ * @category Token Collection
  */
 const asLogoToken = asVitalTokenSpec<LogoComponents>();
 
 /**
  * Clean component to be used for the site logo
+ *
+ * @category Component
  */
 const LogoClean = designable(logoComponents, 'Logo')(LogoBase);
+
+// These are used in defining the VitalLogo interface.
+const logoToken = asLogoToken();
+export type LogoToken = typeof logoToken;
 
 export default LogoClean;
 export { asLogoToken };

--- a/packages/vital-layout/src/components/Logo/index.ts
+++ b/packages/vital-layout/src/components/Logo/index.ts
@@ -12,17 +12,17 @@
  * limitations under the License.
  */
 
-import vitaLogoBaseOrig, { VitalLogo } from './tokens/vitalLogo';
+import vitalLogoBaseOrig, { VitalLogo } from './tokens/vitalLogo';
 
 /**
  * Use this version of the vital logo tokens when extending or shadowing.
  * @category Token Collection
  * @see [[vitalLogo]]
  */
-const vitaLogoBase = vitaLogoBaseOrig;
+const vitalLogoBase = vitalLogoBaseOrig;
 
 export { default as LogoClean, asLogoToken } from './LogoClean';
 export { default as vitalLogo } from './tokens';
 export type { LogoComponents } from './LogoClean';
 
-export { vitaLogoBase, VitalLogo};
+export { vitalLogoBase, VitalLogo};

--- a/packages/vital-layout/src/components/Logo/index.ts
+++ b/packages/vital-layout/src/components/Logo/index.ts
@@ -12,6 +12,17 @@
  * limitations under the License.
  */
 
+import vitaLogoBaseOrig, { VitalLogo } from './tokens/vitalLogo';
+
+/**
+ * Use this version of the vital logo tokens when extending or shadowing.
+ * @category Token Collection
+ * @see [[vitalLogo]]
+ */
+const vitaLogoBase = vitaLogoBaseOrig;
+
 export { default as LogoClean, asLogoToken } from './LogoClean';
 export { default as vitalLogo } from './tokens';
-export { default as vitalLogoBase } from './tokens/vitalLogo';
+export type { LogoComponents } from './LogoClean';
+
+export { vitaLogoBase, VitalLogo};

--- a/packages/vital-layout/src/components/Logo/tokens/vitalLogo.ts
+++ b/packages/vital-layout/src/components/Logo/tokens/vitalLogo.ts
@@ -65,6 +65,23 @@ export interface VitalLogo {
   Base: LogoToken,
   /**
    * Default adds vital specific design reqirements.
+   * @example Will override the layout domain of logo and apply diffent styling.
+   * ```js
+   * import { vitalLogoBase, asLogoToken } from '@bodiless/vital-layout';
+   *
+   * const Default = asLogoToken({
+   *   ...vitalLogoBase.Default,
+   *   Layout: {
+   *      Image: 'h-16 max-w-15',
+   *   },
+   * }),
+   *
+   * export default {
+   *   ...vitalLogoBase,
+   *   Default,
+   * };
+   * ```
+   *
    */
   Default: LogoToken,
 }

--- a/packages/vital-layout/src/components/Logo/tokens/vitalLogo.ts
+++ b/packages/vital-layout/src/components/Logo/tokens/vitalLogo.ts
@@ -22,15 +22,9 @@ import {
 } from '@bodiless/core';
 import { asBodilessLink } from '@bodiless/components-ui';
 import { asLogoToken } from '../LogoClean';
+import type { LogoToken } from '../LogoClean';
 
-const Default = asLogoToken({
-  Layout: {
-    Wrapper: 'w-full max-w-20 md:max-w-28 lg:min-w-28',
-    Image: 'max-h-full',
-  },
-  Spacing: {
-    Wrapper: 'mx-4 lg:ml-0 lg:mr-8',
-  },
+const Base = asLogoToken({
   Components: {
     Image: vitalImage.Default,
   },
@@ -48,6 +42,43 @@ const Default = asLogoToken({
   },
 });
 
-export default {
+const Default = asLogoToken(Base, {
+  Layout: {
+    Wrapper: 'w-full max-w-20 md:max-w-28 lg:min-w-28',
+    Image: 'max-h-full',
+  },
+  Spacing: {
+    Wrapper: 'mx-4 lg:ml-0 lg:mr-8',
+  },
+});
+
+/**
+ * Tokens for the vital logo
+ *
+ * @category Token Collection
+ * @see [[HeaderClean]]
+ */
+export interface VitalLogo {
+  /**
+   * Base makes a clickable image:
+   */
+  Base: LogoToken,
+  /**
+   * Default adds vital specific design reqirements.
+   */
+  Default: LogoToken,
+}
+
+/**
+ * Tokens for Vital Logo
+ *
+ * @category Token Collection
+ * @see [[VitalLogo]]
+ * @see [[LogoClean]]
+ */
+const vitalLogo: VitalLogo = {
+  Base,
   Default,
 };
+
+export default vitalLogo;


### PR DESCRIPTION
## Changes

- Update API Docs
- Update Layout Docs
- Slight adjustments in vital-logo, copyright row and helmet tokens

## Test Instructions
* Smoke test on vital-logo (Default token was added)
* Smoke test on  copyrightrow (export was changed)
* Smoke test on vital-helmet (theme domain moved from base to default)
* Verify API doc : http://localhost:8000/___docs/#/Development/API/@bodiless/vital-layout/README
* Verify component doc : http://localhost:8000/___docs/#/VitalDesignSystem/Components/VitalLayout/

BREAKING CHANGE: 

* Rename of token  vitalHelmet.WithDesktopStatickBody -> vitalHelmet.WithDesktopStaticBody
