### PR TITLE
docs(vital-examples): Clean up Curriculum Lessons

### DIFF
--- a/packages/vital-examples/doc/Curriculum/Lessons/BackgroundImages.md
+++ b/packages/vital-examples/doc/Curriculum/Lessons/BackgroundImages.md
@@ -1,16 +1,27 @@
 # Background Images
 
-@TODO Link to shadowing documentation and Bodiless documentation section on using Tailwind for background images.
+Before engaging in this lesson, it would be beneficial to be familiar with knowing how to [Shadow a
+Simple Component](./ShadowA_SimpleComponent) and [Using Tailwind for Background
+Images](../../Guides/TailwindGuide#using-tailwind-for-background-images).
 
 ## Overview
 
-In this task we'll be customizing the default vital footer to include a new brand-specific SVG logo, as well an SVG wave image on both desktop and mobile.
+In this task we'll be customizing the default Vital footer to include a new brand-specific SVG logo,
+as well as an SVG wave image on both desktop and mobile.
+
+?> **Note:** For the code files used in this lesson, please see the
+`packages/vital-examples/src/background-images` directory in your local repository or on
+[GitHub](https://github.com/johnsonandjohnson/Bodiless-JS/tree/main/packages/vital-examples/src/background-images
+':target=_blank').
 
 ## Assignment
 
-To begin, we will create a react component from our SVG to be used to replace the brand logo on the default vital footer. Using your SVG-to-React conversion app of choice (SVGR Playground), inlcude your SVG in the body of a functional component as illustrated below:
+To begin, we will create a React component from our SVG to be used to replace the brand logo on the
+default Vital footer. Using your SVG-to-React conversion app of choice (e.g., [SVGR
+Playground](https://react-svgr.com/playground/ ':target=_blank')), include your SVG in the body of a
+functional component as illustrated below:
 
-```jsx
+```tsx
 import { stylable } from '@bodiless/fclasses';
 import * as React from 'react';
 
@@ -21,60 +32,126 @@ const Logo = (props: React.SVGProps<SVGSVGElement>) => (
 const LogoIcon = stylable(Logo);
 
 export default LogoIcon;
-
 ```
 
-Next, you'll need to create the folder that will house your new footer component `ExampleFooter` that will be used to override the default vital footer.
+For an example of the above, see:
+[`logo.tsx`](https://github.com/johnsonandjohnson/Bodiless-JS/blob/main/packages/vital-examples/src/background-images/assets/images/logo.tsx
+':target=_blank').
 
-You can structure this component's folder in a similar fashion to that of the vital component found [here](packages/vital-layout/src/components/Footer), or make use of the component scaffolder to create this component structure automatically.
+Next, you'll need to create the folder that will house your new footer component, `ExampleFooter`,
+that will be used to override the default Vital footer.
 
-- TODO: Add more details on import chain and/or refer to new shadow documentation to avoid verbosity here?
+You can structure this component's folder in a similar fashion to that of the Vital component found
+[here](https://github.com/johnsonandjohnson/Bodiless-JS/tree/main/packages/vital-layout/src/components/Footer
+':target=_blank'), or make use of the [component
+scaffolder](../../Guides/ComponentTemplate#component-scaffolding) to create this component structure
+automatically.
 
-### Adding our custom brand logo
+<!-- Inlining HTML to add multi-line info block with unordered list. -->
+<div class="warn">
+  <strong>Note:</strong> For more information on this component file structure, please see:
 
-In our 'Footer' token collection -- named `exampleFooter.ts` -- you'll replace the `Rewards` slot of the footer component with your new custom brand logo, using the `startWith` HOC.
+  - [Component Template : File Structure](../../Guides/ComponentTemplate#file-structure)
+  - [Shadowing Tokens](../../Guides/ShadowingTokens)
 
-NOTE: You may have noticed that a similar HOC, `replaceWith`, can be used to achieve the same result, but `startWith` is the preferred method in this instance, as it replaces a component while still retaining any tokens previously applied to it. `replaceWith` is most often used to remove a component or slot in its entirety (`replaceWith(() => null)`).
+</div>
 
-### Creating a new CSS rule in Tailwind for our wave SVG image mask
+### Adding Our Custom Brand Logo
 
-Using the `addComponents` function provided by Tailwind, we can create a new class containing our image mask path, size, and position, and apply it to our new footer in the next section.
+In our 'Footer' token collection — named `exampleFooter.ts` — you'll replace the `Rewards` slot of
+the footer component with your new custom brand logo, using the `startWith` HOC.
 
-NOTE: In most instances, the utility classes provided out of the box by Tailwind will be enough to satisfy all of your styling needs. However, in cases such as this one where our footer wave must be implemented through the use of an image mask (a CSS property for which no default Tailwind utility class exists), we can construct a CSS rule directly in our Tailwind configuration file.
+?> **Note:** You may have noticed that a similar HOC, `replaceWith`, can be used to achieve the same
+result, but `startWith` is the preferred method in this instance, as it replaces a component while
+still retaining any tokens previously applied to it. `replaceWith` is most often used to remove a
+component or slot in its entirety (`replaceWith(() => null)`).
 
-<!-- @TODO for JONES: use the technique you discovered to embed actual code snippets here rather than inlining them
--->
+### Creating a New CSS Rule in Tailwind for Our Wave SVG Image Mask
+
+Using the `addComponents` function provided by Tailwind, we can create a new class containing our
+image mask path, size, and position, and apply it to our new footer in the next section.
+
+?> **Note:** In most instances, the utility classes provided out-of-the-box by Tailwind will be
+enough to satisfy all of your styling needs. However, in cases such as this one, where our footer
+wave must be implemented through the use of an image mask (a CSS property for which no default
+Tailwind utility class exists), we can construct a CSS rule directly in our Tailwind configuration
+file.
 
 ```js
-plugin(({ addComponents }) => {
+const twConfig = {
+  plugins: [
+    plugin(({ addComponents }) => {
       addComponents({
         '.footer-wave': {
-          maskImage: "url('vital-examples/src/background-images/assets/images/desktopwave.svg')",
+          maskImage: "url('@bodiless/vital-examples/src/background-images/assets/images/desktopwave.svg')",
           maskPosition: 'bottom center',
           maskSize: '100%',
         },
+        // ...
       });
     }),
-
+  ],
+};
 ```
 
-### Adding our 'wave' svg asset and mobile wave to the footer wrapper
+### Adding Our 'wave' SVG Asset and Mobile Wave to the Footer Wrapper
 
-@TODO for JONES -- break this into 3steps following the guide from UsingTailwind Background Images
+01. Get your SVG asset set up via [Using Tailwind for Background
+    Images](../../Guides/TailwindGuide#using-tailwind-for-background-images).
+01. In our `exampleFooter.ts` file, we will construct a `WithTopWave` token, in which we will apply
+    to the [appropriate domains](../../Guides/Tokens/TokenDomains) the Tailwind classes needed to
+    render an SVG wave to the top of the footer.
+01. On the `Wrapper` slot, we will apply our `.footer-wave` CSS rule, and, on the `Column2Wrapper`
+    slot, we will apply the Tailwind classes necessary to render a similar SVG wave to the top of
+    the footer on mobile and tablet devices.
+01. We will then construct a `Default` token for our custom footer and apply our newly-created
+    `WithTopWave` token to this token's `Compose` domain.
 
-In our `exampleFooter.ts`, we will construct a `WithTopWave` token, in which we will apply to the [appropriate domains](../../Guides/Tokens/TokenDomains) the tailwind classes needed to render an SVG wave to the top of the footer.
+**`exampleFooter.ts`:**
 
-On the `Wrapper` slot, we will apply our `.footer-wave` CSS rule, and on the `Column2Wrapper` slot, we will apply the tailwind classes necessary to render a similar SVG wave to the top of the footer on mobile and tablet devices.
+[exampleFooter.ts](https://raw.githubusercontent.com/johnsonandjohnson/Bodiless-JS/main/packages/vital-examples/src/background-images/components/Footer/tokens/exampleFooter.ts
+':include :type=code')
 
- We will then construct a `Default` token for our custom footer and apply our newly-created `WithTopWave` token to this token's `Compose` domain.
+?> **Note:** Our `WithTopWave` token could easily be woven into the body of our `Default` footer
+token, but imagine a future scenario where our design changes, and we no longer want that top wave
+to be present. By encapsulating this styling in its own token, and applying it via the `Compose`
+domain, we can easily add (and just as easily remove) a bit of styling or functionality to an
+existing token, without embedding it so deeply within that making changes to it later becomes
+unnecessarily cumbersome.  
 
- NOTE: Our `WithTopWave` token could easily be woven into the body of our `Default` footer token, but imagine a future scenario where our design changes, and we no longer want that top wave to be present. By encapsulating this styling in its own token, and applying it via the `Compose` domain, we can easily add (and just as easily remove) a bit of styling or functionality to an existing token, without embedding it so deeply within that making changes it later becomes unncessarily cumbersome.
+<!-- @TODO: Complete thought:
+And in the event that this token has more widespread applications (e.g., a token that adds a border
+radius to an element), we can
+-->
 
- And in the event that this token has more widespread applications (i.e., a token that adds a border radius to an element), we can
+## Practice
+
+:construction: _In progress..._
+
+<!-- @TODO:
+    Come up with a new task for the reader to perform that is similar in nature to the lesson they
+    just completed, allowing them to practice what they've learned.
+-->
 
 ## Resources
 
-- [Adding components in Tailwind](https://tailwindcss.com/docs/plugins#adding-components)
-- [SVGR - For converting SVGs to React components](https://react-svgr.com/playground/)
-- [Using Tailwind for Background Images](https://johnsonandjohnson.github.io/Bodiless-JS/#/VitalDesignSystem/Guides/TailwindGuide?id=using-tailwind-for-background-images)
--
+- [Adding components | Tailwind CSS](https://tailwindcss.com/docs/plugins#adding-components
+  ':target=_blank')
+- [SVGR Playground](https://react-svgr.com/playground/ ':target=_blank') - For converting SVGs to
+  React components.
+- [Using Tailwind for Background Images](../../Guides/TailwindGuide#using-tailwind-for-background-images)
+
+<!-- @TODO:
+## FAQ
+
+    If you remember any of the questions you had when completing this task — or can think of any
+    questions a new developer may have — document the Questions and Answers here.
+
+### [ QUESTION 1 ]
+
+     Answer to QUESTION 1
+
+### [ QUESTION 2 ]
+
+     Answer to QUESTION 2
+-->

--- a/packages/vital-examples/doc/Curriculum/Lessons/BackgroundImages.md
+++ b/packages/vital-examples/doc/Curriculum/Lessons/BackgroundImages.md
@@ -124,15 +124,6 @@ And in the event that this token has more widespread applications (e.g., a token
 radius to an element), we can
 -->
 
-## Practice
-
-:construction: _In progress..._
-
-<!-- @TODO:
-    Come up with a new task for the reader to perform that is similar in nature to the lesson they
-    just completed, allowing them to practice what they've learned.
--->
-
 ## Resources
 
 - [Adding components | Tailwind CSS](https://tailwindcss.com/docs/plugins#adding-components
@@ -140,18 +131,3 @@ radius to an element), we can
 - [SVGR Playground](https://react-svgr.com/playground/ ':target=_blank') - For converting SVGs to
   React components.
 - [Using Tailwind for Background Images](../../Guides/TailwindGuide#using-tailwind-for-background-images)
-
-<!-- @TODO:
-## FAQ
-
-    If you remember any of the questions you had when completing this task — or can think of any
-    questions a new developer may have — document the Questions and Answers here.
-
-### [ QUESTION 1 ]
-
-     Answer to QUESTION 1
-
-### [ QUESTION 2 ]
-
-     Answer to QUESTION 2
--->

--- a/packages/vital-examples/doc/Curriculum/Lessons/CustomizeDesignTokens.md
+++ b/packages/vital-examples/doc/Curriculum/Lessons/CustomizeDesignTokens.md
@@ -1,97 +1,100 @@
-# Learn how to Customize Design Tokens
+# Customize Design Tokens
 
-In this lesson we will learn how to shadow the design elements, these are the base elements for customizing a website, in it we will define colors, fonts, typography and the like.
+In this lesson we will learn how to shadow design elements, base elements for customizing a website;
+in it, we will define colors, fonts, typography, and the like.
 
 ## Overview
 
 In this lesson we will:
 
-- Shadow the vital colors with [this palette](https://coolors.co/ccfbfe-cdd6dd-cdcacc-cdaca1-cd8987).
-- Shadow vital text decoration to customize the font weight
-- Shadow H1 and H2 element tokens to use our custom font and it's properties.
-
+- Shadow the Vital colors with [this palette](https://coolors.co/ccfbfe-cdd6dd-cdcacc-cdaca1-cd8987
+  ':target=_blank');
+- Shadow Vital text decoration to customize the font weight;
+- Shadow `H1` and `H2` element tokens to use our custom font and its properties.
 
 ## Assignment
 
-First, we'll need to edit the `tailwind.config.js` file to add the custom variable, colors, font and sizes for examples. You can follow [the naming convention from tailwind](https://tailwindcss.com/docs/customizing-colors#naming-your-colors).
-Note that we use the `vital-` prefix to define our colors, our tailwind file will look like this
+First, we'll need to edit the `tailwind.config.js` file to add the custom variable, colors, font,
+and sizes for our examples. You can follow [the naming convention from
+Tailwind](https://tailwindcss.com/docs/customizing-colors#naming-your-colors ':target=_blank'). Note
+that we use the `vital-` prefix to define our colors. Our Tailwind file will look like this:
 
-#### `tailwind.config.js`
+**`tailwind.config.js`:**
+
 ```js
 module.exports = {
   theme: {
     colors: {
-        'vital-primary': {
-            brand: '<COLOR>',
-            // ...
-        },
+      'vital-primary': {
+        brand: '<COLOR>',
         // ...
-    }
-  }
-}
+      },
+      // ...
+    },
+  },
+};
 ```
-**PS:** With this, the colors should be already overrided.
-You can find all vital colors [in here](https://github.com/johnsonandjohnson/Bodiless-JS/blob/main/packages/vital-elements/src/components/Color/tokens/vitalColor.ts).
 
-Then under the `src/component` folder, we'll create the files with the Components names, in our case, we'll override the `Typography` and `TextDecoration`, so we create theses files.
+?> **Note:** With this, the colors should be already overridden.  
+You can find all Vital colors
+[here](https://github.com/johnsonandjohnson/Bodiless-JS/blob/main/packages/vital-elements/src/components/Color/tokens/vitalColor.ts
+':target=_blank').
+
+Then, under the `src/component` folder, we'll create the files with the components names. In our
+case, we'll override the `Typography` and `TextDecoration`, so we create these files.
 
 ### Components
 
-For the sake of this example, we will two components, which extends the vital components, `TextDecoration` and `Typography` and define our custom tokens, and to shadow them, we'll just export them.
+For the sake of this example, we'll create two components, which extend the Vital components
+(`TextDecoration` and `Typography`) and define our custom tokens. To shadow them, we'll just export
+them.
 
-#### TextDecoration
+#### `TextDecoration`
 
-The `TextDecoration` class is easier to do, since we just export some tokens with only a class for each tokens, our file will look like this.
+The `TextDecoration` class is easier to do, since we just export some tokens with only a class for
+each token. Our file will look like this:
 
-##### `src/component/TextDecoration/tokens/exampleTextDecoration.ts`
-```ts
-import { asTokenGroup, TextDecorationMeta } from '@bodiless/vital-elements';
-import { vitalTextDecorationBase } from '@bodiless/vital-elements/src/base';
+**`src/component/TextDecoration/tokens/exampleTextDecoration.ts`:**
 
-export default asTokenGroup(TextDecorationMeta)({
-  ...vitalTextDecorationBase,
-  Bold: 'font-black',
-});
+[exampleTextDecoration.ts](https://raw.githubusercontent.com/johnsonandjohnson/Bodiless-JS/main/packages/vital-examples/src/customizing-design-tokens/components/TextDecoration/tokens/exampleTextDecoration.ts
+':include :type=code')
 
-```
+?> **Note:** The `asTokenGroup` function creates a group of element tokens that share the same
+metadata. You can find more information about the `Meta` domain
+[here](../../Guides/Tokens/TokenDomains#special-domains).
 
-**PS:** the `asTokenGroup` function creates a group of element tokens that share the same metadata, you can find more information about the Meta domain [here](../../Guides/Tokens/TokenDomains#special-domains).
+In this example we overwrite the `Bold` token to set a bolder font.
 
-In this example we overwrite the the `Bold` token to set a bolder font.
+#### `Typography`
 
-#### Typography
+For the typography, we will have to do some more work. Each typography element should be an instance
+of `asElementToken`, so we can rely on domains to help us to define our tokens. Our typography file
+will be something like this:
 
-For the typography, we will have to do some more work, each typography element should be a instance of `asElementToken`, so we can rely on Domains to help us to define our tokens. Our typography file will be something like this.
+**`src/component/TextDecoration/tokens/exampleTypography.ts`:**
 
-##### `src/component/TextDecoration/tokens/exampleTypography.ts`
-```ts
-import { asElementToken, vitalColor, vitalFontSize, vitalTextDecoration } from '@bodiless/vital-elements';
-import { vitalTypographyBase } from '@bodiless/vital-elements/src/base';
+[exampleTypography.ts](https://raw.githubusercontent.com/johnsonandjohnson/Bodiless-JS/main/packages/vital-examples/src/customizing-design-tokens/components/Typography/tokens/exampleTypography.ts
+':include :type=code')
 
-const H2 = asElementToken({
-  ...vitalTypographyBase.H2,
-  Core: {
-    _: as(vitalTextDecoration.ExtraBold, vitalFontSize.XXL)
-  }
-});
-```
-
-In this example, we created a custom H1 and H2 Tokens and exporting them with the vital typography base. So our package have all the vital tokens.
+In this example, we created custom `H1` and `H2` tokens, and exported them with the Vital typography
+base, so that our package has all the Vital tokens.
 
 ### Shadowing
 
-And now, to shadow the our tokens, create a file with the same path of the package, in out case, since we area shadowing the `@bodiles/vital-elements` package, we'll have this structure.
+And now, to shadow our tokens, create a file with the same path as the package. In our case, since
+we area shadowing the `@bodiless/vital-elements` package, we'll have this structure—
 
-```bash
+```text
 ├── shadow
 │   ├── @bodiless
 │   │   ├── vital-elements
-│   │   |   ├─ Typography.ts
-│   │   |   └─ TextDecoration.ts
+│   │   │   ├─ Typography.ts
+│   │   │   └─ TextDecoration.ts
 ```
 
-Where each file export the tokens from the components folder.
+—Where each file exports the tokens from the `components` folder.
 
 ## Practice
 
-Now you can try to create you own shadow files, try to customize some vital text decorations tokens, or even create a new typography token.
+Now you can try to create you own shadow files. Try to customize some Vital text decorations tokens,
+or even create a new typography token.

--- a/packages/vital-examples/doc/Curriculum/Lessons/CustomizeDesignTokens.md
+++ b/packages/vital-examples/doc/Curriculum/Lessons/CustomizeDesignTokens.md
@@ -12,6 +12,11 @@ In this lesson we will:
 - Shadow Vital text decoration to customize the font weight;
 - Shadow `H1` and `H2` element tokens to use our custom font and its properties.
 
+?> **Note:** For the code files used in this lesson, please see the
+`packages/vital-examples/src/customizing-design-tokens` directory in your local repository or on
+[GitHub](https://github.com/johnsonandjohnson/Bodiless-JS/tree/main/packages/vital-examples/src/customizing-design-tokens
+':target=_blank').
+
 ## Assignment
 
 First, we'll need to edit the `tailwind.config.js` file to add the custom variable, colors, font,

--- a/packages/vital-examples/doc/Curriculum/Lessons/CustomizeDesignTokens.md
+++ b/packages/vital-examples/doc/Curriculum/Lessons/CustomizeDesignTokens.md
@@ -12,10 +12,32 @@ In this lesson we will:
 - Shadow Vital text decoration to customize the font weight;
 - Shadow `H1` and `H2` element tokens to use our custom font and its properties.
 
-?> **Note:** For the code files used in this lesson, please see the
-`packages/vital-examples/src/customizing-design-tokens` directory in your local repository or on
-[GitHub](https://github.com/johnsonandjohnson/Bodiless-JS/tree/main/packages/vital-examples/src/customizing-design-tokens
-':target=_blank').
+<!-- Inlining HTML to add multi-line info block with unordered list and codeblock. -->
+<div class="warn">
+  <strong>Note:</strong> For the code files used in this lesson, please see the following (either
+  locally or on GitHub):
+
+  - `packages/vital-examples/src/customizing-design-tokens`
+    ([GitHub](https://github.com/johnsonandjohnson/Bodiless-JS/tree/main/packages/vital-examples/src/customizing-design-tokens
+    ':target=_blank'))
+  - `packages/vital-examples/src/styleguide/Page/StyleGuideTemplate/` `Typography.tsx`
+    ([GitHub](https://github.com/johnsonandjohnson/Bodiless-JS/blob/main/packages/vital-examples/src/styleguide/Page/StyleGuideTemplate/Typography.tsx
+    ':target=_blank'))
+    - This is the
+      [template](https://github.com/johnsonandjohnson/Bodiless-JS/blob/main/sites/vital-examples/src/data/pages/customizing-design-tokens/template.json
+      ':target=_blank') code for the page referenced below.
+
+  To see the "Typography" page in action, build and run the Vital Examples site—
+
+  ```shell
+  cd sites/vital-examples
+  npm run build
+  npm run start
+  ```
+
+  —and go to <http://localhost:8000/customizing-design-tokens/>.
+
+</div>
 
 ## Assignment
 

--- a/packages/vital-examples/doc/Curriculum/Lessons/DevelopANewComponent.md
+++ b/packages/vital-examples/doc/Curriculum/Lessons/DevelopANewComponent.md
@@ -39,9 +39,22 @@ By building the `vital-section` package, we will cover:
 
 ## Assignment
 
-To develop a new `vital-section` package it is important to keep the `vital-*` package structure in
-mind. Please refer to the [Vital Component Template documentation](../../Guides/ComponentTemplate)
-to follow the right structure and naming conventions.
+To develop a new\* `vital-section` package, it is important to keep the `vital-*` package structure
+in mind. Please refer to the [Vital Component Template
+documentation](../../Guides/ComponentTemplate) to follow the correct structure and naming
+conventions.
+
+?> **Note:** We recommend using the [Component
+Scaffolder](../../Guides/ComponentTemplate#component-scaffolding) to auto-generate the file
+structure for new components.
+
+While we'll be walking through the creation of the Vital Section component, as `vital-section` is an
+existing package, if you wish to follow along, we suggest trying the [practice exercise](#practice),
+and creating a Vital Article component (in a `vital-article` package) in tandem with this lesson.
+
+———  
+\*The `vital-section` package already exists and comes bundled with the Vital Design System; this
+lesson explains what it _would_ be like to create this package from scratch.
 
 ### Creating a Clean Component
 
@@ -461,6 +474,65 @@ Now that you have learned how to develop a new clean Vital component, it's time 
 skills. Create a new `vital-article` package and incorporate tokens to add custom functionality to a
 component of your choosing. Apply the concepts and techniques you have learned in this task to build
 a personalized component with enhanced features.
+
+<!-- Inlining HTML to add multi-line info block with disclosure widget. -->
+<div class="warn">
+  <strong>Note:</strong> We recommend using the <em>Component Scaffolder</em> to create the
+  structure of your new component for you, and then following the instructions in this lesson to
+  build it.
+  <br><br>
+  <details>
+  <summary>
+    Expand for details on using the Component Scaffolder...
+  </summary>
+
+  To use the [Component Scaffolder](../../Guides/ComponentTemplate#component-scaffolding) to get the
+  component built in this lesson started, run the following command from a local directory:
+
+  ```shell
+  npx @bodiless/vital-scaffold@next
+  ```
+
+  Follow the prompts to create the new component. The tool will generate the file structure based on
+  the answers provided and populate it with the necessary files.
+
+  Assuming your current working directory is the project root:
+
+  01. **Path to `src` directory where component should be created [Required]:**
+      `./packages/vital-article/src/`
+  01. **Component name [Required]:** `article`
+  01. **Library name [Required]:** `vital`
+  01. **Upstream package to extend:** _Leave blank_
+  01. **Is the component always static and never hydrated?:** `N`
+
+  ```shell
+  $ mkdir -p packages/vital-article/src/
+  $ npx @bodiless/vital-scaffold@next
+  ? Path to "src" directory where component should be created [Required],
+  e.g. "./", "./src/", "/absolute/path/to/[package name]/src" etc. Default to current directory.
+  >  ./packages/vital-article/src/
+  ? Component name [Required] article
+  ? Library name (eg. myBrand) [Required] vital
+  ? Upstream package to extend (e.g. `@bodiless/vital-card`). Omit if not extending.
+  ? Is the component is always static and never hydrated?
+  (otherwise both static and dynamic versions will be created) - default N No
+  ✔  ++ /packages/vital-article/src/components/Article/index.ts
+  ✔  ++ /packages/vital-article/src/components/Article/tokens/index.ts
+  ✔  ++ /packages/vital-article/src/components/Article/tokens/vitalArticle.ts
+  ✔  ++ /packages/vital-article/src/components/Article/__tests__/Article.test.tsx
+  ✔  ++ /packages/vital-article/src/components/Article/index.bl-edit.ts
+  ✔  ++ /packages/vital-article/src/components/Article/index.static.ts
+  ✔  ++ /packages/vital-article/src/index.ts
+  ✔  ++ /packages/vital-article/src/base.ts
+  ✔  ++ /packages/vital-article/src/components/Article/ArticleClean.tsx
+  ✔  ++ /packages/vital-article/src/components/Article/types.ts
+  ```
+
+  **Note:** As shown above, you first need to create the `packages/vital-article/src/` directory,
+  otherwise you will receive an error that the path is not writeable.
+
+  </details>
+</div>
 
 The `ArticleClean` component may have the following structure:
 

--- a/packages/vital-examples/doc/Curriculum/Lessons/DevelopANewComponent.md
+++ b/packages/vital-examples/doc/Curriculum/Lessons/DevelopANewComponent.md
@@ -1,32 +1,68 @@
-# Learn how to Develop a New Component
+# Develop a New Component
 
 ## Overview
- 
-In this lesson, we will learn how to develop a new vital component, customize it at the brand package, and place it on a site. The goal is to create a `vital-section` package that is a structural element used to divide content into distinct sections or blocks. We will also develop three tokens: `withTitle`, `withLink`, and `withDescription` which may be used by the Site Builder or brand to change the component or provide additional functionality.
+
+In this lesson, we will learn how to develop a new Vital component, customize it at the brand
+package level, and place it on a site. The goal is to create a `vital-section` package that is a
+structural element used to divide content into distinct sections or blocks. We will also develop
+three tokens: `withTitle`, `withLink`, and `withDescription` which may be used by the Site Builder
+or brand to change the component or provide additional functionality.
 
 By building the `vital-section` package, we will cover:
 
- - Creating a new Clean Vital Component from scratch.
- - Creating a set of Tokens for the clean vital component.
- - Composing and extending vital tokens at the Brand package and Site.
- - Token Naming Convention. `WithSectionLink` vs `SectionLink`.
- 
+- Creating a new _clean_ Vital component from scratch.
+- Creating a set of tokens for the clean Vital component.
+- Composing and extending Vital tokens at the brand package and site level.
+- The token naming convention (e.g., `WithSectionLink` vs `SectionLink`).
+
+<!-- Inlining HTML to add multi-line info block with unordered list and codeblock. -->
+<div class="warn">
+  <strong>Note:</strong> For the code files used in this lesson, please see the following (either
+  locally or on GitHub):
+
+  - `packages/vital-examples/src/intro/section-example` ([GitHub](https://github.com/johnsonandjohnson/Bodiless-JS/tree/main/packages/vital-examples/src/intro/section-example
+    ':target=_blank'))
+  - `sites/vital-examples/src/pages/intro/section-example.tsx` ([GitHub](https://github.com/johnsonandjohnson/Bodiless-JS/blob/main/sites/vital-examples/src/pages/intro/section-example.tsx
+    ':target=_blank'))
+
+  To see the "Section Example" page in action, build and run the Vital Examples site—
+
+  ```shell
+  cd sites/vital-examples
+  npm run build
+  npm run start
+  ```
+
+  —and go to <http://localhost:8000/intro/section-example/>.
+
+</div>
+
 ## Assignment
 
-To develop a new `vital-section` package it is important to keep the `vital-*` package structure in mind. Please refer to the [Vital Component Template Documentation](../../Guides/ComponentTemplate) to follow the right structure and naming conventions.
+To develop a new `vital-section` package it is important to keep the `vital-*` package structure in
+mind. Please refer to the [Vital Component Template documentation](../../Guides/ComponentTemplate)
+to follow the right structure and naming conventions.
 
-#### Creating a Clean Component
+### Creating a Clean Component
 
-The `SectionClean` component utilizes the `designable` (HOC) from `@bodiless/fclasses` to enable components customization and the `withNode` HOC from `@bodiless/data` to handle its data. It consists of several inner components (Slots) that define the DOM structure of the SectionClean component, such as the `Wrapper`, `Title`, `Description`, `Link`, and `Content`.
+The `SectionClean` component utilizes the `designable` HOC from `@bodiless/fclasses` to enable
+components customization and the `withNode` HOC from `@bodiless/data` to handle its data. It
+consists of several inner components (_slots_) that define the DOM structure of the `SectionClean`
+component, such as the `Wrapper`, `Title`, `Description`, `Link`, and `Content` slots.
 
-We start developing the Clean component in `@bodiless/vital-section/src/Components/Section/SectionClean.tsx` by defining the `sectionComponents` object, which maps the `SectionClean` component slots to the actual HTML elements. Note that all HTML Elements including the `Fragment` are coming from the `@bodiless/fclasses` package.
+We start developing the clean component in
+`@bodiless/vital-section/src/Components/Section/SectionClean.tsx` by defining the
+`sectionComponents` object, which maps the `SectionClean` component slots to the actual HTML
+elements. Note that all HTML Elements, including the `Fragment`, are coming from the
+`@bodiless/fclasses` package.
 
 ```ts
 import { H2, Section, Fragment } from '@bodiless/fclasses';
 
 /**
- * The `sectionComponents` is basically a map of SectionClean component slots to HTML Elements.
- * This HTML elements will be used in place of SectionClean component slots in the layout.
+ * The `sectionComponents` is basically a map of `SectionClean` component
+ * slots to HTML Elements. These HTML elements will be used in place of
+ * `SectionClean` component slots in the layout.
  */
 const sectionComponents = {
   Wrapper: Section,
@@ -41,14 +77,18 @@ const sectionComponents = {
 };
 ```
 
-> Note that by default, most of the initial slots are Fragments and we will be working on tokens that add an extra slots later.
+?> **Note:** By default, most of the initial slots are Fragments and we will be working on tokens
+that add extra slots later.
 
-Let's also define the interface for the section components. It could live in `SectionClean.tsx` or in its own `types.ts` file.:
+Let's also define the interface for the section components. It could live in `SectionClean.tsx` or
+in its own `types.ts` file:
 
 ```ts
 import { DesignableComponents, ComponentOrTag } from '@bodiless/fclasses';
 /**
- * A set of Section components. By default all slots are typed as `ComponentOrTag<any>`.
+ * A set of Section components. By default all slots are typed as
+ * `ComponentOrTag<any>`.
+ *
  * @category Component
  */
 export interface SectionComponents extends DesignableComponents {
@@ -64,13 +104,14 @@ export interface SectionComponents extends DesignableComponents {
 }
 ```
 
-The next step is to create the base component, `SectionBase`, that defines the inner components' DOM structure:
+The next step is to create the base component, `SectionBase`, that defines the inner components' DOM
+structure:
 
 ```tsx
 /**
- * Base component for the `SectionClean`. It defines the inner components DOM structure.
- * The `components` prop is coming from `designable` HOC below and has its type as
- * `DesignableComponentsProps<SectionComponents>`. 
+ * Base component for `SectionClean`. It defines the inner components' DOM
+ * structure. The `components` prop is coming from the `designable` HOC below
+ * and has its type as `DesignableComponentsProps<SectionComponents>`.
  */
 const SectionBase: FC<SectionBaseProps> = ({ components, ...rest }) => {
   const {
@@ -87,14 +128,17 @@ const SectionBase: FC<SectionBaseProps> = ({ components, ...rest }) => {
 
   return (
     /**
-     * Note that we spread the rest of the arguments into the Wrapper component.
-     * This is the important step to do, otherwise we may loose attributes.
-     * 
-     * For example, the `{...rest}` ensures that if we add a custom ID to <Section id="..." />,
-     * it will flow to the Wrapper component and not get lost.
-     * 
-     * While the outermost element is recommended to receive the rest of the props,
-     * it is not mandatory, and other slots may receive it based on your needs.
+     * Note that we spread the rest of the arguments into the `Wrapper`
+     * component. This is the important step to do, otherwise we may lose
+     * attributes.
+     *
+     * For example, the `{...rest}` ensures that if we add a custom ID to
+     * `<Section id="..." />`, it will flow to the `Wrapper` component and not
+     * get lost.
+     *
+     * While the outermost element is recommended to receive the rest of the
+     * props, it is not mandatory, and other slots may receive it based on
+     * your needs.
      */
     <Wrapper {...rest}>
       <TitleWrapper>
@@ -114,43 +158,53 @@ const SectionBase: FC<SectionBaseProps> = ({ components, ...rest }) => {
 };
 ```
 
-Once we have the Base component, we are ready to compose the `SectionClean` by wrapping `SectionBase` with the `designable` and `withNode` HOCs:
+Once we have the base component, we are ready to compose the `SectionClean` component by wrapping
+`SectionBase` with the `designable` and `withNode` HOCs:
+
 ```ts
 /**
- * Define SectionClean by wrapping `SectionBase` with `designable` HOC that provides the 
- * `components` prop and add Node to the Component so that it is capable of handling it's own data.
+ * Define `SectionClean` by wrapping `SectionBase` with the `designable` HOC
+ * that provides the `components` prop, and add Node to the component so that
+ * it is capable of handling its own data.
  */
 const SectionClean = as(
   /**
    * The second argument `section` is a namespace for the inner components.
-   * For example `Wrapper` component will be marked as `Section:Wrapper`.
+   * For example, the `Wrapper` component will be marked as `Section:Wrapper`.
    */
   designable(sectionComponents, 'Section'),
   withNode,
 )(SectionBase);
 ```
 
-Another important step is to define the `asSectionToken` function using the `asVitalTokenSpec` from `@bodiless/vital-elements`. It will be used to create any token related to the Section component. It allows for the type checking and components autocomplete when working with Tokens.
+Another important step is to define the `asSectionToken` function using the `asVitalTokenSpec` from
+`@bodiless/vital-elements`. It will be used to create any token related to the Section component. It
+allows for the type-checking and components autocompletion when working with tokens.
 
 ```ts
 /**
- * A token modifier that respects the Section Components. Use to create component tokens.
+ * A token modifier that respects the Section components. Use to create
+ * component tokens.
  *
  * @category Token Collection
  */
 export const asSectionToken = asVitalTokenSpec<SectionComponents>();
 ```
 
-#### Creating Tokens for the Clean Component
+### Creating Tokens for the Clean Component
 
-At this point we created the fully functional Vital Clean Component that follows all patterns. The way Site Builder may extend or change the `SectionClean` component is by applying Tokens to it. Let's create few basic tokens. Note that all component tokens should live under the `./tokens/` folder.
+At this point, we have created a fully functional Vital clean component that follows all patterns.
+The way a Site Builder may extend or change the `SectionClean` component is by applying tokens to
+it. Let's create few basic tokens. Note that all component tokens should live under the `./tokens/`
+folder.
 
-We start by defining the `Default` token. Usually this is the token that defines the Core functionality of the component as well as default layout and its schema.
+We start by defining the `Default` token. Usually this is the token that defines the core
+functionality of the component, as well as its default layout and schema.
 
 ```ts
 /**
- * A Default token for the Section Component. This token registers nodes and node keys
- * and sets minimal layout styles.
+ * A `Default` token for the Section component. This token registers nodes and
+ * node keys, and sets minimal layout styles.
  */
 const Default = asSectionToken({
   Layout: {
@@ -171,27 +225,30 @@ The `Default` token is just enough to render the basic version of the component 
 
 ```ts
 /**
- * The below example are the two different ways to achieve the same result.
+ * The examples below are two different ways to achieve the same result.
  */
 const DefaultSection_v1 = on(SectionClean)(vitalSection.Default);
 const DefaultSection_v2 = as(vitalSection.Default)(SectionClean);
 ```
 
-Let's now work on set of tokens that will extend the `Default` token and add more slots to the Clean Component. First we will create a Token that adds Link to the `SectionClean`:
+Let's now work on a set of tokens that will extend the `Default` token and add more slots to the
+clean component. First we will create a token that adds a `Link` to the `SectionClean` component:
 
 ```ts
 /**
- * A token that adds a Link to the Section Component.
+ * A token that adds a `Link` to the Section component.
  * Note that this token does not add any default link text.
  *
- * Note that the name of this token *starts with* `With...`. That means that the token is meant
- * to be layered on top of other tokens and not used by itself. The big difference here is that
- * this token *does not extend* the Default token. It is very limited in what this token can do.
+ * Note that the name of this token _starts with_ `With...`. That means that
+ * the token is meant to be layered on top of other tokens and not used by
+ * itself. The big difference here is that this token _does not extend_ the
+ * `Default` token. It is very limited in what this token can do.
  *
- * Think of it as an Adjective, something that reflects behaviour or additional functionality.
+ * Think of it as an adjective, something that reflects behavior or additional
+ * functionality.
  *
- * This is the preffered Token pattern since it encourages composition
- * and results in a better overall code structure as well as simplifying testing.
+ * This is the preferred token pattern, since it encourages composition and
+ * results in a better overall code structure, as well as simplifies testing.
  */
 const WithLink = asSectionToken({
   Components: {
@@ -206,24 +263,31 @@ const WithLink = asSectionToken({
 });
 ```
 
-##### Tokens Naming Convention
+### Token Naming Convention
 
-When working with Tokens, it's important to understand the different Token types and their intended usage. Here are the examples of two types of Tokens: names of which start with  "With..." and Standalone Tokens (`WithSectionLink` vs `SectionLink`). These two types serve distinct purposes and have specific characteristics that influence how they should be used.
+When working with tokens, it's important to understand the different token types and their intended
+usage. Here are examples of two types of tokens: tokens with names that start with `With...` and
+standalone tokens (e.g., `WithSectionLink` vs `SectionLink`). These two types serve distinct
+purposes and have specific characteristics that influence how they should be used.
 
-Here is an example of `WithSectionLink` token. Note that this token is very limited and adds a component without inheriting any other tokens.
+Here is an example of a `WithSectionLink` token. Note that this token is very limited and adds a
+component without inheriting any other tokens.
+
 ```ts
 /**
- * A token that adds a Link to the Section Component.
+ * A token that adds a `Link` to the Section component.
  * Note that this token does not add any default link text.
  *
- * Note that the name of this token starts with `With...`. That means that the token is meant
- * to be layered on top of other tokens and not used by itself. The big difference here is that
- * this token *does not extend* the Default token. It is very limited in what this token can do.
+ * Note that the name of this token _starts with_ `With...`. That means that
+ * the token is meant to be layered on top of other tokens and not used by
+ * itself. The big difference here is that this token _does not extend_ the
+ * `Default` token. It is very limited in what this token can do.
  *
- * Think of it as an Adjective, something that reflects behaviour or additional functionality.
+ * Think of it as an adjective, something that reflects behavior or additional
+ * functionality.
  *
- * This is the preffered Token pattern since it encourages composition
- * and results in a better overall code structure as well as simplifying testing.
+ * This is the preferred token pattern, since it encourages composition and
+ * results in a better overall code structure, as well as simplifies testing.
  */
 const WithSectionLink = asSectionToken({
   Components: {
@@ -235,17 +299,20 @@ const WithSectionLink = asSectionToken({
 });
 ```
 
-Which is different from `SectionLink` token which actually builds on top of the Default token by extending it:
+This is different from a `SectionLink` token, which actually builds on top of the `Default` token by
+extending it:
+
 ```ts
 /**
- * A token that adds a Link to the Section Component.
+ * A token that adds a `Link` to the Section component.
  * Note that this token does not add any default link text.
  *
- * This token does not have `With...` in it's name and it indicates that this token is meant
- * to be used as a standalone token which can be used *instead* of the `Default` token.
+ * This token does not have `With...` in its name, and that indicates that
+ * this token is meant to be used as a standalone token, which can be used
+ * _instead_ of the `Default` token.
  *
- * Think of it as a Noun, the token is sufficent by itself to render the component,
- * and not just adding a small piece of functionality.
+ * Think of it as a noun, as the token is sufficient by itself to render the
+ * component, and not just adding a small piece of functionality.
  */
 const SectionLink = asSectionToken(Default, {
   Components: {
@@ -257,12 +324,14 @@ const SectionLink = asSectionToken(Default, {
 });
 ```
 
-Now that we know the difference in Token naming convention, lets create few more tokens:
+Now that we know how to apply the token naming convention to these two different types of tokens,
+let's create a few more tokens:
 
 ```ts
 /**
- * A token that adds a Title to the Section Component.
- * The Title is an `EditorPlainClean` with `vitalEditorPlain.Default` token.
+ * A token that adds a `Title` to the Section component.
+ * The `Title` is an `EditorPlainClean` component with a
+ * `vitalEditorPlain.Default` token.
  * `TitleWrapper` is the actual `H2` tag.
  */
 const WithTitle = asSectionToken({
@@ -279,8 +348,9 @@ const WithTitle = asSectionToken({
 });
 
 /**
- * A token that adds a Description to the Section Component.
- * The Description is an `EditorPlainClean` with `vitalEditorPlain.Default` token.
+ * A token that adds a `Description` to the Section component.
+ * The `Description` is an `EditorPlainClean` component with a
+ * `vitalEditorPlain.Default` token.
  * `DescriptionWrapper` is the `P` tag.
  */
 const WithDescription = asSectionToken({
@@ -297,11 +367,12 @@ const WithDescription = asSectionToken({
 });
 ```
 
-With all tokens defined we are ready to export them as a single object:
+With all tokens defined, we are ready to export them as a single object:
 
 ```ts
 /**
- * Export all tokens as a single object that is exported from package as `vitalSection`.
+ * Export all tokens as a single object that is exported from the package as
+ * `vitalSection`.
  */
 export default {
   Default,
@@ -311,114 +382,85 @@ export default {
 };
 ```
 
-Now we are ready to use our Vital Section Component and build our own combinations:
+Now we are ready to use our Vital Section component and build our own combinations:
+
+[section-example.tsx](https://raw.githubusercontent.com/johnsonandjohnson/Bodiless-JS/main/sites/vital-examples/src/pages/intro/section-example.tsx
+':include :type=code :fragment=build-combinations')
+
+### Extending Tokens at the Brand Package Level
+
+In a lot of cases, you may want to change or build on top of the default Vital components at the
+brand level. For example, the Vital token `WithTitle` provides the Editor for the `Title` slot and
+makes it an `H2` tag, but it does not provide any default data to the `Title`. Let's extend the
+Vital token to provide the default data as well:
 
 ```ts
 /**
- * Default Section Component. The result of applying the `Default` token to the `SectionClean`
- * component. `vitalSection.WithSectionCards` provides cards content for `Content` component.
- */
-const DefaultSection = as(
-  vitalSection.Default,
-)(SectionClean);
-
-/**
- * Section Component with Title. The result of composing the `Default` and `WithTitle` tokens.
- */
-const SectionWithTitle = as(
-  vitalSection.Default,
-  vitalSection.WithTitle,
-)(SectionClean);
-
-/**
- * Section Component with Link. The result of composing the `Default` and `WithLink` tokens.
- */
-const SectionWithLink = as(
-  vitalSection.Default,
-  vitalSection.WithLink,
-)(SectionClean);
-
-/**
- * Section Component with Description.
- * The result of composing the `Default` and `WithDescription` tokens.
- */
-const SectionWithDescription = as(
-  vitalSection.Default,
-  vitalSection.WithDescription,
-)(SectionClean);
-
-/**
- * An Example of Section with all elements.
- */
-const SectionFull = as(
-  vitalSection.Default,
-  vitalSection.WithTitle,
-  vitalSection.WithLink,
-  vitalSection.WithDescription,
-)(SectionClean);
-```
-
-
-#### Extending Tokens at Brand Package
-
-In a lot of cases you may want to change or build on top of the default vital components at the brand level. For example the vital token `WithTitle` provides the Editor for the Title slot and makes it an H2 tag, but it does not provide any default data to the Title. Lets extend the vital token to provide the default data as well:
-
-```ts
-/**
- * Hook to provide the default content for the `EditorPlainClean` Title element.
- * It returns the object where key is the nodeKey expected, and the value is the data expected
- * by the underlying component.
+ * Hook to provide the default content for the `EditorPlainClean` `Title`
+ * element.
+ * It returns the object where the key is the `nodeKey` expected, and the
+ * value is the data expected by the underlying component.
  *
- * Note that the nodeKey in this case is empty '' since `withDefaultContext` is used in
- * the same schema node context that is coming from `vitalSectionBase.WithTitle`. See how
- * in `vitalSectionBase.WithTitle` token we set a component for Title slot along with
- * the Schema data for it.
+ * Note that the `nodeKey`, in this case, is empty (`''`) since
+ * `withDefaultContext` is used in the same schema node context that is coming
+ * from `vitalSectionBase.WithTitle`. See how, in the
+ * `vitalSectionBase.WithTitle` token, we set a component for `Title` slot
+ * along with the `Schema` data for it.
  */
 export const useTitleContent = () => ({
   '': { text: 'Hello Section Title!' },
 });
 
 /**
- * A token that adds a Section Title.
- * Title editor setings are inherited from `...vitalSection.WithTitle` Token.
+ * A token that adds a Section `Title`.
+ * Title editor settings are inherited from the `...vitalSection.WithTitle`
+ * token.
  *
- * Note that the name of this token *starts with* `With...`. That means that the token is meant
- * to be layered on top of other tokens and not used by itself. The big difference here is that
- * this token *does not extend* the Default token. It is very limited in what this token can do.
+ * Note that the name of this token _starts with_ `With...`. That means that
+ * the token is meant to be layered on top of other tokens and not used by
+ * itself. The big difference here is that this token _does not extend_ the
+ * `Default` token. It is very limited in what this token can do.
  *
- * Think of it as an Adjective, something that reflects behaviour or additional functionality.
+ * Think of it as an adjective, something that reflects behavior or additional
+ * functionality.
  *
- * This is the preffered Token pattern since it encourages composition
- * and results in a better overall code structure as well as simplifying testing.
+ * This is the preferred token pattern, since it encourages composition and
+ * results in a better overall code structure, as well as simplifies testing.
  */
 const WithSectionTitle = asSectionToken({
   /**
-   * The `vitalSection.WithLink` token is also meant to enhance the main Token.
-   * It provides the Editor for the Section Title and makes `TitleWrapper` h2.
+   * The `vitalSection.WithTitle` token is also meant to enhance the main
+   * token. It provides the Editor for the Section `Title` and makes
+   * `TitleWrapper` an `H2`.
    */
   ...vitalSection.WithTitle,
   Content: {
     /**
-     * We use `withDefaultContent` and the `useTitleContent` hook to add the default text
-     * to the Section Title under the `Content` Domain.
+     * We use `withDefaultContent` and the `useTitleContent` hook to add the
+     * default text to the Section `Title` under the `Content` domain.
      *
-     * Note that for the `withDefaultContent` to work we need to provide the Schema for the slot.
-     * In this case the Schema for the Title is coming from `vitalSectionBase.WithTitle`
+     * Note that for the `withDefaultContent` to work we need to provide the
+     * `Schema` for the slot. In this case, the `Schema` for the `Title` is
+     * coming from `vitalSectionBase.WithTitle`.
      *
-     * When `Schema` and `DefaultContent` for the slot Components are in the same node context,
-     * there will be no need to specify the `nodeKey` for the DefaultContent object. See how
-     * in `vitalSectionBase.WithTitle` token we set a component for Title slot, and
-     * the Schema data for it and then use it to compose this token all with the same node context.
+     * When `Schema` and `DefaultContent` for the slot components are in the
+     * same node context, there will be no need to specify the `nodeKey` for
+     * the `DefaultContent` object. See how, in the
+     * `vitalSectionBase.WithTitle` token, we set a component for the `Title`
+     * slot, and the `Schema` data for it, and then use it to compose this
+     * token all with the same node context.
      */
     Title: withDefaultContent(useTitleContent),
   }
 });
 ```
 
- 
 ## Practice
- 
-Now that you have learned how to develop a new clean vital component, it's time to practice your skills. Create a new `vital-article` package and incorporate tokens to add custom functionality to a component of your choosing. Apply the concepts and techniques you have learned in this task to build a personalized component with enhanced features.
+
+Now that you have learned how to develop a new clean Vital component, it's time to practice your
+skills. Create a new `vital-article` package and incorporate tokens to add custom functionality to a
+component of your choosing. Apply the concepts and techniques you have learned in this task to build
+a personalized component with enhanced features.
 
 The `ArticleClean` component may have the following structure:
 
@@ -439,22 +481,35 @@ The `ArticleClean` component may have the following structure:
 </Wrapper>
 ```
 
-All slots except for the `ArticleTitle` are `Fragments` by default and there are 3 Tokens exported by the package: `WithArticleLink`, `WithArticleCTA`, `WithArticleContent` that add corresponding slots to the component.
+All slots except for the `ArticleTitle` are `Fragments` by default, and there are three tokens
+exported by the package — `WithArticleLink`, `WithArticleCTA`, and `WithArticleContent` — that add
+corresponding slots to the component.
 
 ## Resources
- - [Extending & Composing Tokens](https://github.com/johnsonandjohnson/Bodiless-JS/blob/9d872a75c7ff2a00af0bc53ae9c3b2f3545ddf24/packages/vital-elements/doc/ExtendingAndComposing.md)
- - [Vital Component Template](../../Guides/ComponentTemplate)
- 
+
+- [Extending and Composing Tokens](../../Guides/ExtendingAndComposingTokens)
+- [Vital Component Template](../../Guides/ComponentTemplate)
+
 ## FAQ
 
 ### What is the purpose of the `asSectionToken` function?
 
-A: The `asSectionToken` function is used to create component tokens for the `SectionClean` component. It respects the Section Components and supports Token components name autocomplete and type checking.
- 
-### Why are these tokens called "With..."?
- 
-A: The tokens in BodilessJs are named with the prefix "With..." to indicate that they provide additional functionality or behavior to the component they are applied to. This naming convention helps developers understand that these tokens are meant to be layered on top of other tokens and enable composition. By using the "With..." naming convention, it promotes a modular and composable approach to building components.
- 
+The `asSectionToken` function is used to create component tokens for the `SectionClean` component.
+It respects the Section components, and supports name-autocompletion and type checking for token
+components.
+
+### Why are these tokens called `With...`?
+
+The tokens in BodilessJS are named with the prefix `With...` to indicate that they provide
+additional functionality or behavior to the component they are applied to. This naming convention
+helps developers understand that these tokens are meant to be layered on top of other tokens and
+enable composition. By using the `With...` naming convention, it promotes a modular and composable
+approach to building components.
+
 ### Can I use these tokens independently without other tokens?
- 
-A: Yes, you can use the tokens independently without layering them on top of other tokens. However, it's important to note that the tokens prefixed with "With..." are designed to enhance and extend the functionality of existing tokens or components. Using them independently may limit their capabilities and potential benefits. Consider the specific use case and whether applying the tokens individually aligns with your development goals.
+
+Yes, you can use the tokens independently without layering them on top of other tokens. However,
+it's important to note that the tokens prefixed with `With...` are designed to enhance and extend
+the functionality of existing tokens or components. Using them independently may limit their
+capabilities and potential benefits. Consider the specific use case and whether applying the tokens
+individually aligns with your development goals.

--- a/packages/vital-examples/doc/Curriculum/Lessons/ReusableTokens.md
+++ b/packages/vital-examples/doc/Curriculum/Lessons/ReusableTokens.md
@@ -41,15 +41,51 @@ components in a site.
 
 ## Assignment
 
-### Creating a New CSS Rule in Tailwind for Our Image Border Radius
+### Creating a Simple 'Radius' Token
 
-To begin, we'll use the `addComponents` function provided by Tailwind to first create a collection
-of CSS rules containing the corner radius styling to be applied to the `Hero` card.
+To begin, we will create both a `Card` and `Radius` component folder inside of our example package,
+`reusable-tokens`.
+
+The `Card` component folder will contain the `Default` and `Hero` card tokens in an `exampleCard.ts`
+token collection file, and the `Radius` component folder will contain the corner radius styling
+tokens in an `exampleRadius.ts` token collection file.
+
+Please reference the [Vital Component Template documentation](../../Guides/ComponentTemplate) to
+ensure that you are following the proper naming conventions and file structure when creating a new
+component folder. You should have some familiarity with the naming conventions and file structure
+after completing the previous lesson: [Develop a New Component](./DevelopA_NewComponent).
+
+In our `exampleRadius.ts` token collection file, we will create two tokens that will be used to
+apply two different types of `border-radius` styles to our card components. First, let's create our
+`Simple` token:
+
+[exampleRadius.ts](https://raw.githubusercontent.com/johnsonandjohnson/Bodiless-JS/main/packages/vital-examples/src/reusable-tokens/components/Radius/tokens/exampleRadius.ts
+':include :type=code :fragment=simple-token')
+
+Although we are applying these tokens to card elements in this lesson, they've been written in a way
+that will allow us to apply them to essentially any component/slot that we want.
+
+As we will be shadowing both the `Default` and `Hero` Vital card variants, we'll create two separate
+card tokens inside of our `exampleCard.ts` token collection file. First, let's create our `Default`
+card token, applying our `Simple` radius token to it:
+
+```ts
+const Default = asCardToken(vitalCardBase.Default, {
+  Theme: {
+    ContentWrapper: exampleRadius.Simple,
+  },
+});
+```
+
+### Creating a Fancy 'Radius' Token
+
+Here, we'll use the `addComponents` function provided by Tailwind to first create a collection of
+CSS rules containing the corner radius styling to be applied to the `Hero` card.
 
 ?> **Note:** In most cases, the default utility classes provided by Tailwind will be enough to meet
 your styling needs, but in cases such as this, where we are attempting to apply a more complex set
 of styling rules to a component, we can construct those CSS rules directly in our Tailwind
-configuration file as shown below:
+configuration file (`tailwind.config.js`) as shown below:
 
 ```js
 const twConfig = {
@@ -83,34 +119,29 @@ const twConfig = {
 };
 ```
 
-Next, we will create both a `Card` and `Radius` component folder inside of our example package,
-`reusable-tokens`.
-
-The `Card` component folder will contain the `Default` and `Hero` card tokens in an `exampleCard.ts`
-token collection file, and the `Radius` component folder will contain the corner radius styling
-tokens in an `exampleRadius.ts` token collection file.
-
-Please reference the [Vital Component Template documentation](../../Guides/ComponentTemplate) to
-ensure that you are following the proper naming conventions and file structure when creating a new
-component folder.
-
-### Creating Our Reusable 'Radius' Tokens
-
-In our `exampleRadius.ts` token collection file, we will create two tokens that will be used to
-apply two different types of `border-radius` styles to our card components.
+Returning to our `exampleRadius.ts` token collection file, let's create a `Fancy` token, which will
+be used to apply a different `border-radius` style to our card components:
 
 [exampleRadius.ts](https://raw.githubusercontent.com/johnsonandjohnson/Bodiless-JS/main/packages/vital-examples/src/reusable-tokens/components/Radius/tokens/exampleRadius.ts
-':include :type=code :fragment=radius-tokens')
+':include :type=code :fragment=fancy-token')
 
-Although we are applying these tokens to card elements in this lesson, they've been written in a way
-that will allow us to apply them to essentially any component/slot that we want.
-
-As we will be shadowing both the `Default` and `Hero` Vital card variants, let's create two separate
-card tokens inside of our `exampleCard.ts` token collection file and apply our previously-created
-radius tokens there:
+Now, in our `exampleCard.ts` token collection file, let's create our `Hero` card token and apply our
+`Fancy` radius token to it:
 
 [exampleCard.ts](https://raw.githubusercontent.com/johnsonandjohnson/Bodiless-JS/main/packages/vital-examples/src/reusable-tokens/components/Card/tokens/exampleCard.ts
-':include :type=code :fragment=card-tokens')
+':include :type=code :fragment=hero-card-token')
+
+### The Benefits of Tokens
+
+Let's take a look at the `Default` token we made earlier:
+
+```ts
+const Default = asCardToken(vitalCardBase.Default, {
+  Theme: {
+    ContentWrapper: exampleRadius.Simple,
+  },
+});
+```
 
 It would also be entirely acceptable to apply the `'rounded-br-[40px]'` class from our `Simple`
 element token directly to the `Theme` domain of our `Default` card token as follows:

--- a/packages/vital-examples/doc/Curriculum/Lessons/ReusableTokens.md
+++ b/packages/vital-examples/doc/Curriculum/Lessons/ReusableTokens.md
@@ -109,7 +109,7 @@ As we will be shadowing both the `Default` and `Hero` Vital card variants, let's
 card tokens inside of our `exampleCard.ts` token collection file and apply our previously-created
 radius tokens there:
 
-[exampleCard.ts](https://github.com/johnsonandjohnson/Bodiless-JS/blob/main/packages/vital-examples/src/reusable-tokens/components/Card/tokens/exampleCard.ts
+[exampleCard.ts](https://raw.githubusercontent.com/johnsonandjohnson/Bodiless-JS/main/packages/vital-examples/src/reusable-tokens/components/Card/tokens/exampleCard.ts
 ':include :type=code :fragment=card-tokens')
 
 It would also be entirely acceptable to apply the `'rounded-br-[40px]'` class from our `Simple`

--- a/packages/vital-examples/doc/Curriculum/Lessons/ReusableTokens.md
+++ b/packages/vital-examples/doc/Curriculum/Lessons/ReusableTokens.md
@@ -2,22 +2,59 @@
 
 ## Overview
 
-In this lesson we will be creating two reusable styling tokens and applying them to elements of our 'Default' and 'Hero' Vital card variants.
+In this lesson, we will be creating two reusable styling tokens and applying them to elements of our
+`Default` and `Hero` Vital card variants.
 
-One will apply a simple bottom right border radius, and the other will apply a more complex set of custom CSS rules to be applied to the 'Image' slot of the 'Hero' card.
+One will apply a simple bottom-right border radius, and the other will apply a more complex set of
+custom CSS rules to be applied to the `Image` slot of the `Hero` card.
 
-The purpose of this lesson is to better understand the preferred method of creating reusable tokens, and the reasons why this pattern is encouraged when repeating styling choices across multiple components in a site.
+The purpose of this lesson is to better understand the preferred method of creating reusable tokens,
+and the reasons why this pattern is encouraged when repeating styling choices across multiple
+components in a site.
+
+<!-- Inlining HTML to add multi-line info block with unordered list and codeblock. -->
+<div class="warn">
+  <strong>Note:</strong> For the code files used in this lesson, please see the following (either
+  locally or on GitHub):
+
+  - `packages/vital-examples/src/reusable-tokens`
+    ([GitHub](https://github.com/johnsonandjohnson/Bodiless-JS/tree/main/packages/vital-examples/src/reusable-tokens
+    ':target=_blank'))
+  - `packages/vital-examples/src/styleguide/Page/StyleGuideTemplate/Card.tsx`
+    ([GitHub](https://github.com/johnsonandjohnson/Bodiless-JS/blob/main/packages/vital-examples/src/styleguide/Page/StyleGuideTemplate/Card.tsx
+    ':target=_blank'))
+    - This is the
+      [template](https://github.com/johnsonandjohnson/Bodiless-JS/blob/main/sites/vital-examples/src/data/pages/reusable-tokens/template.json
+      ':target=_blank') code for the page referenced below.
+
+  To see the "Example Cards" page in action, build and run the Vital Examples site—
+
+  ```shell
+  cd sites/vital-examples
+  npm run build
+  npm run start
+  ```
+
+  —and go to <http://localhost:8000/reusable-tokens/>.
+
+</div>
 
 ## Assignment
 
-### Creating a new CSS rule in Tailwind for our image border radius
+### Creating a New CSS Rule in Tailwind for Our Image Border Radius
 
-To begin, we'll use the `addComponents` function provided by Tailwind to first create a collection of CSS rules containing the corner radius styling to be applied to the 'Hero' card.
+To begin, we'll use the `addComponents` function provided by Tailwind to first create a collection
+of CSS rules containing the corner radius styling to be applied to the `Hero` card.
 
-?> **Note:** In most cases, the default utility classes provided by Tailwind will be enough to meet your styling needs, but in cases such as this where we are attempting to apply a more complex set of styling rules to a component, we can construct those CSS rules directly in our Tailwind configuration file as shown below:
+?> **Note:** In most cases, the default utility classes provided by Tailwind will be enough to meet
+your styling needs, but in cases such as this, where we are attempting to apply a more complex set
+of styling rules to a component, we can construct those CSS rules directly in our Tailwind
+configuration file as shown below:
 
 ```js
-plugin(({ addComponents }) => {
+const twConfig = {
+  plugins: [
+    plugin(({ addComponents }) => {
       addComponents({
         '.card-corner': {
           width: 'calc(100% - 60px)',
@@ -39,82 +76,60 @@ plugin(({ addComponents }) => {
           float: 'none',
           'border-radius': '0 0 0 400px',
         },
+        // ...
       });
     }),
+  ],
+};
 ```
 
-Next, we will create both a 'Card' and 'Radius' component folder inside of our example package `reusable-tokens`.
+Next, we will create both a `Card` and `Radius` component folder inside of our example package,
+`reusable-tokens`.
 
-The 'Card' component folder will contain the 'Default' and 'Hero' card tokens in an `exampleCard.ts` token collection file, and the 'Radius' component folder will contain the corner radius styling tokens in an `exampleRadius.ts` token collection file.
+The `Card` component folder will contain the `Default` and `Hero` card tokens in an `exampleCard.ts`
+token collection file, and the `Radius` component folder will contain the corner radius styling
+tokens in an `exampleRadius.ts` token collection file.
 
-Please reference the [Vital Component Template Documentation](../../Guides/ComponentTemplate) to ensure that you are following the proper naming conventions and file structure when creating a new component folder.
+Please reference the [Vital Component Template documentation](../../Guides/ComponentTemplate) to
+ensure that you are following the proper naming conventions and file structure when creating a new
+component folder.
 
-### Creating Our Reusable 'Radius' tokens
+### Creating Our Reusable 'Radius' Tokens
 
-In our `exampleRadius.ts` token collection file we will create two tokens that will be used to apply two different types of border radius styles to our card components.
+In our `exampleRadius.ts` token collection file, we will create two tokens that will be used to
+apply two different types of `border-radius` styles to our card components.
 
-```js
+[exampleRadius.ts](https://raw.githubusercontent.com/johnsonandjohnson/Bodiless-JS/main/packages/vital-examples/src/reusable-tokens/components/Radius/tokens/exampleRadius.ts
+':include :type=code :fragment=radius-tokens')
 
-const Simple = asElementToken({
-  Theme: {
-    _: 'rounded-br-[40px]',
-  },
-});
+Although we are applying these tokens to card elements in this lesson, they've been written in a way
+that will allow us to apply them to essentially any component/slot that we want.
 
-const Fancy = asElementToken({
-  Theme: {
-    _: 'card-corner md:card-corner-md lg:card-corner-lg',
-  },
-});
+As we will be shadowing both the `Default` and `Hero` Vital card variants, let's create two separate
+card tokens inside of our `exampleCard.ts` token collection file and apply our previously-created
+radius tokens there:
 
-```
+[exampleCard.ts](https://github.com/johnsonandjohnson/Bodiless-JS/blob/main/packages/vital-examples/src/reusable-tokens/components/Card/tokens/exampleCard.ts
+':include :type=code :fragment=card-tokens')
 
-Although we are applying these tokens to card elements in this lesson, they've been written in a way that will allow us to apply them to essentially any component/slot that we want.
+It would also be entirely acceptable to apply the `'rounded-br-[40px]'` class from our `Simple`
+element token directly to the `Theme` domain of our `Default` card token as follows:
 
-As we will be shadowing both the 'Default' and 'Hero' Vital card variants, let's create two separate card tokens inside of our `exampleCard.ts` token collection file and apply our previously-created radius tokens there:
-
-```js
-
-const Default = asCardToken(vitalCardBase.Basic, {
-  Theme: {
-    ContentWrapper: exampleRadius.Simple,
-  },
-});
-
-const Hero = asCardToken({
-  ...vitalCardBase.Hero,
-  Theme: {
-    ...vitalCardBase.Hero.Theme,
-/* Note the use of 'as' here. This is a composition utility provided 
-* by BodilessJS that converts a list of tokens into an HOC. When applying
-* multiple tokens to a component, 'as' must be used to properly combine them.
-*
-* In the 'Default' token example above, you'll notice that because only one * token is being applied to the 'ContentWrapper' slot, 'as' is not needed.
-*/
-    Image: as(vitalCardBase.Hero.Theme.Image, exampleRadius.Fancy),
-  },
-});
-
-```
-
-It would also be entirely acceptable to apply the `"rounded-br-[40px]` class from our `Simple` element token directly to the `Theme` domain of our 'Default' card token as follows:
-
-```js
-
+```ts
 const Default = asCardToken(vitalCardBase.Default, {
   Theme: {
     ContentWrapper: 'rounded-br-[40px]',
   },
 });
-
 ```
 
-But what happens if the brand requires that this bit of styling be applied to a number of other elements across the site? In this case, let's also apply this same utility class to the 'Hero' card's `ContentWrapper` slot.
+But what happens if the brand requires that this bit of styling be applied to a number of other
+elements across the site? In this case, let's also apply this same utility class to the `Hero`
+card's `ContentWrapper` slot.
 
-In order to achieve this we can apply that class directly to the 'Hero' token as follows:
+In order to achieve this, we can apply that class directly to the `Hero` token as follows:
 
-```js
-
+```ts
 const Hero = asCardToken({
   ...vitalCardBase.Hero,
   Spacing: {
@@ -125,19 +140,25 @@ const Hero = asCardToken({
     Image: as(vitalCardBase.Hero.Theme.Image, exampleRadius.Fancy),
   },
 });
-
 ```
 
-Though this will achieve the desired result, consider a future scenario where the brand guidelines have changed, and this border radius value is decreased to '20px.'
+Though this will achieve the desired result, consider a future scenario where the brand guidelines
+have changed, and this `border-radius` value is decreased to `20px`.
 
-Because we've duplicated this code in two places, we'll now need to change the value of both instances of this utility class from '40px' to '20px'.
+Because we've duplicated this code in two places, we'll now need to change the value of both
+instances of this utility class from `40px` to `20px`.
 
-Now imagine that we've applied this border radius to a number of components on our site. You can probably begin to see how tedious it might be track down all instances and make this change.
+Now imagine that we've applied this `border-radius` to a number of components on our site. You can
+probably begin to see how tedious it might be to track down all instances and make this change.
 
-By instead encapsulating this styling in its own `Simple` element token as we've done at the beginning of this section, and placing _that_ token on the various components in which we'd like to use it (or even the 'Base' card token from which all other 'Card' components are built if it's decided that all card elements should have this styling) we ensure that if brand guidelines ever shift to alter the value of that border radius, we only need to make a change in one place.
+By, instead, encapsulating this styling in its own `Simple` element token, as we've done at the
+beginning of this section, and placing _that_ token on the various components in which we'd like to
+use it (or even the `Base` card token from which all other `Card` components are built, if it's
+decided that all card elements should have this styling), we ensure that if brand guidelines ever
+shift to alter the value of that `border-radius`, we only need to make a change in one place.
 
 ## Resources
 
-* [Adding components in Tailwind](https://tailwindcss.com/docs/plugins#adding-components)
-
-* [Vital Component Template](../../Guides/ComponentTemplate)
+- [Adding components | Tailwind CSS](https://tailwindcss.com/docs/plugins#adding-components
+  ':target=_blank')
+- [Vital Component Template](../../Guides/ComponentTemplate)

--- a/packages/vital-examples/doc/Curriculum/Lessons/ShadowASimpleComponent.md
+++ b/packages/vital-examples/doc/Curriculum/Lessons/ShadowASimpleComponent.md
@@ -1,115 +1,97 @@
-# Shadowing a Simple component: Button
+# Shadow a Simple Component: Button
 
-In this lesson we will learn how to shadow simple components, these are the base elements for customizing a website, in it we will define colors, fonts, typography and the like.
+In this lesson we will learn how to shadow simple components, base elements for customizing a
+website; in it, we will define colors, fonts, typography, and the like.
 
 ## Overview
 
-In this lesson we will learn how to shadow a button component to apply custom styles and modifications to it.
-In our case, we will override the `vitalButtonsBase.Primary` to add a hover transition, and we will crate a new variation, a larger button, which can be combined with all other existings variations.
-To accomplish this, we will use the best practices for shadowing components.
-
+Specifically, we will learn how to shadow a button component to apply custom styles and
+modifications to it. In our case, we will override `vitalButtonsBase.Primary` to add a hover
+transition, and we will create a new variation: a larger button, which can be combined with all
+other existing variations. To accomplish this, we will use the best practices for shadowing
+components.
 
 ## Assignment
 
-### Creating our tokens
+### Creating Our Tokens
 
-Let's start by creating a new `exampleButtons.ts` file, which will contain all of our tokens, both the one we're going to overwrite and our new variation. The file should be under the follow structure.
+Let's start by creating a new `exampleButtons.ts` file, which will contain all of our tokens, both
+the one we're going to overwrite and our new variation. The file should be under the following
+structure:
 
-```bash
+```text
 ├── src
 │   ├── components
 │   │   ├── Buttons
-│   │   |   ├─ tokens
-│   │   |      └─ exampleButtons.ts
+│   │   │   ├─ tokens
+│   │   │   │  └─ exampleButtons.ts
 ```
 
-Since we are shadowing vital elements, we should import the base version of the component.
+Since we are shadowing Vital elements, we should import the base version of the component:
 
 ```ts
-...
 import { vitalButtonsBase } from '@bodiless/vital-buttons/src/base';
-...
-```
-And once we have the base all the base variations from the vital package, we can spread `vitalButtonsBase.Primary` to preserve the domains that we don't want to change.
-As we're going to add a transition to our button, we're going to use the Theme domain once again, spreading this domain from `vitalButtonsBase.Primary` to preserve the button's settings and prevent unintentional modifications.
-
-```ts
-...
-const WithPrimary = asButtonToken({
-  ...vitalButtonsBase.Primary,
-  Theme: {
-    /**
-     * Spreading Theme here prevents unwanted changes, keeping all tokens other than the wrappers.
-     */
-    ...vitalButtonsBase.Primary.Theme,
-    Wrapper: as(
-      vitalColor.BgPrimaryBrand,
-      vitalColor.TextWhite,
-      vitalTextDecoration.Bold,
-      vitalTextDecoration.Uppercase,
-      vitalFontSize.Base,
-      'rounded hover:bg-vital-primary-interactive transition-colors duration-400',
-    ),
-  },
-});
-...
-```
-Here we rely on the `asButtonToken` function to help us with the tokens convention. This function extends from [asVitalTokenSpec](https://github.com/johnsonandjohnson/Bodiless-JS/blob/main/packages/vital-elements/src/util/tokenSpec.ts#L48) to create the token definition utility for te [ButtonClean](https://github.com/johnsonandjohnson/Bodiless-JS/blob/main/packages/vital-buttons/src/components/Buttons/ButtonClean.tsx) component.
-
-**PS:** As you can notice, we use a mix of `vital-elements` tokens and tailwind classes to compose our token.
-
-Now, let's create a new button variation, a bigger button, with extra padding, for this, we should follow the naming convetion, variations tokens should be prefixed by `With`, so our new variation will look like this.
-
-```ts
-/**
- * Here we follow the same logic, but this time, we'll create a new variation of button, a big
- * button with extra padding.
- */
-const WithBigButton = asButtonToken({
-  ...vitalButtonsBase.Default,
-  Spacing: {
-    ...vitalButtonsBase.Default.Spacing,
-    Wrapper: 'px-12 py-6',
-  },
-});
-```
-After we're done with the tokens, we should export these tokens alongside the ones from vital buttons.
-
-```ts
-// Exporting the vitalButtonsBase with our custom Primary with hover, and our new big variation.
-export default {
-  ...vitalButtonsBase,
-  WithPrimary,
-  WithBigButton,
-};
 ```
 
+And once we have all the base variations from the Vital package, we can spread
+`vitalButtonsBase.Primary` to preserve the domains that we don't want to change. As we're going to
+add a transition to our button, we're going to use the `Theme` domain, and, once again, spread this
+domain from `vitalButtonsBase.Primary` to preserve the button's settings and prevent unintentional
+modifications.
+
+[exampleButtons.ts](https://raw.githubusercontent.com/johnsonandjohnson/Bodiless-JS/main/packages/vital-examples/src/shadowing-simple-component/components/Buttons/tokens/exampleButtons.ts
+':include :type=code :fragment=WithPrimary')
+
+Here we rely on the `asButtonToken` function to help us with the tokens convention. This function
+extends from
+[`asVitalTokenSpec`](https://github.com/johnsonandjohnson/Bodiless-JS/blob/main/packages/vital-elements/src/util/tokenSpec.ts#L48
+':target=_blank') to create the token definition utility for the
+[`ButtonClean`](https://github.com/johnsonandjohnson/Bodiless-JS/blob/main/packages/vital-buttons/src/components/Buttons/ButtonClean.tsx
+':target=_blank') component.
+
+?> **Note:** As you may have noticed, we use a mix of `vital-elements` tokens and Tailwind classes
+to compose our token.
+
+Now let's create a new button variation: a bigger button with extra padding. For this, we should
+follow the naming convention of variation tokens being prefixed by `With`; so, our new variation
+will look like this:
+
+[exampleButtons.ts](https://raw.githubusercontent.com/johnsonandjohnson/Bodiless-JS/main/packages/vital-examples/src/shadowing-simple-component/components/Buttons/tokens/exampleButtons.ts
+':include :type=code :fragment=WithBigButton')
+
+After we're done with the tokens, we should export these tokens alongside the ones from Vital
+buttons:
+
+[exampleButtons.ts](https://raw.githubusercontent.com/johnsonandjohnson/Bodiless-JS/main/packages/vital-examples/src/shadowing-simple-component/components/Buttons/tokens/exampleButtons.ts
+':include :type=code :fragment=export-default')
 
 ### Shadowing
 
-And now, to shadow the our tokens, create a `Buttons.ts` file with the same path of the package, in our case, since we are shadowing the `@bodiles/vital-buttons` package, we'll have this structure.
+And now, to shadow our tokens, create a `Buttons.ts` file with the same path of the package. In our
+case, since we are shadowing the `@bodiles/vital-buttons` package, we'll have this structure:
 
-```bash
+```text
 ├── shadow
 │   ├── @bodiless
 │   │   ├── vital-buttons
-│   │   |   └─ Buttons.ts
+│   │   │   └─ Buttons.ts
 ```
 
-<!-- Waiting for the actual function to be available; -->
-Each file must only export the tokens from the components folder with the our helper `shadow` function. You can see more about this function [here](TBD).
+Each file must only export the tokens from the components folder with our helper `shadow` function.
+
+<!-- @TODO: Waiting for the actual function and docs to be available.
+You can see more about this function [here](TBD). -->
 
 Our whole file will only have 3 lines.
 
-```ts
-import { shadow } from '@bodiless/vital-elements';
-import { exampleButtons } from '../../../components/Buttons';
+[Buttons.ts](https://raw.githubusercontent.com/johnsonandjohnson/Bodiless-JS/main/packages/vital-examples/src/shadowing-simple-component/shadow/%40bodiless/vital-buttons/Buttons.ts
+':include :type=code')
 
-export default shadow(exampleButtons, 'Example:Buttons');
-```
-
-That's all, with this done, ou primary button will have a nice looking transition, and we will also have a new variation, a bigger button with extra padding, which can go with all other existing tokens.
+That's all. With this done, our primary button will have a nice looking transition; we will also
+have a new variation — a bigger button with extra padding — which can go with all other existing
+tokens.
 
 ## Practice
 
-Now you can try to create you own shadow files, try to customize some vital text decorations tokens, or even create a new typography token.
+Now you can try to create you own shadow files. Try to customize some Vital text decorations tokens,
+or even create a new typography token.

--- a/packages/vital-examples/doc/Curriculum/Lessons/ShadowASimpleComponent.md
+++ b/packages/vital-examples/doc/Curriculum/Lessons/ShadowASimpleComponent.md
@@ -11,6 +11,11 @@ transition, and we will create a new variation: a larger button, which can be co
 other existing variations. To accomplish this, we will use the best practices for shadowing
 components.
 
+?> **Note:** For the code files used in this lesson, please see the
+`packages/vital-examples/src/shadowing-simple-component` directory in your local repository or on
+[GitHub](https://github.com/johnsonandjohnson/Bodiless-JS/tree/main/packages/vital-examples/src/shadowing-simple-component
+':target=_blank').
+
 ## Assignment
 
 ### Creating Our Tokens

--- a/packages/vital-examples/doc/Curriculum/Lessons/ShadowASimpleComponent.md
+++ b/packages/vital-examples/doc/Curriculum/Lessons/ShadowASimpleComponent.md
@@ -11,10 +11,32 @@ transition, and we will create a new variation: a larger button, which can be co
 other existing variations. To accomplish this, we will use the best practices for shadowing
 components.
 
-?> **Note:** For the code files used in this lesson, please see the
-`packages/vital-examples/src/shadowing-simple-component` directory in your local repository or on
-[GitHub](https://github.com/johnsonandjohnson/Bodiless-JS/tree/main/packages/vital-examples/src/shadowing-simple-component
-':target=_blank').
+<!-- Inlining HTML to add multi-line info block with unordered list and codeblock. -->
+<div class="warn">
+  <strong>Note:</strong> For the code files used in this lesson, please see the following (either
+  locally or on GitHub):
+
+  - `packages/vital-examples/src/shadowing-simple-component`
+    ([GitHub](https://github.com/johnsonandjohnson/Bodiless-JS/tree/main/packages/vital-examples/src/shadowing-simple-component
+    ':target=_blank'))
+  - `packages/vital-examples/src/styleguide/Page/StyleGuideTemplate/Button.tsx`
+    ([GitHub](https://github.com/johnsonandjohnson/Bodiless-JS/blob/main/packages/vital-examples/src/styleguide/Page/StyleGuideTemplate/Button.tsx
+    ':target=_blank'))
+    - This is the
+      [template](https://github.com/johnsonandjohnson/Bodiless-JS/blob/main/sites/vital-examples/src/data/pages/shadow-simple-component/template.json
+      ':target=_blank') code for the page referenced below.
+
+  To see the "Buttons" page in action, build and run the Vital Examples site—
+
+  ```shell
+  cd sites/vital-examples
+  npm run build
+  npm run start
+  ```
+
+  —and go to <http://localhost:8000/shadow-simple-component/>.
+
+</div>
 
 ## Assignment
 

--- a/packages/vital-examples/src/background-images/components/Footer/tokens/exampleFooter.ts
+++ b/packages/vital-examples/src/background-images/components/Footer/tokens/exampleFooter.ts
@@ -6,14 +6,19 @@ import {
 import { vitalFooterBase } from '@bodiless/vital-layout/lib/base';
 import LogoIcon from '../../../assets/images/logo';
 
-// NOTE: In truth, all of the styling found within this withTopFooterWave token
-// could be applied directly to the exampleFooter token below, but is separated
-// here for readability and modularity's sake.
+/**
+ * NOTE: In truth, all of the styling found within this `withTopWave` token
+ * could be applied directly to the `Default` token below, but is separated
+ * here for readability and modularity's sake.
+ */
 
 const WithTopWave = asFooterToken({
   Theme: {
-    // NOTE: Here in 'Theme' domain of our footer token, we apply our footer-wave
-    // class to the container (Wrapper) at desktop screen sizes using Tailwind's '2xl' prefix.
+    /**
+     * NOTE: Here, in the `Theme` domain of our footer token, we apply our
+     * 'footer-wave' class to the container (`Wrapper`) at desktop screen
+     * sizes using Tailwind's '2xl' prefix.
+     */
     Wrapper: '2xl:footer-wave',
     Column2Wrapper: '2xl:before:content-none before:content-[\'\'] before:bg-mobile-wave-top relative',
   },
@@ -25,22 +30,29 @@ const WithTopWave = asFooterToken({
     Column2Wrapper: 'before:absolute before:w-screen before:h-9'
   },
 });
-// Here, we'll merge two tokens by passing 2 arguments to `asFooterToken`
+// Here, we'll merge two tokens by passing two arguments to `asFooterToken`.
 const Default = asFooterToken({
-// In the first argument, we'll spread the values of the original token, overriding
-// only the `Rewards` and `RewardsWrapper` slots in the `Components` domain.
+  /**
+   * In the first argument, we'll spread the values of the original token,
+   * overriding only the `Rewards` and `RewardsWrapper` slots in the
+   * `Components` domain.
+   */
   ...vitalFooterBase.Default,
   Components: {
     ...vitalFooterBase.Default.Components,
     RewardsWrapper: startWith(Div),
     Rewards:
-      // NOTE: Here we replace our footer's current 'Rewards' slot with
-      // our custom logo using the `startWith` HOC.
+      /**
+       * NOTE: Here we replace our footer's current `Rewards` slot with our
+       * custom logo using the `startWith` HOC.
+       */
       startWith(LogoIcon)
   },
 }, {
-  // In the second, we'll *add* styling to the `Spacing` domain,
-  // and add our 'WithFooterWave' token to the 'Compose' domain.
+  /**
+   * In the second, we'll _add_ styling to the `Spacing` domain, and add our
+   * `WithTopWave` token to the `Compose` domain.
+   */
   Spacing: {
     Wrapper: 'py-40',
     RewardsWrapper: '2xl:px-40 py-10',

--- a/packages/vital-examples/src/customizing-design-tokens/components/TextDecoration/tokens/exampleTextDecoration.ts
+++ b/packages/vital-examples/src/customizing-design-tokens/components/TextDecoration/tokens/exampleTextDecoration.ts
@@ -1,7 +1,10 @@
 import { asTokenGroup, TextDecorationMeta } from '@bodiless/vital-elements';
 import { vitalTextDecorationBase } from '@bodiless/vital-elements/src/base';
 
-// Here we use `asTokenGroup` to share the TextDecorationMeta among all tokens exported.
+/**
+ * Here we use `asTokenGroup` to share the `TextDecorationMeta` among all
+ * tokens exported.
+ */
 export default asTokenGroup(TextDecorationMeta)({
   ...vitalTextDecorationBase,
   Bold: 'font-black',

--- a/packages/vital-examples/src/customizing-design-tokens/components/Typography/tokens/exampleTypography.ts
+++ b/packages/vital-examples/src/customizing-design-tokens/components/Typography/tokens/exampleTypography.ts
@@ -21,8 +21,9 @@ const H2 = asElementToken({
 });
 
 /**
- * Here we export the a object that spread vitalTypographyBase and place our tokens at the bottom
- * of the object so they will override the tokens from the vital typography.
+ * Here we export the object that spread `vitalTypographyBase`, and place our
+ * tokens at the bottom of the object so they will override the tokens from
+ * the Vital typography.
  */
 export default {
   ...vitalTypographyBase,

--- a/packages/vital-examples/src/intro/section-example/components/ElementsList/tokens/exampleElementsList.ts
+++ b/packages/vital-examples/src/intro/section-example/components/ElementsList/tokens/exampleElementsList.ts
@@ -4,7 +4,7 @@ import { CardClean, vitalCard } from '@bodiless/vital-card';
 import { asElementListToken } from '../ElementsListClean';
 
 /**
- * The Default ElementList token with some basic layout styles.
+ * The `Default` `ElementList` token with some basic layout styles.
  */
 const Default = asElementListToken({
   Layout: {
@@ -17,14 +17,14 @@ const Default = asElementListToken({
 });
 
 /**
- * The ElementList token that extends the Default and sets `CardClean` as an Element
- * to be repeated in the list.
+ * The `ElementList` token that extends the `Default` and sets `CardClean` as an `Element` to be
+ * repeated in the list.
  */
 const Card = asElementListToken(Default, {
   Core: {
     /**
      * An example of how you can add a custom prop to the component.
-     * `times` prop for the ElementList component specifies how many time the provided `Element`
+     * `times` prop for the `ElementList` component specifies how many time the provided `Element`
      * has to be repeated in the markup.
      */
     _: addProps({ times: 5 }),

--- a/packages/vital-examples/src/intro/section-example/components/Section/tokens/exampleSection.ts
+++ b/packages/vital-examples/src/intro/section-example/components/Section/tokens/exampleSection.ts
@@ -14,40 +14,41 @@ import { asSectionToken } from '@bodiless/vital-section';
 import { ElementsListClean, elementsList } from '../../ElementsList';
 
 /**
- * Hook to provide the default content for the `EditorPlainClean` Title element.
- * It returns the object where key is the nodeKey expected, and the value is the data expected
+ * Hook to provide the default content for the `EditorPlainClean` `Title` element.
+ * It returns the object where the key is the `nodeKey` expected, and the value is the data expected
  * by the underlying component.
  *
- * Note that the nodeKey in this case is empty '' since `withDefaultContext` is used in
- * the same schema node context that is coming from `vitalSectionBase.WithTitle`. See how
- * in `vitalSectionBase.WithTitle` token we set a component for Title slot along with
- * the Schema data for it.
+ * Note that the `nodeKey` in this case is empty (`''`) since `withDefaultContext` is used in the
+ * same schema node context that is coming from `vitalSectionBase.WithTitle`. See how, in the
+ * `vitalSectionBase.WithTitle` token, we set a component for the `Title` slot along with the
+ * `Schema` data for it.
  */
 export const useTitleContent = () => ({
   '': { text: 'Hello Section Title!' },
 });
 
 /**
- * Hook to provide the default content for the `EditorPlainClean` Description element.
- * It returns the object where key is the nodeKey expected, and the value is the data expected
+ * Hook to provide the default content for the `EditorPlainClean` `Description` element.
+ * It returns the object where the key is the `nodeKey` expected, and the value is the data expected
  * by the underlying component.
  *
- * Note that the nodeKey in this case is empty '' since `withDefaultContext` is used in
- * the same schema node context that is coming from `vitalSectionBase.WithDescription`. See how
- * in `vitalSectionBase.WithDescription` token we set a component for Description slot along with
- * the Schema data for it.
+ * Note that the `nodeKey` in this case is empty (`''`) since `withDefaultContext` is used in the
+ * same schema node context that is coming from `vitalSectionBase.WithDescription`. See how, in the
+ * `vitalSectionBase.WithDescription` token, we set a component for `Description` slot along with
+ * the `Schema` data for it.
  */
 export const useDescriptionContent = () => ({
   '': { text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.'}
 });
 
 /**
- * Default example token for the Section component which adds Section Content.
- * Note how we Omit 'Content' and 'Components' domains from the original `vitalSectionBase.Default`.
+ * `Default` example token for the Section component which adds Section `Content`.
+ * Note how we `omit` 'Content' and 'Components' domains from the original
+ * `vitalSectionBase.Default` token.
  *
- * This is done to illustrate another way to change the original vital token.
- * Here we want to make sure we don't inherit Title and Description from `vitalSectionBase.Default`.
- * We will add `WithTitle` and `WithDescription` as standalone tokens.
+ * This is done to illustrate another way to change the original Vital token.
+ * Here we want to make sure we don't inherit the `Title` and `Description` from
+ * `vitalSectionBase.Default`. We will add `WithTitle` and `WithDescription` as standalone tokens.
  */
 const Default = asSectionToken(omit(vitalSectionBase.Default, 'Content', 'Components'), {
   Spacing: {
@@ -56,163 +57,164 @@ const Default = asSectionToken(omit(vitalSectionBase.Default, 'Content', 'Compon
 });
 
 /**
- * Token that extends the vital WithLink token and adds the Link text.
- * Note that `vitalSectionBase.WithLink` is a token that meant to be layered
- * on top of other tokens using the `Compose` domain.
+ * Token that extends the Vital `WithLink` token and adds the `Link` text.
+ * Note that `vitalSectionBase.WithLink` is a token that is meant to be layered on top of other
+ * tokens using the `Compose` domain.
  *
- * Note that the name of this token *starts with* `With...`. That means that the token is meant
- * to be layered on top of other tokens and not used by itself. The big difference here is that
- * this token *does not extend* the Default token. It is very limited in what this token can do.
+ * Note that the name of this token _starts with_ `With...`. That means that the token is meant to
+ * be layered on top of other tokens and not used by itself. The big difference here is that this
+ * token _does not extend_ the `Default` token. It is very limited in what this token can do.
  *
- * Think of it as an Adjective, something that reflects behaviour or additional functionality.
+ * Think of it as an _adjective_, something that reflects behavior or additional functionality.
  *
- * This is the preffered Token pattern since it encourages composition
- * and results in a better overall code structure as well as simplifying testing.
+ * This is the preferred token pattern, since it encourages composition and results in a better
+ * overall code structure, as well as simplifies testing.
  *
- * The best way to use this token as part of another token to add a link is to place
- * `WithLink` into the special `Compose` key of the token.
+ * The best way to use this token as part of another token to add a link is to place `WithLink` into
+ * the special `Compose` key of the token.
  */
 const WithLink = asSectionToken({
   /**
-   * The `vitalSectionBase.WithLink` token is also starts with `With...` that indicates that it is
-   * limited in functionality and meant to enhance the main Token.
+   * The `vitalSectionBase.WithLink` token also starts with `With...`, which indicates that it is
+   * limited in functionality and meant to enhance the main token.
    * We take `vitalSectionBase.WithLink` and just add default text to the link.
    */
   ...vitalSectionBase.WithLink,
   Content: {
     /**
-     * Another quick way way to add content such as link text is to add
-     * children directly to the element like so:
+     * Another quick way way to add content, such as link text, is to add children directly to the
+     * element, like so:
      */
     Link: addProps({ children: 'Section Link' }),
   }
 });
 
 /**
- * Token that extends the Default and adds the Link to the Section.
- * Note that `vitalSectionBase.WithLink` is a token that meant to be layered
- * on top of other tokens.
+ * Token that extends the `Default` token and adds the `Link` to the Section.
+ * Note that `vitalSectionBase.WithLink` is a token that is meant to be layered on top of other
+ * tokens.
  *
- * This token *does not* have `With...` in it's name and it indicates that this token is meant
- * to be used as a standalone token which can be used *instead* of the `Default` token.
+ * This token _does not_ have `With...` in its name, which indicates that this token is meant to be
+ * used as a standalone token that can be used _instead_ of the `Default` token.
  *
- * Think of it as a Noun, the token is sufficent by itself to render the component,
- * and not just adding a small piece of functionality.
+ * Think of it as a _noun_, the token is sufficient by itself to render the component, and not just
+ * adding a small piece of functionality.
  *
- * This is *not* the preffered Token pattern to use. Try to avoid it and instead compose
- * `WithLink` into the Default domain.
+ * This is _not_ the preferred token pattern to use. Try to avoid it and instead compose `WithLink`
+ * into the `Default` domain.
  */
 const Linked = asSectionToken(Default, {
   /**
-   * Sometimes, you want to provide a fully composed token with several Variators which can be used
-   * as-is, while allowing one or more of the Variators to be easily removed. For this purpose,
-   * Vital provides the special Compose domain. Unlike those in other domains, the keys inside the
-   * Compose domain do not refer to slots; rather they refer to named variators.
+   * Sometimes you want to provide a fully composed token with several variators that can be used
+   * as-is, while allowing one or more of the variators to be easily removed. For this purpose,
+   * Vital provides the special `Compose` domain. Unlike those in other domains, the keys inside the
+   * `Compose` domain do not refer to slots; rather they refer to named variators.
    *
-   * @TODO: Update Link once these docs are released.
-   * See more here: https://github.com/johnsonandjohnson/Bodiless-JS/blob/9d872a75c7ff2a00af0bc53ae9c3b2f3545ddf24/packages/vital-elements/doc/ExtendingAndComposing.md#the-compose-domain
+   * See more here: https://johnsonandjohnson.github.io/Bodiless-JS/#/VitalDesignSystem/Guides/ExtendingAndComposingTokens?id=the-compose-domain
    */
   Compose: { WithLink },
 });
 
 /**
- * A token that adds a Section Description.
- * Description editor setings are inherited from `...vitalSectionBase.WithDescription` Token.
+ * A token that adds a Section `Description`.
+ * `Description` editor settings are inherited from the `...vitalSectionBase.WithDescription` token.
  *
- * Note that the name of this token *starts with* `With...`. That means that the token is meant
- * to be layered on top of other tokens and not used by itself. The big difference here is that
- * this token *does not extend* the Default token. It is very limited in what this token can do.
+ * Note that the name of this token _starts with_ `With...`. That means that the token is meant to
+ * be layered on top of other tokens and not used by itself. The big difference here is that this
+ * token _does not extend_ the `Default` token. It is very limited in what this token can do.
  *
- * Think of it as an Adjective, something that reflects behaviour or additional functionality.
+ * Think of it as an _adjective_, something that reflects behavior or additional functionality.
  *
- * This is the preffered Token pattern since it encourages composition
- * and results in a better overall code structure as well as simplifying testing.
+ * This is the preferred token pattern, since it encourages composition and results in a better
+ * overall code structure, as well as simplifies testing.
  *
- * The best way to use this token as part of another token is
- * to add it to the special `Compose` key of the token.
+ * The best way to use this token as part of another token is to add it to the special `Compose` key
+ * of the token.
  */
 const WithDescription = asSectionToken({
   /**
-   * The `vitalSectionBase.WithDescription` token is also meant to enhance the main Token.
-   * It provides the Editor for the Section Description and sets `DescriptionWrapper` to `<P>`.
+   * The `vitalSectionBase.WithDescription` token is also meant to enhance the main token.
+   * It provides the Editor for the Section `Description` and sets `DescriptionWrapper` to `<P>`.
    */
   ...vitalSectionBase.WithDescription,
   Content: {
     /**
-     * We use `withDefaultContent` and the `useDescriptionContent` hook to add the default text
-     * to the Section Description under the `Content` Domain.
+     * We use `withDefaultContent` and the `useDescriptionContent` hook to add the default text to
+     * the Section `Description` under the `Content` domain.
      *
-     * Note that for the `withDefaultContent` to work we need to provide the Schema for the slot.
-     * In this case the Schema for the Description is coming from `vitalSectionBase.WithDescription`
+     * Note that, for `withDefaultContent` to work, we need to provide the `Schema` for the slot. In
+     * this case, the `Schema` for the `Description` is coming from
+     * `vitalSectionBase.WithDescription`.
      *
-     * When `Schema` and `DefaultContent` for the slot Components are in the same node context,
-     * there will be no need to specify the `nodeKey` for the DefaultContent object. See how
-     * in `vitalSectionBase.WithDescription` token we set a component for Description slot, and
-     * the Schema data for it and then use it to compose this token all with the same node context.
+     * When `Schema` and `DefaultContent` for the slot components are in the same node context,
+     * there will be no need to specify the `nodeKey` for the `DefaultContent` object. See how, in
+     * the `vitalSectionBase.WithDescription` token, we set a component for the `Description` slot,
+     * and the `Schema` data for it, and then use it to compose this token all with the same node
+     * context.
      */
     Description: withDefaultContent(useDescriptionContent),
   },
 });
 
 /**
- * A token that adds a Section Title.
- * Title editor setings are inherited from `...vitalSectionBase.WithTitle` Token.
+ * A token that adds a Section `Title`.
+ * `Title` editor settings are inherited from the `...vitalSectionBase.WithTitle` token.
  *
- * Note that the name of this token *starts with* `With...`. That means that the token is meant
- * to be layered on top of other tokens and not used by itself. The big difference here is that
- * this token *does not extend* the Default token. It is very limited in what this token can do.
+ * Note that the name of this token _starts with_ `With...`. That means that the token is meant to
+ * be layered on top of other tokens and not used by itself. The big difference here is that this
+ * token _does not extend_ the `Default` token. It is very limited in what this token can do.
  *
- * Think of it as an Adjective, something that reflects behaviour or additional functionality.
+ * Think of it as an _adjective_, something that reflects behavior or additional functionality.
  *
- * This is the preffered Token pattern since it encourages composition
- * and results in a better overall code structure as well as simplifying testing.
+ * This is the preferred token pattern, since it encourages composition and results in a better
+ * overall code structure, as well as simplifies testing.
  *
- * The best way to use this token as part of another token is
- * to add it to the special `Compose` key of the token.
+ * The best way to use this token as part of another token is to add it to the special `Compose` key
+ * of the token.
  */
 const WithTitle = asSectionToken({
   /**
-   * The `vitalSectionBase.WithLink` token is also meant to enhance the main Token.
-   * It provides the Editor for the Section Title and makes `TitleWrapper` h2.
+   * The `vitalSectionBase.WithTitle` token is also meant to enhance the main token.
+   * It provides the Editor for the Section `Title` and makes `TitleWrapper` an `H2`.
    */
   ...vitalSectionBase.WithTitle,
   Content: {
     /**
-     * We use `withDefaultContent` and the `useTitleContent` hook to add the default text
-     * to the Section Title under the `Content` Domain.
+     * We use `withDefaultContent` and the `useTitleContent` hook to add the default text to the
+     * Section `Title` under the `Content` domain.
      *
-     * Note that for the `withDefaultContent` to work we need to provide the Schema for the slot.
-     * In this case the Schema for the Title is coming from `vitalSectionBase.WithTitle`
+     * Note that, for `withDefaultContent` to work, we need to provide the `Schema` for the slot. In
+     * this case, the `Schema` for the `Title` is coming from `vitalSectionBase.WithTitle`.
      *
-     * When `Schema` and `DefaultContent` for the slot Components are in the same node context,
-     * there will be no need to specify the `nodeKey` for the DefaultContent object. See how
-     * in `vitalSectionBase.WithTitle` token we set a component for Title slot, and
-     * the Schema data for it and then use it to compose this token all with the same node context.
+     * When `Schema` and `DefaultContent` for the slot components are in the same node context,
+     * there will be no need to specify the `nodeKey` for the `DefaultContent` object. See how, in
+     * the `vitalSectionBase.WithTitle` token, we set a component for the `Title` slot, and the
+     * `Schema` data for it, and then use it to compose this token all with the same node context.
      */
     Title: withDefaultContent(useTitleContent),
   }
 });
 
 /**
- * A token that adds a list of cards as Content of the Section Component.
+ * A token that adds a list of cards as `Content` of the Section component.
  *
- * Note that the name of this token *starts with* `With...`. That means that the token is meant
- * to be layered on top of other tokens and not used by itself. The big difference here is that
- * this token *does not extend* the Default token. It is very limited in what this token can do.
+ * Note that the name of this token _starts with_ `With...`. That means that the token is meant to
+ * be layered on top of other tokens and not used by itself. The big difference here is that this
+ * token _does not extend_ the `Default` token. It is very limited in what this token can do.
  *
- * Think of it as an Adjective, something that reflects behaviour or additional functionality.
+ * Think of it as an _adjective_, something that reflects behavior or additional functionality.
  *
- * This is the preffered Token pattern since it encourages composition
- * and results in a better overall code structure as well as simplifying testing.
+ * This is the preferred token pattern, since it encourages composition and results in a better
+ * overall code structure, as well as simplifies testing.
  *
- * The best way to use this token as part of another token is
- * to add it to the special `Compose` key of the token.
+ * The best way to use this token as part of another token is to add it to the special `Compose` key
+ * of the token.
  */
 const WithCards = asSectionToken({
   /**
-   * Here we will replace the default Section Content with the `ElementsListClean`
-   * which just repeats it's `Element` n times. You can specify the number of
-   * repeats by providing `times` prop.
+   * Here we will replace the default Section `Content` with the `ElementsListClean` component,
+   * which just repeats its `Element` _n_ times. You can specify the number of repeats by providing
+   * the `times` prop.
    */
   Components: {
     Content: on(ElementsListClean)(elementsList.Card),
@@ -220,7 +222,7 @@ const WithCards = asSectionToken({
 });
 
 /**
- * Export a default `exampleSection` token collection for the Example Section Component.
+ * Export a default `exampleSection` token collection for the Example Section component.
  */
 export default {
   Default,

--- a/packages/vital-examples/src/reusable-tokens/components/Card/tokens/exampleCard.ts
+++ b/packages/vital-examples/src/reusable-tokens/components/Card/tokens/exampleCard.ts
@@ -3,7 +3,6 @@ import { asCardToken } from '@bodiless/vital-card';
 import { vitalCardBase } from '@bodiless/vital-card/lib/base';
 import { exampleRadius } from '../../Radius';
 
-/// [card-tokens]
 /*
  * Here we extend the `Default` card token using the merge pattern by
  * supplying multiple arguments to `asCardToken`. Our radius token will be
@@ -24,6 +23,7 @@ const Default = asCardToken(vitalCardBase.Default, {
   },
 });
 
+/// [hero-card-token]
 /*
  * Here we extend the Vital `Hero` card token using the override pattern.
  * In this case, we use the spread operator to pull in all tokens applied to
@@ -58,7 +58,7 @@ const Hero = asCardToken({
     Image: as(vitalCardBase.Hero.Theme.Image, exampleRadius.Fancy),
     //     ^^
     // Note the use of `as` here. This is a composition utility provided by
-    // BodilessJS that converts a list of tokens into an HOC. When applying
+    // BodilessJS that converts a list of tokens into a HOC. When applying
     // multiple tokens to a component, `as` must be used to properly combine
     // them.
     // In the `Default` token example above, you'll notice that because only
@@ -66,7 +66,7 @@ const Hero = asCardToken({
     // needed.
   },
 });
-/// [card-tokens]
+/// [hero-card-token]
 
 export default {
   ...vitalCardBase,

--- a/packages/vital-examples/src/reusable-tokens/components/Card/tokens/exampleCard.ts
+++ b/packages/vital-examples/src/reusable-tokens/components/Card/tokens/exampleCard.ts
@@ -3,17 +3,19 @@ import { asCardToken } from '@bodiless/vital-card';
 import { vitalCardBase } from '@bodiless/vital-card/lib/base';
 import { exampleRadius } from '../../Radius';
 
+/// [card-tokens]
 /*
- * Here we extend the `Default` card token using the merge pattern by supplying
- * multiple arguments to `asCardToken`. Our radius token will be merged with
- * other tokens applied to the ContentWrapper in the Theme domain.
+ * Here we extend the `Default` card token using the merge pattern by
+ * supplying multiple arguments to `asCardToken`. Our radius token will be
+ * merged with other tokens applied to the `ContentWrapper` in the `Theme`
+ * domain.
  */
-
 const Default = asCardToken(vitalCardBase.Default, {
   Theme: {
     ContentWrapper: as(
       exampleRadius.Simple,
-      // Padding and bg color are added here to make the rounded corner visible.
+      // Padding and background color are added here to make the rounded
+      // corner visible.
       'bg-vital-secondary-footer-bg p-4',
     ),
   },
@@ -23,35 +25,48 @@ const Default = asCardToken(vitalCardBase.Default, {
 });
 
 /*
- * Here we extend the Vital 'Hero` card token using the override pattern.
+ * Here we extend the Vital `Hero` card token using the override pattern.
  * In this case, we use the spread operator to pull in all tokens applied to
- * the vital 'Hero' card.
+ * the Vital `Hero` card.
  *
- * We then use the spread operator again to pull in all tokens applied to items in
- * the 'Theme' domain of the Vital 'Hero' card and replace the 'Image' component's tokens
- * with our own.
+ * We then use the spread operator again to pull in all tokens applied to
+ * items in the `Theme` domain of the Vital `Hero` card and replace the
+ * `Image` component's tokens with our own.
  */
 const Hero = asCardToken({
-  // This will spread all existing 'Hero' card functionality across all domains.
+  // This will spread all existing `Hero` card functionality across all
+  // domains.
   ...vitalCardBase.Hero,
   Theme: {
-    // This will spread all existing 'Hero' card tokens present in the 'Theme' domain.
+    // This will spread all existing `Hero` card tokens present in the `Theme`
+    // domain.
     ...vitalCardBase.Hero.Theme,
-    // Normally, after spreading in a domain's tokens as we have at the top of
-    // this token, setting new tokens as we have below will effectively clear that
-    // component's tokens, and replace them with the ones we've specified.
+    // Normally, after spreading in a domain's tokens (as we have at the top
+    // of this token), setting new tokens (as we have below) will effectively
+    // clear that component's tokens and replace them with the ones we've
+    // specified.
 
-    // In this case, because we're restoring the vital Hero card's 'Image' tokens in the first
-    // argument (a step that must be taken when using the override pattern if we wish to modify a
-    // component while retaining it's original tokens), this application is effectively the same
-    // as writing: 'Image: exampleRadius.Fancy', in the same way that we have in the 'Default'
-    // token example above.
+    // In this case, because we're restoring the Vital `Hero` card's `Image`
+    // tokens in the first argument (a step that must be taken when using the
+    // override pattern if we wish to modify a component while retaining its
+    // original tokens), this application is effectively the same as writing:
+    // `Image: exampleRadius.Fancy`, in the same way that we have in the
+    // `Default` token example above.
     //
-    // Both options are perfectly acceptable, but as you can see, the Default example
-    // is much more concise.
+    // Both options are perfectly acceptable, but, as you can see, the
+    // `Default` example is much more concise.
     Image: as(vitalCardBase.Hero.Theme.Image, exampleRadius.Fancy),
+    //     ^^
+    // Note the use of `as` here. This is a composition utility provided by
+    // BodilessJS that converts a list of tokens into an HOC. When applying
+    // multiple tokens to a component, `as` must be used to properly combine
+    // them.
+    // In the `Default` token example above, you'll notice that because only
+    // one token is being applied to the `ContentWrapper` slot, `as` is not
+    // needed.
   },
 });
+/// [card-tokens]
 
 export default {
   ...vitalCardBase,

--- a/packages/vital-examples/src/reusable-tokens/components/Radius/tokens/exampleRadius.ts
+++ b/packages/vital-examples/src/reusable-tokens/components/Radius/tokens/exampleRadius.ts
@@ -1,10 +1,10 @@
 import { asElementToken } from '@bodiless/vital-elements';
-/*
-* Below, we craft a simple element token that will apply
-* a 40px, bottom right border radius to any component on
-* which the token is applied.
-*/
 
+/// [radius-tokens]
+/*
+ * Below, we craft a simple element token that will apply a 40px, bottom-right
+ * border radius to any component on which the token is applied.
+ */
 const Simple = asElementToken({
   Theme: {
     _: 'rounded-bl-[40px]',
@@ -12,15 +12,15 @@ const Simple = asElementToken({
 });
 
 /*
-* Here, we craft a second reusable element token that will apply
-* the more complex CSS rules previously added to the tailwind
-* configuration file.
-*/
+ * Here, we craft a second reusable element token that will apply the more
+ * complex CSS rules previously added to the Tailwind configuration file.
+ */
 const Fancy = asElementToken({
   Theme: {
     _: 'card-corner md:card-corner-md lg:card-corner-lg',
   },
 });
+/// [radius-tokens]
 
 export default {
   Simple,

--- a/packages/vital-examples/src/reusable-tokens/components/Radius/tokens/exampleRadius.ts
+++ b/packages/vital-examples/src/reusable-tokens/components/Radius/tokens/exampleRadius.ts
@@ -1,6 +1,6 @@
 import { asElementToken } from '@bodiless/vital-elements';
 
-/// [radius-tokens]
+/// [simple-token]
 /*
  * Below, we craft a simple element token that will apply a 40px, bottom-right
  * border radius to any component on which the token is applied.
@@ -10,7 +10,9 @@ const Simple = asElementToken({
     _: 'rounded-bl-[40px]',
   },
 });
+/// [simple-token]
 
+/// [fancy-token]
 /*
  * Here, we craft a second reusable element token that will apply the more
  * complex CSS rules previously added to the Tailwind configuration file.
@@ -20,7 +22,7 @@ const Fancy = asElementToken({
     _: 'card-corner md:card-corner-md lg:card-corner-lg',
   },
 });
-/// [radius-tokens]
+/// [fancy-token]
 
 export default {
   Simple,

--- a/packages/vital-examples/src/shadowing-simple-component/components/Buttons/tokens/exampleButtons.ts
+++ b/packages/vital-examples/src/shadowing-simple-component/components/Buttons/tokens/exampleButtons.ts
@@ -7,19 +7,22 @@ import {
   vitalTextDecoration,
 } from '@bodiless/vital-elements';
 
+/// [WithPrimary]
 /**
- * Here we spread the vital primary button to inherit the tokens that won't be replaced.
- * Note that the order is essential, since, as we are working with javascript objects
- * at the end of the day, the keys that come later in the object's definition overwrite
- * the ones we inherit from vitalButtonsBase.Primary.
+ * Here we spread the Vital primary button to inherit the tokens that won't be
+ * replaced.
+ * Note that the order is essential, since — as we are working with JavaScript
+ * objects at the end of the day — the keys that come later in the object's
+ * definition overwrite the ones we inherit from `vitalButtonsBase.Primary`.
  *
- * The `asButtonToken` function to help us with the tokens convention, creating the auto-completing
- * for the ButtonClean component.
+ * The `asButtonToken` function helps us with the tokens convention, creating
+ * the auto-complete for the `ButtonClean` component.
  */
 const WithPrimary = asButtonToken({
   ...vitalButtonsBase.Primary,
   Theme: {
-    // Spreading Theme here prevents unwanted changes, keeping all tokens other than the wrappers.
+    // Spreading `Theme` here prevents unwanted changes,
+    // keeping all tokens other than the wrappers.
     ...vitalButtonsBase.Primary.Theme,
     Wrapper: as(
       // vital-elements tokens
@@ -28,19 +31,22 @@ const WithPrimary = asButtonToken({
       vitalTextDecoration.Bold,
       vitalTextDecoration.Uppercase,
       vitalFontSize.Base,
-      // For the sake of example/simplicity, we have provided some example classes to modify the
-      // button style. The best practice would be to use tokens for any reusable classes.
+      // For the sake of example/simplicity, we have provided some example
+      // classes to modify the button style. The best practice would be to use
+      // tokens for any reusable classes.
       'rounded hover:bg-vital-primary-interactive transition-colors duration-400',
     ),
   },
 });
+/// [WithPrimary]
 
+/// [WithBigButton]
 /**
- * Here we follow the same logic, but this time, we'll create a new variation of button, a big
- * button with extra padding.
+ * Here we follow the same logic, but, this time, we'll create a new variation
+ * of button: a big button with extra padding.
  *
- * The `asButtonToken` function to help us with the tokens convention, creating the auto-completing
- * for the ButtonClean component.
+ * The `asButtonToken` function helps us with the tokens convention, creating
+ * the auto-complete for the `ButtonClean` component.
  */
 const WithBigButton = asButtonToken({
   ...vitalButtonsBase.Default,
@@ -49,10 +55,16 @@ const WithBigButton = asButtonToken({
     Wrapper: 'px-12 py-6',
   },
 });
+/// [WithBigButton]
 
-// Exporting the vitalButtonsBase with our custom Primary with hover, and our new big variation.
+/// [export-default]
+/**
+ * Exporting the `vitalButtonsBase` with our custom Primary with hover, and
+ * our new big variation.
+ */
 export default {
   ...vitalButtonsBase,
   WithPrimary,
   WithBigButton,
 };
+/// [export-default]

--- a/packages/vital-section/src/Components/Section/SectionClean.tsx
+++ b/packages/vital-section/src/Components/Section/SectionClean.tsx
@@ -12,8 +12,8 @@ import { asVitalTokenSpec } from '@bodiless/vital-elements';
 import { SectionComponents, SectionBaseProps } from './types';
 
 /**
- * The `sectionComponents` is basically a map of SectionClean component slots to HTML Elements.
- * This HTML elements will be used in place of SectionClean component slots in the layout.
+ * The `sectionComponents` is basically a map of `SectionClean` component slots to HTML Elements.
+ * These HTML elements will be used in place of `SectionClean` component slots in the layout.
  */
 const sectionComponents: SectionComponents = {
   Wrapper: Section,
@@ -28,8 +28,8 @@ const sectionComponents: SectionComponents = {
 };
 
 /**
- * Base component for the `SectionClean`. It defines the inner components DOM structure.
- * The `components` prop is coming from `designable` HOC below and has its type as
+ * Base component for `SectionClean`. It defines the inner components' DOM structure.
+ * The `components` prop is coming from the `designable` HOC below and has its type as
  * `DesignableComponentsProps<SectionComponents>`.
  */
 const SectionBase: FC<SectionBaseProps> = ({ components, ...rest }) => {
@@ -43,13 +43,13 @@ const SectionBase: FC<SectionBaseProps> = ({ components, ...rest }) => {
     /**
      * Renaming the link because of this error:
      *
-     * `The href attribute is required for an anchor to be keyboard accessible.
-     *  Provide a valid, navigable address as the href value. If you cannot provide an href,
-     *  but still need the element to resemble a link, use a button and change it
-     *  withappropriate styles.
+     * > The href attribute is required for an anchor to be keyboard accessible.
+     * > Provide a valid, navigable address as the href value. If you cannot provide an href,
+     * > but still need the element to resemble a link, use a button and change it
+     * > with appropriate styles.
      *
-     *  Learn more:
-     *  https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/anchor-is-valid.md
+     * > Learn more:
+     * > https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/anchor-is-valid.md
      */
     Link: SectionLink,
     ContentWrapper,
@@ -58,11 +58,11 @@ const SectionBase: FC<SectionBaseProps> = ({ components, ...rest }) => {
 
   return (
     /**
-     * Note that we spread the rest of the arguments into the Wrapper component.
-     * This is the important step to do, otherwise we may loose attributes.
+     * Note that we spread the rest of the arguments into the `Wrapper` component.
+     * This is the important step to do, otherwise we may lose attributes.
      *
-     * For example, the `{...rest}` ensures that if we add a custom ID to <Section id="..." />,
-     * it will flow to the Wrapper component and not get lost.
+     * For example, the `{...rest}` ensures that if we add a custom ID to `<Section id="..." />`,
+     * it will flow to the `Wrapper` component and not get lost.
      *
      * While the outermost element is recommended to receive the rest of the props,
      * it is not mandatory, and other slots may receive it based on your needs.
@@ -85,20 +85,20 @@ const SectionBase: FC<SectionBaseProps> = ({ components, ...rest }) => {
 };
 
 /**
- * Define SectionClean by wrapping `SectionBase` with `designable` HOC that provides the
- * `components` prop and add Node to the Component so that it is capable of handling it's own data.
+ * Define `SectionClean` by wrapping `SectionBase` with the `designable` HOC that provides the
+ * `components` prop, and add Node to the component so that it is capable of handling its own data.
  */
 const SectionClean = as(
   /**
-   * The second argument `section` is a namespace for the inner components.
-   * For example `Wrapper` component will be marked as `Section:Wrapper`.
+   * The second argument, 'Section', is a namespace for the inner components.
+   * For example, the `Wrapper` component will be marked as `Section:Wrapper`.
    */
   designable(sectionComponents, 'Section'),
   withNode,
 )(SectionBase);
 
 /**
- * A token modifier that respects the Section Components. Use to create component tokens.
+ * A token modifier that respects the Section components. Use to create component tokens.
  *
  * @category Token Collection
  */

--- a/packages/vital-section/src/Components/Section/tokens/vitalSection.ts
+++ b/packages/vital-section/src/Components/Section/tokens/vitalSection.ts
@@ -10,8 +10,8 @@ import {
 import { asSectionToken } from '../SectionClean';
 
 /**
- * A Default token for the Section Component. This token registers nodes and node keys
- * and sets minimal layout styles.
+ * A `Default` token for the Section component.
+ * This token registers nodes and node keys and sets minimal layout styles.
  */
 const Default = asSectionToken({
   Layout: {
@@ -28,17 +28,17 @@ const Default = asSectionToken({
 });
 
 /**
- * A token that adds a Link to the Section Component.
+ * A token that adds a `Link` to the Section component.
  * Note that this token does not add any default link text.
  *
- * Note that the name of this token *starts with* `With...`. That means that the token is meant
- * to be layered on top of other tokens and not used by itself. The big difference here is that
- * this token *does not extend* the Default token. It is very limited in what this token can do.
+ * Note that the name of this token _starts with_ `With...`. That means that the token is meant to
+ * be layered on top of other tokens and not used by itself. The big difference here is that this
+ * token _does not extend_ the `Default` token. It is very limited in what this token can do.
  *
- * Think of it as an Adjective, something that reflects behaviour or additional functionality.
+ * Think of it as an adjective, something that reflects behavior or additional functionality.
  *
- * This is the preffered Token pattern since it encourages composition
- * and results in a better overall code structure as well as simplifying testing.
+ * This is the preferred token pattern, since it encourages composition and results in a better
+ * overall code structure, as well as simplifies testing.
  */
 const WithLink = asSectionToken({
   Components: {
@@ -53,18 +53,18 @@ const WithLink = asSectionToken({
 });
 
 /**
- * A token that adds a Title to the Section Component.
- * The Title is an `EditorPlainClean` with `vitalEditorPlain.Default` token.
+ * A token that adds a `Title` to the Section component.
+ * The `Title` is an `EditorPlainClean` component with a `vitalEditorPlain.Default` token.
  * `TitleWrapper` is the actual `H2` tag.
  *
- * Note that the name of this token *starts with* `With...`. That means that the token is meant
- * to be layered on top of other tokens and not used by itself. The big difference here is that
- * this token *does not extend* the Default token. It is very limited in what this token can do.
+ * Note that the name of this token _starts with_ `With...`. That means that the token is meant to
+ * be layered on top of other tokens and not used by itself. The big difference here is that this
+ * token _does not extend_ the `Default` token. It is very limited in what this token can do.
  *
- * Think of it as an Adjective, something that reflects behaviour or additional functionality.
+ * Think of it as an adjective, something that reflects behavior or additional functionality.
  *
- * This is the preffered Token pattern since it encourages composition
- * and results in a better overall code structure as well as simplifying testing.
+ * This is the preferred token pattern, since it encourages composition and results in a better
+ * overall code structure, as well as simplifies testing.
  */
 const WithTitle = asSectionToken({
   Components: {
@@ -80,18 +80,18 @@ const WithTitle = asSectionToken({
 });
 
 /**
- * A token that adds a Description to the Section Component.
- * The Description is an `EditorPlainClean` with `vitalEditorPlain.Default` token.
+ * A token that adds a `Description` to the Section component.
+ * The `Description` is an `EditorPlainClean` component with a `vitalEditorPlain.Default` token.
  * `DescriptionWrapper` is the `P` tag.
  *
- * Note that the name of this token *starts with* `With...`. That means that the token is meant
- * to be layered on top of other tokens and not used by itself. The big difference here is that
- * this token *does not extend* the Default token. It is very limited in what this token can do.
+ * Note that the name of this token _starts with_ `With...`. That means that the token is meant to
+ * be layered on top of other tokens and not used by itself. The big difference here is that this
+ * token _does not extend_ the `Default` token. It is very limited in what this token can do.
  *
- * Think of it as an Adjective, something that reflects behaviour or additional functionality.
+ * Think of it as an adjective, something that reflects behavior or additional functionality.
  *
- * This is the preffered Token pattern since it encourages composition
- * and results in a better overall code structure as well as simplifying testing.
+ * This is the preferred token pattern, since it encourages composition and results in a better
+ * overall code structure, as well as simplifies testing.
  */
 const WithDescription = asSectionToken({
   Components: {
@@ -107,7 +107,7 @@ const WithDescription = asSectionToken({
 });
 
 /**
- * Export all tokens as a single object that is exported from package as `vitalSection`.
+ * Export all tokens as a single object that is exported from the package as `vitalSection`.
  */
 export default {
   Default,

--- a/sites/vital-examples/src/pages/intro/section-example.tsx
+++ b/sites/vital-examples/src/pages/intro/section-example.tsx
@@ -7,29 +7,51 @@ import { vitalTypography } from '@bodiless/vital-elements';
 
 import { exampleSection } from '@bodiless/vital-examples/lib/intro/section-example';
 
+/// [build-combinations]
+/**
+ * Default Section component.
+ * The result of applying the `Default` token to the `SectionClean` component.
+ * `vitalSection.WithSectionCards` provides cards content for the `Content`
+ * component.
+ */
 const DefaultSection = as(
   exampleSection.Default,
   exampleSection.WithCards,
 )(SectionClean);
 
+/**
+ * Section component with `Title`.
+ * The result of composing the `Default` and `WithTitle` tokens.
+ */
 const SectionWithTitle = as(
   exampleSection.Default,
   exampleSection.WithTitle,
   exampleSection.WithCards,
 )(SectionClean);
 
+/**
+ * Section component with `Link`.
+ * The result of composing the `Default` and `WithLink` tokens.
+ */
 const SectionWithLink = as(
   exampleSection.Default,
   exampleSection.WithLink,
   exampleSection.WithCards,
 )(SectionClean);
 
+/**
+ * Section component with `Description`.
+ * The result of composing the `Default` and `WithDescription` tokens.
+ */
 const SectionWithDescription = as(
   exampleSection.Default,
   exampleSection.WithDescription,
   exampleSection.WithCards,
 )(SectionClean);
 
+/**
+ * An example Section component with all elements.
+ */
 const SectionFull = as(
   exampleSection.Default,
   exampleSection.WithTitle,
@@ -37,6 +59,7 @@ const SectionFull = as(
   exampleSection.WithDescription,
   exampleSection.WithCards,
 )(SectionClean);
+/// [build-combinations]
 
 const Container = as('mx-2.5 md:mx-8 lg:mx-36')(Div);
 const Title = as(vitalTypography.H1)(H1);


### PR DESCRIPTION
## Changes

- Perform "doc clean-up" on Curriculum Lessons.
  - Fix typos, formatting, etc.
  - Replace applicable code blocks with embedded code from the associated example files.
- Update example files.
  - Restrict code comments to column 78 (for Docsify).