### PR TITLE
bug(vital-layout): Update the exports for CopyrightRow

### DIFF
--- a/packages/vital-layout/src/components/Footer/CopyrightRow/CopyrightRowClean.tsx
+++ b/packages/vital-layout/src/components/Footer/CopyrightRow/CopyrightRowClean.tsx
@@ -39,7 +39,7 @@ const CopyrightRowCleanBase: FC<CopyrightRowProps> = ({ components: C, ...rest }
   </C.Wrapper>
 );
 
-const CopyrightRowCleanDesignable = designable(copyrightRowComponents, 'CopyrightRow')(CopyrightRowCleanBase);
+const CopyrightRowClean = designable(copyrightRowComponents, 'CopyrightRow')(CopyrightRowCleanBase);
 /**
  * A clean static copyright row to be used in footer following vital design
  * with copyright & social links.
@@ -47,17 +47,18 @@ const CopyrightRowCleanDesignable = designable(copyrightRowComponents, 'Copyrigh
  * @category Component
  *
  */
-const CopyrightRowClean = withoutHydration()(CopyrightRowCleanDesignable);
+const CopyrightRowStatic = withoutHydration()(CopyrightRowClean);
 
 /**
  * A token modifier that respects the CopyRightRow Components.
  *
  * @category Token Collection
  */
-export const asCopyrightRowToken = asVitalTokenSpec<CopyrightRowComponents>();
+const asCopyrightRowToken = asVitalTokenSpec<CopyrightRowComponents>();
 
 // These are used in defining the VitalCopyrightRow interface.
 const copyrightRowToken = asCopyrightRowToken();
 export type CopyrightRowToken = typeof copyrightRowToken;
 
 export default CopyrightRowClean;
+export { asCopyrightRowToken, CopyrightRowStatic };

--- a/packages/vital-layout/src/components/Footer/CopyrightRow/index.bl-edit.ts
+++ b/packages/vital-layout/src/components/Footer/CopyrightRow/index.bl-edit.ts
@@ -12,7 +12,5 @@
  * limitations under the License.
  */
 
-import CopyrightRowClean from './CopyrightRowClean';
-import vitalCopyrightRow from './tokens';
-
-export { CopyrightRowClean, vitalCopyrightRow };
+export { default as vitalCopyrightRowStatic } from './tokens';
+export { CopyrightRowStatic } from './CopyrightRowClean';

--- a/packages/vital-layout/src/components/Footer/CopyrightRow/index.static.ts
+++ b/packages/vital-layout/src/components/Footer/CopyrightRow/index.static.ts
@@ -12,9 +12,7 @@
  * limitations under the License.
  */
 
-import {
+export {
   StaticBlock as CopyrightRowStatic,
-  staticTokenCollection as vitalCopyrightRow,
+  staticTokenCollection as vitalCopyrightRowStatic,
 } from '@bodiless/hydration';
-
-export { CopyrightRowStatic, vitalCopyrightRow };

--- a/packages/vital-layout/src/components/Footer/CopyrightRow/index.ts
+++ b/packages/vital-layout/src/components/Footer/CopyrightRow/index.ts
@@ -21,7 +21,8 @@ import vitalCopyrightRowBaseOrig, { VitalCopyrightRow } from './tokens/vitalCopy
   */
 const vitalCopyrightRowBase = vitalCopyrightRowBaseOrig;
 
-export { asCopyrightRowToken } from './CopyrightRowClean';
+export { default as CopyrightRowClean, asCopyrightRowToken, CopyrightRowStatic } from './CopyrightRowClean';
+export { default as vitalCopyrightRow } from './tokens';
 export type { CopyrightRowComponents, CopyrightRowProps } from './types';
+
 export { vitalCopyrightRowBase, VitalCopyrightRow };
-export * from './index.bl-edit';


### PR DESCRIPTION
## Changes
Clean up the exports of CopyrightRow

## Test Instructions
With vital demo site:

- Run Static and confirm Copyright appears 
- Run Edit and confirm Copyright works as normal (appears & editable)

Tested as well on https://deploy-preview-24--neon-caramel-1c470e.netlify.app/
using this Canary PR : https://github.com/wodenx/bodiless-demo/pull/24
