### PR TITLE
docs(bodiless-documentation): Fix endless cycle

### DIFF
--- a/packages/bodiless-documentation/src/defaultToc.ts
+++ b/packages/bodiless-documentation/src/defaultToc.ts
@@ -39,7 +39,6 @@ const toc = {
     Guides: {
       'IntroToBodilessConcepts.md': '',
       'CreatingBodilessComponents.md': '',
-      'Shadowing.md': '',
     },
     'Packages.md': '',
     Architecture: {


### PR DESCRIPTION
## Changes
- Remove moved file "Shadowing.md" from default ToC, to fix endless doc build cycle.
