### PR TITLE
feat(gatsby-theme-bodiless): Allow disabling of editor in dev mode.

### DIFF
--- a/packages/gatsby-theme-bodiless/src/dist/Page.bl-edit.tsx
+++ b/packages/gatsby-theme-bodiless/src/dist/Page.bl-edit.tsx
@@ -104,6 +104,6 @@ const EditPage: FC<PageProps> = observer(({ children, ui, ...rest }) => {
   );
 });
 
-const Page = process.env.BODILESS_DISABLE_EDITOR ? StaticPage : EditPage;
+const Page = process.env.BODILESS_DISABLE_EDITOR === '1' ? StaticPage : EditPage;
 
 export default Page;

--- a/packages/gatsby-theme-bodiless/src/dist/Page.bl-edit.tsx
+++ b/packages/gatsby-theme-bodiless/src/dist/Page.bl-edit.tsx
@@ -38,6 +38,7 @@ import {
 import GatsbyNodeProvider from './GatsbyNodeProvider.bl-edit';
 import { FinalUI, UI, PageProps } from './types';
 import ShowDesignKeys from './ShowDesignKeys';
+import StaticPage from './Page.static';
 
 const defaultUI: FinalUI = {
   ContextWrapper,
@@ -60,7 +61,7 @@ const GitButtons: FC = () => {
   return <></>;
 };
 
-const Page: FC<PageProps> = observer(({ children, ui, ...rest }) => {
+const EditPage: FC<PageProps> = observer(({ children, ui, ...rest }) => {
   const { PageEditor: Editor, ContextWrapper: Wrapper } = getUI(ui);
   const { pageContext } = rest;
   const {
@@ -102,5 +103,7 @@ const Page: FC<PageProps> = observer(({ children, ui, ...rest }) => {
     </GatsbyNodeProvider>
   );
 });
+
+const Page = process.env.BODILESS_DISABLE_EDITOR ? StaticPage : EditPage;
 
 export default Page;

--- a/sites/__minimal__/.env.site
+++ b/sites/__minimal__/.env.site
@@ -6,6 +6,9 @@
 # To disable it - uncomment the following line.
 # BODILESS_BACKEND_SAVE_ENABLED='0'
 
+# Set to 1 to disable the bodiless editor even in dev mode.
+# BODILESS_DISABLE_EDITOR=1
+
 # Git commit paths used by the backend, in our case @bodiless/backend/server.js.
 # APP_GIT_PATH='.'
 # BODILESS_BACKEND_DATA_FILE_PATH='src/data'

--- a/sites/__vital__/.env.site
+++ b/sites/__vital__/.env.site
@@ -8,6 +8,9 @@
 # Or you can disable on a per-branch basis, see bodiless.env.config.js 
 # BODILESS_BACKEND_SAVE_ENABLED='0'
 
+# Set to 1 to disable the bodiless editor even in dev mode.
+# BODILESS_DISABLE_EDITOR=1
+
 # Git commit paths used by the backend, in our case @bodiless/backend/server.js.
 # APP_GIT_PATH='.'
 # BODILESS_BACKEND_DATA_FILE_PATH='src/data'


### PR DESCRIPTION
## Changes
Add a BODILESS_DISABLE_EDITOR env var which disables the editor even when running in development mode.

Will allow running a bodiless site using an alternative editor (eg Stackbit).