### PR TITLE
fix(__vital__): Fix ContentLibrary not working on vital cards

### DIFF
--- a/packages/__vital__/src/shadow/@bodiless/vital-card/FlowContainer.ts
+++ b/packages/__vital__/src/shadow/@bodiless/vital-card/FlowContainer.ts
@@ -11,11 +11,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { as } from '@bodiless/fclasses';
+
 import { vitalCardFlowContainerBase } from '@bodiless/vital-card';
+import { asFluidToken } from '@bodiless/vital-elements';
 
 // Demostrating only showing Basic & Hero Card Variations in Component Picker
-const WithCardVariations = as(
+const WithCardVariations = asFluidToken(
   vitalCardFlowContainerBase.WithBasicVariations,
   vitalCardFlowContainerBase.WithHeroVariations,
 );


### PR DESCRIPTION
## Changes
Fix shadowing of cards in __vital__ package so that ContentLibrary works as expected

## Test Instructions
* Verify content library works as expected now without it disappearing as its added to content library.  https://github.com/johnsonandjohnson/Bodiless-JS/issues/1960
* Verify only Basic & Hero type cards are available in vital demo site and they work as expected.

