### PR TITLE
feat(core,gatsby-theme,page): Allow composition of fully custom page editors.

### DIFF
--- a/packages/bodiless-components/src/List/List.tsx
+++ b/packages/bodiless-components/src/List/List.tsx
@@ -53,7 +53,7 @@ const ListBase: FC<ListBaseProps> = ({
     Title,
   } = components;
 
-  const { addItem, deleteItem } = useItemsMutators({ unwrap, onDelete });
+  const { addItem, deleteItem, moveItem } = useItemsMutators({ unwrap, onDelete });
   const { getItems } = useItemsAccessors();
   const { setId } = useActivateOnEffect();
   const dataItems = getItems();
@@ -83,7 +83,11 @@ const ListBase: FC<ListBaseProps> = ({
       ) {
         value.deleteItem = () => deleteItem(currentItem);
       }
-
+      if (dataItems.includes(currentItem)) {
+        value.moveItem = (offset: number) => {
+          moveItem(currentItem, offset);
+        };
+      }
       return value;
     }),
     [dataItems, prependItems, appendItems],

--- a/packages/bodiless-components/src/List/model.ts
+++ b/packages/bodiless-components/src/List/model.ts
@@ -81,6 +81,20 @@ const useAddItem = () => {
   };
 };
 
+const useMoveItem = () => {
+  const { getItems, setItems } = useItemsAccessors();
+  return (item: string, offset: number) => {
+    const items = getItems();
+    const newItems: Array<string> = items.filter(i => i !== item);
+    const index = items.findIndex(i => i === item);
+    const newIndex = index + offset;
+    if (newIndex <= 0) newItems.splice(0, 0, item);
+    else if (newIndex >= items.length - 1) newItems.push(item);
+    else newItems.splice(newIndex, 0, item);
+    setItems(newItems);
+  };
+};
+
 /**
  * Returns a pair of functions which can be used to insert
  * or delete items.
@@ -88,5 +102,6 @@ const useAddItem = () => {
 export const useItemsMutators = (props?: Pick<ListBaseProps, 'unwrap' | 'onDelete'>) => ({
   addItem: useAddItem(),
   deleteItem: useDeleteItem(props || { unwrap: undefined, onDelete: undefined }),
+  moveItem: useMoveItem(),
   deleteSublist: useDeleteSublist(),
 });

--- a/packages/bodiless-components/src/List/types.ts
+++ b/packages/bodiless-components/src/List/types.ts
@@ -27,6 +27,7 @@ export type ListContextValue = {
   currentItem?: string,
   addItem?: Function,
   deleteItem?: Function,
+  moveItem?: Function,
 };
 
 export type ListBaseProps = {

--- a/packages/bodiless-components/src/List/withListButtons.tsx
+++ b/packages/bodiless-components/src/List/withListButtons.tsx
@@ -38,7 +38,7 @@ const hasChildSubList = (context: PageEditContextInterface, count: number = 1): 
 
 const useMenuOptions = (useOverrides: UseListOverrides = () => ({})) => (props: any) => {
   const {
-    addItem, deleteItem,
+    addItem, deleteItem, items = [], currentItem, moveItem,
   } = useListContext();
 
   // Search for parent lists to set the default group label
@@ -56,11 +56,21 @@ const useMenuOptions = (useOverrides: UseListOverrides = () => ({})) => (props: 
 
   const menuOptions:TMenuOption[] = useMemo(() => ([
     {
+      name: `move-left-${id}`,
+      icon: 'chevron_left',
+      label: 'Move',
+      isDisabled: !moveItem || !items.length || currentItem === items[0],
+      handler: () => (moveItem ? moveItem(-1) : undefined),
+      global,
+      local,
+      group,
+    },
+    {
       name: `add-${id}`,
       icon: 'add',
       label: 'Add',
       isDisabled: !addItem,
-      handler: addItem as TMenuOption['handler'] || (() => undefined),
+      handler: () => (addItem ? addItem() : undefined),
       global,
       local,
       group,
@@ -70,7 +80,17 @@ const useMenuOptions = (useOverrides: UseListOverrides = () => ({})) => (props: 
       icon: 'delete',
       label: 'Delete',
       isDisabled: !deleteItem,
-      handler: deleteItem as TMenuOption['handler'] || (() => undefined),
+      handler: () => (deleteItem ? deleteItem() : undefined),
+      global,
+      local,
+      group,
+    },
+    {
+      name: `move-right-${id}`,
+      icon: 'chevron_right',
+      label: 'Move',
+      isDisabled: !moveItem || !items.length || currentItem === items[items.length - 1],
+      handler: () => (moveItem ? moveItem(1) : undefined),
       global,
       local,
       group,

--- a/packages/bodiless-core/src/PageEditContext/index.tsx
+++ b/packages/bodiless-core/src/PageEditContext/index.tsx
@@ -57,6 +57,8 @@ class PageEditContext implements PageEditContextInterface {
 
   hasLocalMenu = false;
 
+  lastActivated: Date|undefined = undefined;
+
   // When called with no argument this creates a new store and react context.
   constructor(values?: DefinesLocalEditContext, parent?: PageEditContextInterface) {
     if (values) {
@@ -128,6 +130,7 @@ class PageEditContext implements PageEditContextInterface {
 
   // Make this the "current" context.
   activate() {
+    this.lastActivated = new Date();
     this.store.setActiveContext(this);
   }
 

--- a/packages/bodiless-core/src/PageEditContext/types.ts
+++ b/packages/bodiless-core/src/PageEditContext/types.ts
@@ -96,6 +96,7 @@ export interface PageEditContextInterface extends
   readonly id: string;
   readonly name: string;
   readonly parent?: PageEditContextInterface;
+  readonly lastActivated?: Date;
   /**
    * The "peer" contexts registered with this context.  Peer contexts contribute their menu
    * options when the context wo which they are registered becomes active.

--- a/packages/bodiless-core/src/components/LocalContextMenu.tsx
+++ b/packages/bodiless-core/src/components/LocalContextMenu.tsx
@@ -222,19 +222,21 @@ const ContextMenuOverlay = observer(() => {
  */
 const LocalContextMenu: FC<{children: ReactElement}> = ({ children }) => {
   const context = useEditContext();
-  // console.log('render tooltip for', context.name);
+
   // let the context know it has a localMenu
   context.hasLocalMenu = true;
-  const { isInnermostLocalMenu, areLocalTooltipsDisabled } = context;
-  // TODO: Only render tooltip when needed. Currently this causes focus issues with editables.
-  // (The editable gets the focus, then the tooltip re-renders and creates a new editable
-  // which is not focused.  Might be worth investigating this at some point.)
-  // if (!isInnermostLocalMenu) {
-  //   return <>{children}</>;
-  // }
+  const { isInnermostLocalMenu, areLocalTooltipsDisabled, lastActivated } = context;
+  if (!isInnermostLocalMenu || areLocalTooltipsDisabled) {
+    return <>{children}</>;
+  }
+  // Set key based on last activated time to force remount when activated. This is
+  // necessary so that the menu will move when its underlying component moves
+  // (eg when a list is reordered).
+  const key = lastActivated ? String(lastActivated.getTime()) : 'local-context-menu';
   return (
     <Tooltip
-      visible={isInnermostLocalMenu && !areLocalTooltipsDisabled}
+      key={key}
+      visible
       overlay={<ContextMenuOverlay />}
       trigger={[]}
       destroyTooltipOnHide

--- a/packages/bodiless-core/src/components/PageEditor.tsx
+++ b/packages/bodiless-core/src/components/PageEditor.tsx
@@ -55,12 +55,7 @@ const GlobalContextMenu: FC<Props> = observer(() => {
   );
 });
 
-/**
- * Component providing the global Bodiless UI elements, the Main Menu and Page Overlay.
- * Also provides the Edit and Docs buttons on the main menu.
- */
-const PageEditor: FC<Props> = ({ children, ui }) => {
-  const context = useEditContext();
+export const useDocsButton = () => {
   const getMenuOptions = useCallback(() => [
     {
       name: 'docs',
@@ -70,6 +65,18 @@ const PageEditor: FC<Props> = ({ children, ui }) => {
         window.open(process.env.BODILESS_DOCS_URL, '_blank');
       },
     },
+  ], []);
+
+  // Register buttons to the main menu.
+  useRegisterMenuOptions({
+    getMenuOptions,
+    name: 'Docs',
+  });
+};
+
+export const useEditButton = () => {
+  const context = useEditContext();
+  const getMenuOptions = useCallback(() => [
     {
       name: 'edit',
       icon: 'edit',
@@ -82,18 +89,25 @@ const PageEditor: FC<Props> = ({ children, ui }) => {
     },
   ], []);
 
-  const newUI = {
-    ...useUI(),
-    ...ui,
-  };
-
-  const { PageOverlay = () => null } = newUI;
-
   // Register buttons to the main menu.
   useRegisterMenuOptions({
     getMenuOptions,
     name: 'Editor',
   });
+};
+
+/**
+ * Component providing the global Bodiless UI elements, the Main Menu and Page Overlay.
+ * Also provides the Edit and Docs buttons on the main menu.
+ */
+const PageEditor: FC<Props> = ({ children, ui }) => {
+  const context = useEditContext();
+
+  const newUI = {
+    ...useUI(),
+    ...ui,
+  };
+  const { PageOverlay = () => null } = newUI;
   useEffect(() => {
     if (!context.isActive) context.activate();
   }, []);

--- a/packages/bodiless-core/src/components/index.ts
+++ b/packages/bodiless-core/src/components/index.ts
@@ -15,7 +15,7 @@
 import ContextMenu from './ContextMenu';
 import ContextWrapper from './ContextWrapper';
 import LocalContextMenu from './LocalContextMenu';
-import PageEditor from './PageEditor';
+import PageEditor, { useDocsButton, useEditButton } from './PageEditor';
 import StaticPage from './StaticPage';
 import PageOverlay from './PageOverlay';
 import ContextMenuProvider, { getUI } from './ContextMenuContext';
@@ -34,6 +34,8 @@ export {
   ContextWrapper,
   LocalContextMenu,
   PageEditor,
+  useDocsButton,
+  useEditButton,
   StaticPage,
   PageOverlay,
   ReactTagsField,

--- a/packages/bodiless-page/src/MenuOptions/usePageMenuOptions.ts
+++ b/packages/bodiless-page/src/MenuOptions/usePageMenuOptions.ts
@@ -19,6 +19,18 @@ import {
 } from '@bodiless/core';
 import { PageMenuOptions } from '../types';
 
+const usePageMenuGroup = () => {
+  const menuOptions = [
+    {
+      name: 'page-group',
+      icon: 'description',
+      label: 'Page',
+      Component: ContextSubMenu,
+    },
+  ];
+  return menuOptions;
+};
+
 const usePageMenuOptions = (
   options: PageMenuOptions,
 ) => {
@@ -35,12 +47,7 @@ const usePageMenuOptions = (
   );
 
   const menuOptions = [
-    {
-      name: 'page-group',
-      icon: 'description',
-      label: 'Page',
-      Component: ContextSubMenu,
-    },
+    ...usePageMenuGroup(),
     {
       name,
       icon,
@@ -56,4 +63,5 @@ const usePageMenuOptions = (
 
 export {
   usePageMenuOptions,
+  usePageMenuGroup,
 };

--- a/packages/bodiless-page/src/MenuOptions/withPageMenuOptions.ts
+++ b/packages/bodiless-page/src/MenuOptions/withPageMenuOptions.ts
@@ -22,7 +22,7 @@ import {
   menuFormPageDelete,
   menuFormPageNew,
 } from '../Forms';
-import { usePageMenuOptions } from './usePageMenuOptions';
+import { usePageMenuGroup, usePageMenuOptions } from './usePageMenuOptions';
 
 const defaultClient = new BodilessBackendClient();
 
@@ -86,9 +86,16 @@ const withNewPageButton = withMenuOptions({
   root: true,
 });
 
+const withPageMenuGroup = withMenuOptions({
+  useMenuOptions: () => usePageMenuGroup(),
+  name: 'Page Group',
+  root: true,
+});
+
 export {
   withClonePageButton,
   withDeletePageButton,
   withMovePageButton,
   withNewPageButton,
+  withPageMenuGroup,
 };

--- a/packages/gatsby-theme-bodiless/src/dist/Page.bl-edit.tsx
+++ b/packages/gatsby-theme-bodiless/src/dist/Page.bl-edit.tsx
@@ -20,6 +20,8 @@ import {
   OnNodeErrorNotification,
   useGitButtons,
   GitContextProvider,
+  useDocsButton,
+  useEditButton,
 } from '@bodiless/core';
 import {
   Fragment,
@@ -61,6 +63,12 @@ const GitButtons: FC = () => {
   return <></>;
 };
 
+const EditButtons: FC = () => {
+  useDocsButton();
+  useEditButton();
+  return <></>;
+};
+
 const EditPage: FC<PageProps> = observer(({ children, ui, ...rest }) => {
   const { PageEditor: Editor, ContextWrapper: Wrapper } = getUI(ui);
   const { pageContext } = rest;
@@ -84,6 +92,7 @@ const EditPage: FC<PageProps> = observer(({ children, ui, ...rest }) => {
               <SwitcherButton />
               <NotificationButton />
               <Editor>
+                <EditButtons />
                 <OnNodeErrorNotification />
                 <NewPageButton />
                 <MovePageButton />


### PR DESCRIPTION
## Changes
- Remove edit and docs buttons from core page editor and add them at gatsby theme level
- Expose an HOC from @!boeiless/page to allow adding the 'Page' menu group.