### PR TITLE
`renderToString` as a solution for TBT issues in Next.js

### DIFF
--- a/packages/bodiless-next/src/getStaticProps.tsx
+++ b/packages/bodiless-next/src/getStaticProps.tsx
@@ -249,6 +249,7 @@ export const getStaticHtml = (Component: any) => async ({ params }: getServerSid
     );
     staticProps.props = { html } as any;
   }
+  
   return staticProps;
 };
 

--- a/packages/bodiless-next/src/getStaticProps.tsx
+++ b/packages/bodiless-next/src/getStaticProps.tsx
@@ -12,6 +12,11 @@
  * limitations under the License.
  */
 
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import { RouterContext } from 'next/dist/shared/lib/router-context';
+// @ts-ignore
+import { makePublicRouterInstance } from 'next/dist/client/router';
 import {
   findComponentPath,
   findSubPageTemplateTemplate,
@@ -231,6 +236,21 @@ const getStaticProps = async ({ params }: getServerSideProps) => {
   return {
     props: pageData,
   };
+};
+
+export const getStaticHtml = (Component: any) => async ({ params }: getServerSideProps) => {
+  const staticProps = await getStaticProps({ params });
+
+  if (staticProps.props) {
+    const html = await renderToString(
+      <RouterContext.Provider value={makePublicRouterInstance({ pathname: '/' })}>
+        <Component {...staticProps.props} />
+      </RouterContext.Provider>
+    );
+    staticProps.props = { html } as any;
+  }
+
+  return staticProps;
 };
 
 export default getStaticProps;

--- a/packages/bodiless-next/src/getStaticProps.tsx
+++ b/packages/bodiless-next/src/getStaticProps.tsx
@@ -249,7 +249,6 @@ export const getStaticHtml = (Component: any) => async ({ params }: getServerSid
     );
     staticProps.props = { html } as any;
   }
-
   return staticProps;
 };
 

--- a/sites/vital-demo-next/src/pages/[[...slug]].tsx
+++ b/sites/vital-demo-next/src/pages/[[...slug]].tsx
@@ -1,4 +1,4 @@
-import getStaticProps from '@bodiless/next/lib/getStaticProps';
+import { getStaticHtml } from '@bodiless/next/lib/getStaticProps';
 import getStaticPaths from '@bodiless/next/lib/getStaticPaths';
 import PageRenderer from '@bodiless/next/lib/PageRenderer';
 import _default from '../templates/_default';
@@ -6,20 +6,23 @@ import styleguide from '../templates/styleguide';
 
 const Templates = {
   '_default.jsx': _default,
-  'styleguide.jsx': styleguide
-};
-
-export {
-  getStaticProps,
-  getStaticPaths
+  'styleguide.jsx': styleguide,
 };
 
 const Page = ({ component, ...rest }: any) => {
   const DefaultPage = Templates[component] || _default;
   return PageRenderer({
     Component: DefaultPage,
-    ...rest
+    ...rest,
   });
 };
 
-export default Page;
+const Html = ({ html }: any) => (
+  <div dangerouslySetInnerHTML={{ __html: html }} />
+);
+
+export const getStaticProps = getStaticHtml(Page);
+
+export { getStaticPaths };
+
+export default Html;

--- a/sites/vital-demo-next/src/pages/[[...slug]].tsx
+++ b/sites/vital-demo-next/src/pages/[[...slug]].tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { getStaticHtml } from '@bodiless/next/lib/getStaticProps';
 import getStaticPaths from '@bodiless/next/lib/getStaticPaths';
 import PageRenderer from '@bodiless/next/lib/PageRenderer';


### PR DESCRIPTION
## Changes

Now using `renderToString` to improve TBT.

Demo URL: [bodiless-js-vital-next.vercel.app](https://bodiless-js-vital-next.vercel.app/)
Lightouse run: https://lighthouse-metrics.com/lighthouse/checks/bafbb6c3-1abf-48b5-a590-2a07e2314195