### PR TITLE
ci: Trigger test workflow only on test labels

### DIFF
--- a/.github/workflows/build-test-lint-simple.yml
+++ b/.github/workflows/build-test-lint-simple.yml
@@ -3,18 +3,17 @@ env:
   CI: true
   FORCE_COLOR: 1
   NODE_OPTIONS: --max_old_space_size=4096
+
 on:
-  pull_request_target:
-    types: [labeled]
-    branches:
-      - main
-      - 'upgrade/**'
+  workflow_call:
+
 jobs:
   setup:
     name: Setup, Build, Lint and Test
     permissions:
       pull-requests: write
     runs-on: ubuntu-20.04
+    if: ${{ github.event.label.name == 'ready-to-test' }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/test-workflow-listener.yml
+++ b/.github/workflows/test-workflow-listener.yml
@@ -1,0 +1,16 @@
+name: Test Workflow Listener
+
+on:
+  pull_request_target:
+    types: [labeled]
+    branches:
+      - main
+      - 'upgrade/**'
+
+jobs:
+  on-label:
+    permissions:
+      pull-requests: write
+    uses: johnsonandjohnson/Bodiless-JS/.github/workflows/build-test-lint-simple.yml@main
+    secrets: inherit
+    if: ${{ github.event.label.name == 'ready-to-test' || github.event.label.name == 'skip-tests' }}


### PR DESCRIPTION
Changes
* ready-to-test label will trigger testing workflow
* skip-tests label will mark testing workflow as skipped allowing the PR to be merged
* any other labels won't have any effect on testing workflow