### PR TITLE
fix: Page order in Docsify

### DIFF
--- a/packages/bodiless-documentation/src/tree.ts
+++ b/packages/bodiless-documentation/src/tree.ts
@@ -65,17 +65,17 @@ export const getTreeFromDir = (startDir:string) => (
 
 /**
  * PrePendPath take a path and returns a treeHO that will walk though a passed in Tree
- * and prepend the path to every docuement in the tree.
+ * and prepend the path to every document in the tree.
  * @param prePend
  */
 export const prependPath = (prePend:string) => (tree:Tree):Tree => (
   Object.keys(tree).reduce(
     (acc:Tree, key:string) => {
       if (typeof tree[key] === 'string') {
-        return { [key]: path.join(prePend, tree[key] as string), ...acc } as Tree;
+        return { ...acc, [key]: path.join(prePend, tree[key] as string) } as Tree;
       }
       const subTree = prependPath(prePend)(tree[key] as Tree);
-      return { [key]: subTree, ...acc } as Tree;
+      return { ...acc, [key]: subTree } as Tree;
     },
     {} as Tree,
   )
@@ -134,7 +134,7 @@ export const withTreeFromFile = (filePath:string):Promise<TreeHO> => {
 };
 
 /**
- * getSipmlePaths returns a simple list of paths gathered from a nested tree.
+ * getSimplePaths returns a simple list of paths gathered from a nested tree.
  * @param tree
  */
 export const getSimplePaths = (tree: Tree): string[] => {

--- a/packages/bodiless-ga4/bodiless.docs.json
+++ b/packages/bodiless-ga4/bodiless.docs.json
@@ -3,8 +3,8 @@
     "Analytics": {
       "README.md": "./doc/README.md",
       "About_GTM_and_GA4.md": "./doc/AboutGTM.md",
-      "AddingTracking.md": "./doc/AddingTracking.md",
-      "GA4Activation.md": "./doc/GA4Activation.md"
+      "GA4Activation.md": "./doc/GA4Activation.md",
+      "AddingTracking.md": "./doc/AddingTracking.md"
     }
   }
 }

--- a/packages/bodiless-organisms/bodiless.docs.json
+++ b/packages/bodiless-organisms/bodiless.docs.json
@@ -1,8 +1,8 @@
 {
   "Components": {
-    "SingleAccordion.md": "./doc/SingleAccordion.md",
-    "FilterByGroup.md": "./doc/FilterByGroup.md",
     "Embed.md": "./doc/Embed.md",
+    "FilterByGroup.md": "./doc/FilterByGroup.md",
+    "SingleAccordion.md": "./doc/SingleAccordion.md",
     "SocialShare.md": "./doc/SocialShare.md",
     "assets": {
       "CategoryContextMenu.jpg": "./doc/assets/CategoryContextMenu.jpg",

--- a/packages/vital-editors/bodiless.docs.json
+++ b/packages/vital-editors/bodiless.docs.json
@@ -3,9 +3,9 @@
     "Components": {
       "VitalEditors": {
           "README.md": "./doc/README.md",
-          "RichTextCustomizing.md": "./doc/RichTextCustomizing.md",
+          "PlainEditor.md": "./doc/PlainEditor.md",
           "RTE_Editor.md": "./doc/RichText.md",
-          "PlainEditor.md": "./doc/PlainEditor.md"
+          "RichTextCustomizing.md": "./doc/RichTextCustomizing.md"
       }
     }
   }

--- a/packages/vital-elements/bodiless.docs.json
+++ b/packages/vital-elements/bodiless.docs.json
@@ -3,17 +3,17 @@
     "README.md": "./doc/README.md",
     "Guides": {
       "README.md": "./doc/Guides.md",
-      "StaticReplacement.md": "./doc/StaticReplacement.md",
-      "SiteTypography.md": "./doc/SiteTypography.md",
-      "TailwindGuide.md": "./doc/TailwindGuide.md",
-      "ShadowingTokens.md": "",
-      "ExtendingAndComposingTokens.md": "./doc/ExtendingAndComposing.md",
+      "RepositoryStructure.md": "./doc/RepositoryStructure.md",
+      "ComponentTemplate.md": "./doc/ComponentTemplate.md",
       "Tokens": {
         "README.md": "./doc/Tokens.md",
         "TokenDomains.md": "./doc/TokenDomains.md"
       },
-      "ComponentTemplate.md": "./doc/ComponentTemplate.md",
-      "RepositoryStructure.md": "./doc/RepositoryStructure.md"
+      "ExtendingAndComposingTokens.md": "./doc/ExtendingAndComposing.md",
+      "ShadowingTokens.md": "",
+      "TailwindGuide.md": "./doc/TailwindGuide.md",
+      "SiteTypography.md": "./doc/SiteTypography.md",
+      "StaticReplacement.md": "./doc/StaticReplacement.md"
     },
     "Components": {
       "README.md": "./doc/Components.md",

--- a/packages/vital-examples/bodiless.docs.json
+++ b/packages/vital-examples/bodiless.docs.json
@@ -1,26 +1,26 @@
 {
   "VitalDesignSystem": {
     "Curriculum": {
-      "Lessons": {
-        "ReusableTokens.md": "./doc/Curriculum/Lessons/ReusableTokens.md",
-        "DevelopA_NewComponent.md": "./doc/Curriculum/Lessons/DevelopANewComponent.md",
-        "BackgroundImages.md": "./doc/Curriculum/Lessons/BackgroundImages.md",
-        "CustomizeDesignTokens.md": "./doc/Curriculum/Lessons/CustomizeDesignTokens.md",
-        "ShadowA_SimpleComponent.md": "./doc/Curriculum/Lessons/ShadowASimpleComponent.md",
-        "README.md": "./doc/Curriculum/Lessons/README.md"
-      },
+      "README.md": "./doc/README.md",
       "Introduction": {
-        "WhyVital.md": "./doc/Introduction/WhyVital.md",
-        "WorkingWithContent.md": "./doc/Introduction/WorkingWithContent.md",
-        "FunctionalClasses.md": "./doc/Introduction/FunctionalClasses.md",
-        "AnatomyOfA_Token.md": "./doc/Introduction/AnatomyOfAToken.md",
-        "ReachingInside.md": "./doc/Introduction/ReachingInside.md",
-        "ComposingFromOutside.md": "./doc/Introduction/ComposingFromOutside.md",
-        "ComponentsAndTokens.md": "./doc/Introduction/ComponentsAndTokens.md",
+        "README.md": "./doc/Introduction/README.md",
         "CoreConcepts.md": "./doc/Introduction/CoreConcepts.md",
-        "README.md": "./doc/Introduction/README.md"
+        "ComponentsAndTokens.md": "./doc/Introduction/ComponentsAndTokens.md",
+        "ComposingFromOutside.md": "./doc/Introduction/ComposingFromOutside.md",
+        "ReachingInside.md": "./doc/Introduction/ReachingInside.md",
+        "AnatomyOfA_Token.md": "./doc/Introduction/AnatomyOfAToken.md",
+        "FunctionalClasses.md": "./doc/Introduction/FunctionalClasses.md",
+        "WorkingWithContent.md": "./doc/Introduction/WorkingWithContent.md",
+        "WhyVital.md": "./doc/Introduction/WhyVital.md"
       },
-      "README.md": "./doc/README.md"
+      "Lessons": {
+        "README.md": "./doc/Curriculum/Lessons/README.md",
+        "ShadowA_SimpleComponent.md": "./doc/Curriculum/Lessons/ShadowASimpleComponent.md",
+        "CustomizeDesignTokens.md": "./doc/Curriculum/Lessons/CustomizeDesignTokens.md",
+        "BackgroundImages.md": "./doc/Curriculum/Lessons/BackgroundImages.md",
+        "DevelopA_NewComponent.md": "./doc/Curriculum/Lessons/DevelopANewComponent.md",
+        "ReusableTokens.md": "./doc/Curriculum/Lessons/ReusableTokens.md"
+      }
     },
     "Guides": {
       "ShadowingTokens.md": "./doc/Guides/ShadowingTokens.md"

--- a/packages/vital-layout/bodiless.docs.json
+++ b/packages/vital-layout/bodiless.docs.json
@@ -3,11 +3,11 @@
     "Components": {
       "VitalLayout": {
         "README.md": "./doc/README.md",
-        "Logo.md": "./doc/Logo.md",
-        "Footer.md": "./doc/Footer.md",
-        "Header.md": "./doc/Header.md",
+        "Layout.md": "./doc/Layout.md",
         "Helmet.md": "./doc/Helmet.md",
-        "Layout.md": "./doc/Layout.md"
+        "Header.md": "./doc/Header.md",
+        "Footer.md": "./doc/Footer.md",
+        "Logo.md": "./doc/Logo.md"
       }
     }
   }


### PR DESCRIPTION
## Changes

- Fix sections in the Bodiless documentation sidebar from generating pages in the reverse order from what is configured.
- Update `bodiless.docs.json` files for sections that were intentionally reversed to compensate for this bug.

## Test Instructions

1. Find an existing `bodiless.docs.json` file (e.g., [`packages/vital-examples/bodiless.docs.json`](https://github.com/misterjones/Bodiless-JS/blob/99290901589bb3f9dd7daf214400725f52da3182/packages/vital-examples/bodiless.docs.json)).
2. Locally, navigate to `sites/test-site` and run `npm run docs`.
3. Confirm that the section configured by the `bodiless.docs.json` file generates its pages in the same order as they are listed in the file.