### PR TITLE
docs: misc fixes

### DIFF
--- a/packages/bodiless-bv/doc/README.md
+++ b/packages/bodiless-bv/doc/README.md
@@ -445,7 +445,7 @@ Then you can place the custom component on a page
 <CustomBVComponent />
 ```
 
-# BazaarVoice HOC's
+# BazaarVoice HOCs
 
 ## asBodilessBV
 

--- a/packages/bodiless-components/doc/Chameleon.md
+++ b/packages/bodiless-components/doc/Chameleon.md
@@ -105,7 +105,7 @@ states.  What if you want to apply some styling to the component in its default 
 For example, what if we wanted the "Call for availability" message to be red?
 
 To support this, a design applied to a chameleon has a special
-`_default` key which allows you to apply HOC's to the component when in its
+`_default` key which allows you to apply HOCs to the component when in its
 default state:
 
 ```js
@@ -208,7 +208,7 @@ Here we've decomposed `asBodilessChameleon` into three constituent parts:
   > }
   > ```
 - `applyChameleon` uses the chameleon state established by
-  `withChameleonContext` to apply the appropriate HOC's from a design to the
+  `withChameleonContext` to apply the appropriate HOCs from a design to the
   underlying components.
 
 First, We create a wrapper component (`VisibilityToggleWrapper`) which

--- a/packages/bodiless-components/doc/Link.md
+++ b/packages/bodiless-components/doc/Link.md
@@ -97,8 +97,8 @@ You can apply `asBodilessLink` to any component which accepts the same props as 
 ## Customize Link Behavior
 
 The `asBodilessLink` function, like any other `asBodiless...` function, accepts a node key, a
-default value, and a `useOverrides` hook; and returns an HOC which makes a link editable. You can
-use the `useOverrides` hook to customize the link editor. In particular, you can define a custom
+default value, and a `useOverrides` hook; and returns a HOC which makes a link editable. You can use
+the `useOverrides` hook to customize the link editor. In particular, you can define a custom
 function which will be used to normalize the `href` attribute when the link is saved or displayed.
 By default, `asBodilessLink` performs some basic normalization.  Here's an example of how to disable
 it:

--- a/packages/bodiless-components/doc/List.md
+++ b/packages/bodiless-components/doc/List.md
@@ -123,7 +123,7 @@ const withTitles = withDesign({
 
 And let's add some padding to the sublist items to make the list more legible.
 We use the bodiless [FClasses](..) package and [TailwindCSS]() for this, but it
-could be done with almost any CSS-in-JS library which uses higher order
+could be done with almost any CSS-in-JS library which uses higher-order
 components for styling.
 
 ```ts

--- a/packages/bodiless-components/doc/List.md
+++ b/packages/bodiless-components/doc/List.md
@@ -280,7 +280,7 @@ const withSubListDesigns = (depth: number) => (withDesign$: HOC) => withSubListD
   Numbered: withDesign$,
 });
 ```
-> Note that while in the previous example, we passed an HOC to
+> Note that while in the previous example, we passed a HOC to
 > `withSubListDesign`, here we pass a *design*. In fact, passing the HOC above
 > was shorthand, and we could instead have used exactly the same syntax as here:
 > ```ts

--- a/packages/bodiless-components/doc/List.md
+++ b/packages/bodiless-components/doc/List.md
@@ -121,10 +121,10 @@ const withTitles = withDesign({
 });
 ```
 
-And let's add some padding to the sublist items to make the list more legible.
-We use the bodiless [FClasses](..) package and [TailwindCSS]() for this, but it
-could be done with almost any CSS-in-JS library which uses higher-order
-components for styling.
+And let's add some padding to the sublist items to make the list more legible. We use the bodiless
+[FClasses](../Development/Architecture/FClasses) package and [TailwindCSS](https://tailwindcss.com/
+':target=_blank') for this, but it could be done with almost any CSS-in-JS library which uses
+higher-order components for styling.
 
 ```ts
 import { addClasses, stylable } from '@bodiless/fclasses';

--- a/packages/bodiless-components/doc/Meta.md
+++ b/packages/bodiless-components/doc/Meta.md
@@ -104,7 +104,7 @@ of each page.
 For example, to add an editable meta description field:
 
 01. Import `withMeta` from `@bodiless/components`.
-01. Create an HOC `withMetaPageDescription`, with meta field name `description`, form field label
+01. Create a HOC `withMetaPageDescription`, with meta field name `description`, form field label
     `Description`, and placeholder text.  
     For example:
     ```js

--- a/packages/bodiless-components/src/Chameleon/applyChameleon.tsx
+++ b/packages/bodiless-components/src/Chameleon/applyChameleon.tsx
@@ -40,7 +40,7 @@ import { useChameleonContext } from './withChameleonContext';
  * Note the use of `withTitle` here.  Only design elements with title metadata will be considered
  * valid chameleon states.
  *
- * @return The wrapped component enhanced by the appropriate HOC's from the design.
+ * @return The wrapped component enhanced by the appropriate HOCs from the design.
  */
 const applyChameleon: HOC = Component => {
   const Chameleon: FC<any> = props => {

--- a/packages/bodiless-components/src/Chameleon/applyChameleon.tsx
+++ b/packages/bodiless-components/src/Chameleon/applyChameleon.tsx
@@ -23,7 +23,7 @@ import { useChameleonContext } from './withChameleonContext';
  * Use this function when you want to separate the form controlling the chameleon
  * state from the component on which the chameleon acts (for example, if you want
  * to add controls to a component edit form, but actually act on the component
- * to which the edit form was added), eg:
+ * to which the edit form was added), e.g.:
  *
  * ```
  * flowRight(

--- a/packages/bodiless-components/src/Editable.bl-edit.tsx
+++ b/packages/bodiless-components/src/Editable.bl-edit.tsx
@@ -138,7 +138,7 @@ const withPlaceholder = <P extends object> (
   };
 
 /**
- * asEditable takes a nodeKey and a placeholder, and returns an HOC which injects
+ * asEditable takes a nodeKey and a placeholder, and returns a HOC which injects
  * an editable span as a child of the wrapped component.  The original children
  * of the wrapped component will become children of the editable span.  In addition,
  * `nodeKey`, `nodeCollection` and `placeholder` props passed to the enhanced

--- a/packages/bodiless-components/src/Editable.static.tsx
+++ b/packages/bodiless-components/src/Editable.static.tsx
@@ -84,7 +84,7 @@ const withPlaceholder = <P extends object> (
   };
 
 /**
- * asEditable takes a nodeKey and a placeholder, and returns an HOC which injects
+ * asEditable takes a nodeKey and a placeholder, and returns a HOC which injects
  * an editable span as a child of the wrapped component.  The original children
  * of the wrapped component will become children of the editable span.  In addition,
  * `nodeKey`, `nodeCollection` and `placeholder` props passed to the enhanced

--- a/packages/bodiless-components/src/Image/withDefaultImageContent.ts
+++ b/packages/bodiless-components/src/Image/withDefaultImageContent.ts
@@ -20,7 +20,7 @@ import identity from 'lodash/identity';
 import type { AsBodilessImage, Data } from './Image';
 
 /**
- * Adds default content to an asEditableImage hoc
+ * Adds default content to an asEditableImage HOC
  */
 const withDefaultImageContent = (
   asEditableImage: AsBodilessImage,

--- a/packages/bodiless-components/src/Image/withDefaultImageContent.ts
+++ b/packages/bodiless-components/src/Image/withDefaultImageContent.ts
@@ -20,7 +20,7 @@ import identity from 'lodash/identity';
 import type { AsBodilessImage, Data } from './Image';
 
 /**
- * Adds default content to an asEditableImage HOC
+ * Adds default content to an `asEditableImage` HOC.
  */
 const withDefaultImageContent = (
   asEditableImage: AsBodilessImage,

--- a/packages/bodiless-components/src/Image/withImageLibrary.ts
+++ b/packages/bodiless-components/src/Image/withImageLibrary.ts
@@ -23,7 +23,7 @@ import { withContentLibrary, ComponentSelector } from '@bodiless/layouts';
 import path from 'path';
 import type { AsBodilessImage } from './Image';
 
-// Adds image library to an asEditableImage HOC.
+// Adds image library to an `asEditableImage` HOC.
 const withImageLibrary = (
   asEditableImage: AsBodilessImage,
   Selector = ComponentSelector,

--- a/packages/bodiless-components/src/Image/withImageLibrary.ts
+++ b/packages/bodiless-components/src/Image/withImageLibrary.ts
@@ -23,7 +23,7 @@ import { withContentLibrary, ComponentSelector } from '@bodiless/layouts';
 import path from 'path';
 import type { AsBodilessImage } from './Image';
 
-// Adds image library to an asEditableImage hoc.
+// Adds image library to an asEditableImage HOC.
 const withImageLibrary = (
   asEditableImage: AsBodilessImage,
   Selector = ComponentSelector,

--- a/packages/bodiless-components/src/List/asChameleonSubList.tsx
+++ b/packages/bodiless-components/src/List/asChameleonSubList.tsx
@@ -100,7 +100,7 @@ const withSubListDesign = (depth: number) => (
  * sublist types which can be swapped (eg for different bullet styles).
  *
  * @param Depth The number of nested sublists to attach.
- * @return An function accepting a sublist definition and returning an HOC which adds the sublists.
+ * @return An function accepting a sublist definition and returning a HOC which adds the sublists.
  */
 const withSubLists = (
   depth: number,

--- a/packages/bodiless-components/src/withBodilessLinkToggle.tsx
+++ b/packages/bodiless-components/src/withBodilessLinkToggle.tsx
@@ -44,7 +44,7 @@ const extendOverrides = <P extends object, D extends object>(
 
 /**
  * @private
- * Default hoc used to replace link when toggled off.
+ * Default HOC used to replace link when toggled off.
  */
 const defaultAsOff: HOC = flowHoc(
   ifEditable(replaceWith(SafeSpan)),

--- a/packages/bodiless-components/src/withResponsiveVariants.tsx
+++ b/packages/bodiless-components/src/withResponsiveVariants.tsx
@@ -28,7 +28,7 @@ type FinalComponents = {
 };
 
 /**
- * Generates an HOC which makes the underlying component designable at different
+ * Generates a HOC which makes the underlying component designable at different
  * breakpoints. This allows responsive rendering or swapping a component entirely
  * depending on viewport size.
  *

--- a/packages/bodiless-core/README.md
+++ b/packages/bodiless-core/README.md
@@ -193,7 +193,7 @@ const ComponentWithMenuOption = flowRight(
 )(AnyComponent)
 ```
 
-Finally, you will want to be sure that none of the above HOC's are applied when not in edit mode.
+Finally, you will want to be sure that none of the above HOCs are applied when not in edit mode.
 For this, `ifEditable` comes in handy:
 ```
 const ComponentWithMenuOption = ifEditable(
@@ -202,7 +202,7 @@ const ComponentWithMenuOption = ifEditable(
   withActivatorWrapper('div'),
 )(AnyComponent)
 ```
-Note that the order of these HOC's is important.
+Note that the order of these HOCs is important.
 
 ## Context Menu Options
 

--- a/packages/bodiless-core/README.md
+++ b/packages/bodiless-core/README.md
@@ -95,7 +95,7 @@ activated. It should return any menu options this component wishes to provide
 > callback even if the menu options it returns change.
 
 It is actually unusual to invoke the provider directly in this manner. Instead,
-use the `withMenuOptions` hoc to attach options to your component. First you
+use the `withMenuOptions` HOC to attach options to your component. First you
 define a custom hook which will create your `getMenuOptions()` callback. This
 hook will be invoked when the component is rendered, and will receive its props
 as an argument:

--- a/packages/bodiless-core/README.md
+++ b/packages/bodiless-core/README.md
@@ -108,7 +108,7 @@ const useMenuOptions = (props) => {
 };
 ```
 
-Then, pass that along with a unique name to `withMenuOptions` to create an HOC
+Then, pass that along with a unique name to `withMenuOptions` to create a HOC
 which will add the options to your component.
 
 ```

--- a/packages/bodiless-core/src/PageContextProvider.tsx
+++ b/packages/bodiless-core/src/PageContextProvider.tsx
@@ -148,7 +148,7 @@ const setDefaultOptionScope = (options: TMenuOption[], global: boolean) => optio
 }));
 
 /**
- * Using supplied options, returns an HOC which adds one or more menu options (buttons).
+ * Using supplied options, returns a HOC which adds one or more menu options (buttons).
  * This simply wraps the supplied component with a `PageContextProvider`.
  *
  * Note that, unlike `PageContextProvider` itself, this function takes a custom hook
@@ -161,7 +161,7 @@ const setDefaultOptionScope = (options: TMenuOption[], global: boolean) => optio
  *
  * @param def The definition of the menu options to be provided.
  *
- * @return An HOC which will cause the component it enhances to contribute the specified
+ * @return A HOC which will cause the component it enhances to contribute the specified
  *         menu options when placed.
  */
 export const withMenuOptions = <P extends object>(

--- a/packages/bodiless-core/src/asBodilessComponent/asBodilessComponent.bl-edit.tsx
+++ b/packages/bodiless-core/src/asBodilessComponent/asBodilessComponent.bl-edit.tsx
@@ -31,7 +31,7 @@ import { ifToggledOn } from '../withFlowToggle';
 import type { BodilessOptions, AsBodiless } from '../Types/AsBodilessTypes';
 
 /**
- * Given an event name and a wrapper component, provides an HOC which will wrap the base component
+ * Given an event name and a wrapper component, provides a HOC which will wrap the base component
  * the wrapper, passing the event prop to the wrapper, and all other props to the base component.
  *
  * @param event The event name.
@@ -54,7 +54,7 @@ export const withActivatorWrapper = (event: string, Wrapper: ComponentOrTag<any>
 /**
  * Makes a component "Bodiless" by connecting it to the Bodiless-jS data flow and giving it
  * a form which can be used to edit its props. Returns a standard `asBodiless...` function,
- * which takes `nodeKey` and `defaultData` parameters, and returns an HOC which yields an editable
+ * which takes `nodeKey` and `defaultData` parameters, and returns a HOC which yields an editable
  * version of the base component.
  *
  * @param options An object describing how this component should be made editable.
@@ -62,7 +62,7 @@ export const withActivatorWrapper = (event: string, Wrapper: ComponentOrTag<any>
 // eslint-disable-next-line max-len
 const asBodilessComponent = <P extends object, D extends object>(options: BodilessOptions<P, D>): AsBodiless<P, D> => (
   /**
-   * Creates an HOC that will make a component "Bodilesss".
+   * Creates a HOC that will make a component "Bodilesss".
    *
    * @param nodeKey The nodeKey identifying where the components data will be stored.
    * @param defaultData An object representing the initial/default data. Supercedes any default
@@ -71,7 +71,7 @@ const asBodilessComponent = <P extends object, D extends object>(options: Bodile
    * be invoked in the render context of the wrapped component and passed the
    * component's props.
    *
-   * @return An HOC which will make the wrapped component "bodiless".
+   * @return A HOC which will make the wrapped component "bodiless".
    */
   (
     nodeKeys?,

--- a/packages/bodiless-core/src/asBodilessComponent/asBodilessReadOnlyComponent.tsx
+++ b/packages/bodiless-core/src/asBodilessComponent/asBodilessReadOnlyComponent.tsx
@@ -22,7 +22,7 @@ export const withActivatorWrapper = identity;
 /**
  * Makes a component "Bodiless" by connecting it to the Bodiless-jS data flow and giving it
  * a form which can be used to edit its props. Returns a standard `asBodiless...` function,
- * which takes `nodeKey` and `defaultData` parameters, and returns an HOC which yields an editable
+ * which takes `nodeKey` and `defaultData` parameters, and returns a HOC which yields an editable
  * version of the base component.
  *
  * @param options An object describing how this component should be made editable.
@@ -30,7 +30,7 @@ export const withActivatorWrapper = identity;
 // eslint-disable-next-line max-len
 const asBodilessReadOnlyComponent = <P extends object, D extends object>(options: BodilessOptions<P, D>): AsBodiless<P, D> => (
   /**
- * Creates an HOC that will make a component "Bodilesss".
+ * Creates a HOC that will make a component "Bodilesss".
  *
  * @param nodeKey The nodeKey identifying where the components data will be stored.
  * @param defaultData An object representing the initial/default data. Supercedes any default
@@ -39,7 +39,7 @@ const asBodilessReadOnlyComponent = <P extends object, D extends object>(options
  * be invoked in the render context of the wrapped component and passed the
  * component's props.
  *
- * @return An HOC which will make the wrapped component "bodiless".
+ * @return A HOC which will make the wrapped component "bodiless".
  */
   (
     nodeKeys?,

--- a/packages/bodiless-core/src/hoc.bl-edit.tsx
+++ b/packages/bodiless-core/src/hoc.bl-edit.tsx
@@ -26,14 +26,14 @@ import { withClickOutside, withExtendHandler, withOnlyProps } from './hoc.static
 import type { resizeDetectorProps, ClickOutsideProps } from './hoc.static';
 
 /**
- * Creates an HOC which provides the base component event handler which activates the current
+ * Creates a HOC which provides the base component event handler which activates the current
  * context.
  *
  * @param event
  * The event which should trigger the context activation.
  *
  * @returns
- * An HOC which injects the event handler.
+ * A HOC which injects the event handler.
  */
 export const withContextActivator = (
   event: string = 'onClick',
@@ -66,7 +66,7 @@ export const withLocalContextMenu = addProps(() => {
  * Optionally a callback can be provided by the component.
  * If the callback is not provided, as default the component is rendered at resize.
  *
- * @return An HOC which will detect resize.
+ * @return A HOC which will detect resize.
  */
 export const withResizeDetector = <P extends object>(Component: CT<P> | string) => {
   const WithResizeDetector = (props: P & resizeDetectorProps) => {

--- a/packages/bodiless-core/src/hoc.bl-edit.tsx
+++ b/packages/bodiless-core/src/hoc.bl-edit.tsx
@@ -62,7 +62,7 @@ export const withLocalContextMenu = addProps(() => {
 });
 
 /**
- * Utility hoc to add resize detector to the original component.
+ * Utility HOC to add resize detector to the original component.
  * Optionally a callback can be provided by the component.
  * If the callback is not provided, as default the component is rendered at resize.
  *

--- a/packages/bodiless-core/src/hoc.static.tsx
+++ b/packages/bodiless-core/src/hoc.static.tsx
@@ -22,7 +22,7 @@ import { HOC } from '@bodiless/fclasses';
 import { useExtendHandler, useClickOutside } from './hooks';
 
 /**
- * Utility hoc to add an event handler which extends any handler passed to
+ * Utility HOC to add an event handler which extends any handler passed to
  * the original component.
  *
  * Only adds the extension when in edit mode.
@@ -69,7 +69,7 @@ export type ClickOutsideProps = {
 };
 
 /**
- * Utility hoc to add onClickOutside handler to the original component.
+ * Utility HOC to add onClickOutside handler to the original component.
  * A callback will be executed on both click outside as well as on the `esc` keypress.
  *
  * @return An HOC which will add the handler.

--- a/packages/bodiless-core/src/hoc.static.tsx
+++ b/packages/bodiless-core/src/hoc.static.tsx
@@ -27,7 +27,7 @@ import { useExtendHandler, useClickOutside } from './hooks';
  *
  * Only adds the extension when in edit mode.
  *
- * @param event The name of the event whose handler is to be extended
+ * @param event The name of the event whose handler is to be extended.
  * @param useExtender Custom hook returning the handler to add. Will be invoked
  *        during render and receive the original props of the component.
  *
@@ -69,7 +69,7 @@ export type ClickOutsideProps = {
 };
 
 /**
- * Utility HOC to add onClickOutside handler to the original component.
+ * Utility HOC to add `onClickOutside` handler to the original component.
  * A callback will be executed on both click outside as well as on the `esc` keypress.
  *
  * @return An HOC which will add the handler.

--- a/packages/bodiless-core/src/hoc.static.tsx
+++ b/packages/bodiless-core/src/hoc.static.tsx
@@ -31,7 +31,7 @@ import { useExtendHandler, useClickOutside } from './hooks';
  * @param useExtender Custom hook returning the handler to add. Will be invoked
  *        during render and receive the original props of the component.
  *
- * @return An HOC which will add the handler.
+ * @return A HOC which will add the handler.
  */
 export const withExtendHandler = <P extends object>(
   event: string,
@@ -47,11 +47,11 @@ export const withExtendHandler = <P extends object>(
   };
 
 /*
- * Creates an HOC which strips all but the specified props.
+ * Creates a HOC which strips all but the specified props.
  *
  * @param keys A list of the prop-names to keep.
  *
- * @return An HOC which will strip all but the specified props.
+ * @return A HOC which will strip all but the specified props.
  */
 export const withOnlyProps = <Q extends object>(...keys: string[]) => (
   <P extends object>(Component: CT<P> | string) => {
@@ -72,7 +72,7 @@ export type ClickOutsideProps = {
  * Utility HOC to add `onClickOutside` handler to the original component.
  * A callback will be executed on both click outside as well as on the `esc` keypress.
  *
- * @return An HOC which will add the handler.
+ * @return A HOC which will add the handler.
  */
 export const withClickOutside = <P extends object>(Component: CT<P> | string) => {
   const WithClickOutside = (props: P & ClickOutsideProps) => {

--- a/packages/bodiless-core/src/withChild.tsx
+++ b/packages/bodiless-core/src/withChild.tsx
@@ -33,7 +33,7 @@ type InsertChildOptions = {
  * @param Child - Component to add as a child
  * @param options - A Design key to reach the Child and an optional mode ('append' | 'prepend').
  *
- * @return An HOC which will append the Child to the given Component.
+ * @return A HOC which will append the Child to the given Component.
  */
 const insertChild = (Child: CT, options: InsertChildOptions): HOC => (
   Component = Fragment,
@@ -80,7 +80,7 @@ const insertChild = (Child: CT, options: InsertChildOptions): HOC => (
  * @param designKey - Design key to reach the Child component using Design API.
  * @param componentName - Optional component namespace for design key data attribute.
  *
- * @return An HOC which will add the Child to the given Parent.
+ * @return A HOC which will add the Child to the given Parent.
  *
  * @example Example of adding 'span' as a child to 'div'.
  * Then customizing the span leveraging design API.
@@ -112,7 +112,7 @@ const withChild = <P extends object>(
  * @param designKey - Design key to reach the Child component using Design API.
  * @param componentName - Optional component namespace for design key data attribute.
  *
- * @return An HOC which will append the Child to the given Component.
+ * @return A HOC which will append the Child to the given Component.
  */
 const withAppendChild = <P extends object>(
   Child: CT<any>,
@@ -128,7 +128,7 @@ const withAppendChild = <P extends object>(
  * @param designKey - Design key to reach the Child component using Design API.
  * @param componentName - Optional component namespace for design key data attribute.
  *
- * @return An HOC which will prepend the Child to the given Component.
+ * @return A HOC which will prepend the Child to the given Component.
  */
 const withPrependChild = <P extends object>(
   Child: CT<any>,

--- a/packages/bodiless-core/src/withEditButton.bl-edit.tsx
+++ b/packages/bodiless-core/src/withEditButton.bl-edit.tsx
@@ -54,12 +54,12 @@ export const createMenuOptionGroup = (
 };
 
 /**
- * Uses the provided options to create an HOC which adds an edit button provider
+ * Uses the provided options to create a HOC which adds an edit button provider
  * to the wrapped component.
  *
  * @param options The options defining the edit button.
  *
- * @return An HOC which will add an edit button for the wrapped component.
+ * @return A HOC which will add an edit button for the wrapped component.
  */
 const withEditButton = <P extends object, D extends object>(
   options: EditButtonOptions<P, D> | ((props: P) => EditButtonOptions<P, D>),

--- a/packages/bodiless-core/src/withEditButton.static.tsx
+++ b/packages/bodiless-core/src/withEditButton.static.tsx
@@ -29,12 +29,12 @@ export const createMenuOptionGroup = (
 ):TMenuOption[] => [baseOption];
 
 /**
- * Uses the provided options to create an HOC which adds an edit button provider
+ * Uses the provided options to create a HOC which adds an edit button provider
  * to the wrapped component.
  *
  * @param options The options defining the edit button.
  *
- * @return An HOC which will add an edit button for the wrapped component.
+ * @return A HOC which will add an edit button for the wrapped component.
  */
 const withEditButton = identity;
 

--- a/packages/bodiless-core/src/withParent.tsx
+++ b/packages/bodiless-core/src/withParent.tsx
@@ -24,7 +24,7 @@ import { HOC, DesignableComponentsProps, extendDesignable } from '@bodiless/fcla
  * @param designKey - A Design key to reach the Parent. 'Parent' by default.
  * @param componentName - Optional component namespace for design key data attribute.
  *
- * @return An HOC which will wrap the given Child component with provided Parent.
+ * @return A HOC which will wrap the given Child component with provided Parent.
  *
  * @example Example of adding 'div' as a parent to 'span'.
  * Then customizing the div leveraging the design API.

--- a/packages/bodiless-data/__tests__/withSidecarNodes.test.tsx
+++ b/packages/bodiless-data/__tests__/withSidecarNodes.test.tsx
@@ -157,7 +157,7 @@ describe('Sidecar Node Use Cases', () => {
 });
 
 describe('withSidecarNodes', () => {
-  it('Preserves the original nodeKey when an HOC is applied outside.', () => {
+  it('Preserves the original nodeKey when a HOC is applied outside.', () => {
     const Test = flowRight(
       withSidecarNodes(
         withFoo('foo'),

--- a/packages/bodiless-data/src/Contentful/withDefaultContent.tsx
+++ b/packages/bodiless-data/src/Contentful/withDefaultContent.tsx
@@ -19,7 +19,7 @@ import NodeProvider, { useNode } from '../NodeProvider';
 import ContentfulNode from './ContentfulNode';
 
 /**
- * Creates an HOC which provides default content to the wrapped component.
+ * Creates a HOC which provides default content to the wrapped component.
  *
  * The default content is an object (or a function returning an object) keyed
  * by the relative node key at which the wrapped component or its children are
@@ -33,7 +33,7 @@ import ContentfulNode from './ContentfulNode';
  * An object or function returning an object containing default content keyed by node key.
  *
  * @returns
- * An HOC providing default content to the wrapped component.
+ * A HOC providing default content to the wrapped component.
  */
 const withDefaultContent = <P extends object, D extends object>(
   content: D | ((props: P) => D),

--- a/packages/bodiless-data/src/hoc.bl-edit.tsx
+++ b/packages/bodiless-data/src/hoc.bl-edit.tsx
@@ -21,7 +21,7 @@ import withNode from './withNode';
 
 // @TODO: Combine withNode and withNodeDataHandlers and fix types
 /**
- * Creates an HOC which reads data from the current content node and injects two
+ * Creates a HOC which reads data from the current content node and injects two
  * props to the target component:
  * - `componentData`: The `data` property from the node.
  * - `setComponentData`: A function which calls the `setData` method

--- a/packages/bodiless-data/src/hoc.static.tsx
+++ b/packages/bodiless-data/src/hoc.static.tsx
@@ -24,7 +24,7 @@ import withNode from './withNode';
  * props to the target component:
  * - `componentData`: The `data` property from the node.
  * - `setComponentData`: A function which calls the `setData` method
- *    on the node,
+ *    on the node.
  *
  * @param defaultData
  * A default value for `componentData` when the node's `data` property is empty.

--- a/packages/bodiless-data/src/hoc.static.tsx
+++ b/packages/bodiless-data/src/hoc.static.tsx
@@ -20,7 +20,7 @@ import withNode from './withNode';
 
 // @TODO: Combine withNode and withNodeDataHandlers and fix types
 /**
- * Creates an HOC which reads data from the current content node and injects two
+ * Creates a HOC which reads data from the current content node and injects two
  * props to the target component:
  * - `componentData`: The `data` property from the node.
  * - `setComponentData`: A function which calls the `setData` method

--- a/packages/bodiless-data/src/withSidecarNodes.tsx
+++ b/packages/bodiless-data/src/withSidecarNodes.tsx
@@ -73,8 +73,8 @@ const endSidecarNodes: HOC = Component => {
 
 /**
  * `withSidecarNodes` allows you to establish a `ContentNode` sub-hierarchiy which should
- * be used by a series of one or more HOC's. Any nodes created by the HOC's enclosed in this
- * wrapper will not affect the hierarchy for subsequent HOC's *outside* the wrapper. For
+ * be used by a series of one or more HOCs. Any nodes created by the HOCs enclosed in this
+ * wrapper will not affect the hierarchy for subsequent HOCs *outside* the wrapper. For
  * example:
  * ```js
  * flowRight(
@@ -90,7 +90,7 @@ const endSidecarNodes: HOC = Component => {
  * This is useful, for example, if you want to apply an enhancement HOC which uses its own
  * content node(s) without affecting the node paths of other children of the wrapped component.
  *
- * @param hocs A list of HOC's to be applied using the parallel node hierarchy.  These will
+ * @param hocs A list of HOCs to be applied using the parallel node hierarchy.  These will
  *             be composed using lodash `flowRight`
  *
  * @return an HOC which can wrap any Component using the Bodiless `ContentNode` system.

--- a/packages/bodiless-data/src/withSidecarNodes.tsx
+++ b/packages/bodiless-data/src/withSidecarNodes.tsx
@@ -21,7 +21,7 @@ import type { NodeMap } from './NodeProvider';
 const SidecarNodeContext = createContext<NodeMap<any>[]>([]);
 
 /**
- * `startSidecarNodes` is an HOC which records the current ContentNode so that
+ * `startSidecarNodes` is a HOC which records the current ContentNode so that
  * it can later be restored.
  *
  * @see `withSidecarNodes`
@@ -43,7 +43,7 @@ const startSidecarNodes: HOC = Component => {
 };
 
 /**
- * `endSidecarNodes` is an HOC which restores the ContentNode preserved
+ * `endSidecarNodes` is a HOC which restores the ContentNode preserved
  * by `startSidecarNodes`.
  *
  * @see `withSidecarNodes`
@@ -93,7 +93,7 @@ const endSidecarNodes: HOC = Component => {
  * @param hocs A list of HOCs to be applied using the parallel node hierarchy.  These will
  *             be composed using lodash `flowRight`
  *
- * @return an HOC which can wrap any Component using the Bodiless `ContentNode` system.
+ * @return A HOC which can wrap any Component using the Bodiless `ContentNode` system.
  */
 const withSidecarNodes = (...hocs: HOC[]) => flowRight(
   startSidecarNodes,

--- a/packages/bodiless-documentation/doc/Development/Architecture/Data.md
+++ b/packages/bodiless-documentation/doc/Development/Architecture/Data.md
@@ -318,8 +318,8 @@ content$component.json
 
 The examples above can be refactored to make them more composable.
 
-Instead of defining our `ComponentWithData` as a Component, we can abstract that functionality
-to an HOC (a very common pattern in BodilessJS).
+Instead of defining our `ComponentWithData` as a Component, we can abstract that functionality to a
+HOC (a very common pattern in BodilessJS).
 
 ```tsx
 const asComponentWithData = BaseComponent => {

--- a/packages/bodiless-documentation/doc/Development/Guides/BuildingSites/Responsiveness.md
+++ b/packages/bodiless-documentation/doc/Development/Guides/BuildingSites/Responsiveness.md
@@ -63,7 +63,7 @@ BodilessJS provides the following tools to work with these breakpoints:
   ':target=_blank'): Accepts the site's breakpoints from `resolveConfig()` and will listen on the
   window's resize event.
 - [`withResponsiveVariants`](https://github.com/johnsonandjohnson/Bodiless-JS/blob/main/packages/bodiless-components/src/withResponsiveVariants.tsx
-  ':target=_blank'): Generates an HOC which makes the underlying component designable at different
+  ':target=_blank'): Generates a HOC which makes the underlying component designable at different
   breakpoints. This allows responsive rendering or swapping a component entirely depending on
   viewport size.
 

--- a/packages/bodiless-documentation/doc/Development/Guides/CreatingBodilessComponents.md
+++ b/packages/bodiless-documentation/doc/Development/Guides/CreatingBodilessComponents.md
@@ -310,7 +310,7 @@ const submitValueHandler = (values: any) => ({
 });
 ```
 
-Finally, we compose a series of core Bodiless HOC's (using Lodash `flowRight`) to
+Finally, we compose a series of core Bodiless HOCs (using Lodash `flowRight`) to
 fully integrate our component and its custom form:
 
 ```ts
@@ -340,11 +340,11 @@ Let's take this step by step:
   }),
 ```
 
-These three HOC's provide integration to
+These three HOCs provide integration to
 [the BodilessJS data flow](../Architecture/Data). They
 ensure that the component is given a place to store its data, and
 define the "empty" value for that data. They add two props--`componentData`
-and `setComponentData`--which are used by the HOC's further down the
+and `setComponentData`--which are used by the HOCs further down the
 chain.
 
 ```ts
@@ -355,7 +355,7 @@ chain.
 
 Bodiless components may behave differently when a site is editable than when it is
 built statically.  To facilitate different compositions for different modes,
-BodilessJS provides `ifEditable` and `ifReadOnly` meta-HOC's, which can be
+BodilessJS provides `ifEditable` and `ifReadOnly` meta-HOCs, which can be
 used to control what enhancements are added in each mode.  Since a component
 on a static site never alters its content, we here strip the `setComponentData`
 prop.

--- a/packages/bodiless-filtering/src/FilterByGroup/withFilterSelection.tsx
+++ b/packages/bodiless-filtering/src/FilterByGroup/withFilterSelection.tsx
@@ -298,7 +298,7 @@ const withFilterDefaultSelection = <P extends object>(Component: ComponentOrTag<
 };
 
 /**
- * Creates an HOC which allows a content editor to specify a set of default
+ * Creates a HOC which allows a content editor to specify a set of default
  * filter selections which will be applied whenever a filterable content
  * listing is displayed.
  *

--- a/packages/bodiless-filtering/src/Taggable/asTaggableItem.tsx
+++ b/packages/bodiless-filtering/src/Taggable/asTaggableItem.tsx
@@ -30,7 +30,7 @@ const emptyValue: TagsNodeType = {
   tags: [],
 };
 
-// Composed hoc which creates editable version of the component.
+// Composed HOC which creates editable version of the component.
 // Note - the order is important. In particular:
 // - the node data handlers must be outermost
 // - anything relying on the context (activator, indicator) must be

--- a/packages/bodiless-ga4/doc/AboutGTM.md
+++ b/packages/bodiless-ga4/doc/AboutGTM.md
@@ -19,8 +19,9 @@ Vital Component is utilized:
   [`PageView`](https://github.com/searchdiscovery/client-jnj-ga4-dl-spec/blob/master/events/page_view.md
   ':target=_blank') event.
 - Product pages  render a `view_item` event with data that can be set by a Content Editor.
-- Product Listing pages (utilizing `@vital-templates/ProductListing`) render a set of [`list`]()
-  events based on user interaction with the filter.
+- Product Listing pages (utilizing `@vital-templates/ProductListing`) render a set of
+  [`list`](https://github.com/searchdiscovery/client-jnj-ga4-dl-spec/blob/master/events/lists/view_item_list.md
+  ':target=_blank') events based on user interaction with the filter.
 - Search pages (utilizing `@vital-search`) render
   [`search`](https://github.com/searchdiscovery/client-jnj-ga4-dl-spec/blob/master/events/search/search.md
   ':target=_blank') or

--- a/packages/bodiless-ga4/doc/GA4Activation.md
+++ b/packages/bodiless-ga4/doc/GA4Activation.md
@@ -11,7 +11,7 @@ GA4 documentation](https://support.google.com/analytics/answer/9304153 ':target=
 ## Step 1: Confirm Google Tag Manager ID and Connect Tag Manager to GA4
 
 Using the following documentation, create a GA4 Configuration tag:
-[Google Analytics 4 tags](.https://support.google.com/tagmanager/answer/9442095 ':target=_blank')
+[Google Analytics 4 tags](https://support.google.com/tagmanager/answer/9442095 ':target=_blank').
 
 Once obtained, proceed to Step 2.
 
@@ -57,7 +57,8 @@ Visit the `/sites/SITENAME/src/data/site` folder and update the following three 
     If you wish to use another plugin and/or set custom options, this is the recommended place to
     set it.
 
-    GTM and data layer functionality is enabled by adding the following to the site's `gatsby-config.js` file and replacing the `GTM-XXXXXXX` from Step 1:
+    GTM and data layer functionality is enabled by adding the following to the site's
+    `gatsby-config.js` file and replacing the `GTM-XXXXXXX` from Step 1:
 
     ```js
     {

--- a/packages/bodiless-ga4/doc/README.md
+++ b/packages/bodiless-ga4/doc/README.md
@@ -13,7 +13,6 @@ For more information, please see:
 
 The GA4 package provides some utilities to support pushing `DataLayer` objects to the head:
 
-- `withDataLayerItem`: An HOC that will read/store its value in `nodeKey` and render on the GTM
-  form.
-- `withDefaultDataLayer`: An HOC that adds the default data layer to a Component.
-- `withDataLayerScript`: An HOC that renders the data layer script.
+- `withDataLayerItem`: A HOC that will read/store its value in `nodeKey` and render on the GTM form.
+- `withDefaultDataLayer`: A HOC that adds the default data layer to a Component.
+- `withDataLayerScript`: A HOC that renders the data layer script.

--- a/packages/bodiless-ga4/src/util/index.ts
+++ b/packages/bodiless-ga4/src/util/index.ts
@@ -53,7 +53,7 @@ export const renderDataLayerScript = (Component : ComponentType) => {
  * @param hocs array
  *   An array of HOCs to act on the helmet component before it renders.
  *
- * @return An HOC which will add the the DataLayer properties.
+ * @return A HOC which will add the the DataLayer properties.
  */
 export const withGlobalGA4 = (...hocs: HOC[]) => flowRight(
   asBodilessHelmet('datalayer'),
@@ -69,7 +69,7 @@ export const withGlobalGA4 = (...hocs: HOC[]) => flowRight(
  * @param hocs array
  *   An array of HOCs to act on the helmet component before it renders.
  *
- * @return An HOC which will add the the DataLayer properties.
+ * @return A HOC which will add the the DataLayer properties.
  */
 export const withGlobalGA4Form = (...hocs: HOC[]) => flowRight(
   withMetaForm(useMenuOptions, gtmFormHeader),

--- a/packages/bodiless-ga4/src/util/index.ts
+++ b/packages/bodiless-ga4/src/util/index.ts
@@ -47,7 +47,7 @@ export const renderDataLayerScript = (Component : ComponentType) => {
 
 /**
 *
- * Utility hoc to add a reusable global GA4/DataLayer data to a helmet
+ * Utility HOC to add a reusable global GA4/DataLayer data to a helmet
  * component.
  *
  * @param hocs array
@@ -63,7 +63,7 @@ export const withGlobalGA4 = (...hocs: HOC[]) => flowRight(
 
 /**
 *
- * Utility hoc to add a reusable global GA4/DataLayer form and data to a helmet
+ * Utility HOC to add a reusable global GA4/DataLayer form and data to a helmet
  * component.
  *
  * @param hocs array

--- a/packages/bodiless-i18n/doc/README.md
+++ b/packages/bodiless-i18n/doc/README.md
@@ -112,7 +112,7 @@ export default {
 ### 4. Set global components to store data per language
 
 On all global components (anything saving to global site collection) that you
-want to save multilingual data. Add an HOC
+want to save multilingual data. Add a HOC
 [`withLanguageNode`](../../../Development/API/@bodiless/i18n/README?id=withlanguagenode)
 to the component's Schema domain. The best way is to shadow the component. It is
 suggested to shadow the top level components (such as Header & Footer and then

--- a/packages/bodiless-i18n/src/LanguageNode/withLanguageNode.tsx
+++ b/packages/bodiless-i18n/src/LanguageNode/withLanguageNode.tsx
@@ -14,8 +14,8 @@ type NodeProps = {
 };
 
 /**
- * withLanguageNode is a HOC that allows the wrapped component to handle its data
- * in multilingual manner.
+ * `withLanguageNode` is a HOC that allows the wrapped component to handle its
+ * data in a multilingual manner.
  *
  * @category Language Node API
  */

--- a/packages/bodiless-i18n/src/LanguageNode/withLanguageNode.tsx
+++ b/packages/bodiless-i18n/src/LanguageNode/withLanguageNode.tsx
@@ -14,7 +14,7 @@ type NodeProps = {
 };
 
 /**
- * withLanguageNode is a hoc that allows the wrapped component to handle its data
+ * withLanguageNode is a HOC that allows the wrapped component to handle its data
  * in multilingual manner.
  *
  * @category Language Node API

--- a/packages/bodiless-i18n/src/LanguageProvider/LanguageProvider.token.tsx
+++ b/packages/bodiless-i18n/src/LanguageProvider/LanguageProvider.token.tsx
@@ -7,7 +7,7 @@ import { withLanguageProvider, setCurrentLanguage$ } from './LanguageProvider';
 import type { PropsWithLanguages, Languages } from './LanguageProvider';
 
 /**
- * withCurrentLanguageFromHostPrefix hoc defines the current language
+ * withCurrentLanguageFromHostPrefix HOC defines the current language
  * by reading the host prefix, e.g. 'es' in https://es.example.com
  *
  * @category Language Provider
@@ -48,7 +48,7 @@ export const withCurrentLanguageFromPath: HOC = Component => (props: any) => {
 };
 
 /**
- * withLanguages hoc adds language provider to the component and implements default
+ * withLanguages HOC adds language provider to the component and implements default
  * mechanism of detecting which language is active (by firsh path section).
  * Should be applied on page wrapper component in order to provide necessary language info for
  * all nested components.

--- a/packages/bodiless-i18n/src/LanguageProvider/LanguageProvider.token.tsx
+++ b/packages/bodiless-i18n/src/LanguageProvider/LanguageProvider.token.tsx
@@ -7,8 +7,8 @@ import { withLanguageProvider, setCurrentLanguage$ } from './LanguageProvider';
 import type { PropsWithLanguages, Languages } from './LanguageProvider';
 
 /**
- * withCurrentLanguageFromHostPrefix HOC defines the current language
- * by reading the host prefix, e.g. 'es' in https://es.example.com
+ * `withCurrentLanguageFromHostPrefix` HOC defines the current language
+ * by reading the host prefix, e.g., 'es' in https://es.example.com.
  *
  * @category Language Provider
  */
@@ -28,8 +28,8 @@ export const withCurrentLanguageFromHostPrefix: HOC = Component => (props: any) 
 };
 
 /**
- * withCurrentLanguageFromPath defines the current language
- * by reading the first section in the path, eg 'es' in https://example.com/es/some-page
+ * `withCurrentLanguageFromPath` defines the current language
+ * by reading the first section in the path, e.g., 'es' in https://example.com/es/some-page.
  *
  * @category Language Provider
  */
@@ -48,8 +48,8 @@ export const withCurrentLanguageFromPath: HOC = Component => (props: any) => {
 };
 
 /**
- * withLanguages HOC adds language provider to the component and implements default
- * mechanism of detecting which language is active (by firsh path section).
+ * `withLanguages` HOC adds language provider to the component and implements default
+ * mechanism of detecting which language is active (by first path section).
  * Should be applied on page wrapper component in order to provide necessary language info for
  * all nested components.
  *

--- a/packages/bodiless-i18n/src/LanguageProvider/LanguageProvider.tsx
+++ b/packages/bodiless-i18n/src/LanguageProvider/LanguageProvider.tsx
@@ -142,7 +142,7 @@ export const getLanguagesWithDefaultValues = (languages: Languages = []): Langua
 };
 
 /**
- * withLanguageProvider is a hoc that wrapps a component into a context provider
+ * withLanguageProvider is a HOC that wrapps a component into a context provider
  * which provides a list of sites' languages and allows to get and set the current (active)
  * language.
  *

--- a/packages/bodiless-i18n/src/LanguageProvider/LanguageProvider.tsx
+++ b/packages/bodiless-i18n/src/LanguageProvider/LanguageProvider.tsx
@@ -42,14 +42,14 @@ export const LanguageContext = createContext<LanguageContextType>({
 LanguageContext.displayName = 'LanguageContext';
 
 /**
- * Hook which can be used to use language contet
+ * Hook which can be used to use language content.
  *
  * @category Language Provider
  */
 export const useLanguageContext = () => useContext(LanguageContext);
 
 /**
- * getCurrentLanguage$ is a helper function that filters the list of languages and
+ * `getCurrentLanguage$` is a helper function that filters the list of languages and
  * defines which one is current.
  *
  * @param languages - list of language objects.
@@ -57,7 +57,7 @@ export const useLanguageContext = () => useContext(LanguageContext);
  * @returns current language object.
  *
  * @example will return true for all home pages of root and each language top
-   path/folder.
+ * path/folder.
  * ```js
  * const isHomePage = () => (
  *   useNode().node.pagePath === '/'
@@ -72,8 +72,9 @@ export const getCurrentLanguage$ = (languages: Languages): Language => (
 );
 
 /**
- * setCurrentLanguage$ is a helper function that sets isCurrent option to true
- * for the selected language, and set isCurrent: false for all other languages in the list.
+ * `setCurrentLanguage$` is a helper function that sets `isCurrent` option to
+ * true for the selected language, and sets `isCurrent: false` for all other
+ * languages in the list.
  *
  * @param langName - string
  * @param languages - list of language objects
@@ -99,8 +100,8 @@ export const setCurrentLanguage$ = (langName: string, languages: Languages): Lan
 };
 
 /**
- * getLanguagesWithDefaultValues is a helper function which ensures that all languages
- * in the passed list get all necessary default values.
+ * `getLanguagesWithDefaultValues` is a helper function which ensures that all
+ * languages in the passed list get all necessary default values.
  *
  * @param languages - list of language objects
  *
@@ -142,7 +143,7 @@ export const getLanguagesWithDefaultValues = (languages: Languages = []): Langua
 };
 
 /**
- * withLanguageProvider is a HOC that wrapps a component into a context provider
+ * `withLanguageProvider` is a HOC that wraps a component into a context provider
  * which provides a list of sites' languages and allows to get and set the current (active)
  * language.
  *

--- a/packages/bodiless-i18n/src/LanguageProvider/withLangDirProps.ts
+++ b/packages/bodiless-i18n/src/LanguageProvider/withLangDirProps.ts
@@ -19,7 +19,7 @@ export const useLangDirProps = () => {
 };
 
 /**
- * withLangDirProps hoc adds lang and dir attributes on a tag where applied.
+ * withLangDirProps HOC adds lang and dir attributes on a tag where applied.
  *
  * @params useLanguageSelectorProps hook
  * @see useLangDirProps

--- a/packages/bodiless-i18n/src/LanguageSelector/index.ts
+++ b/packages/bodiless-i18n/src/LanguageSelector/index.ts
@@ -45,7 +45,7 @@ export const useLanguageSelectorProps = () => {
 };
 
 /**
- * asLanguageSelector is a hoc which, when applied to a link,
+ * asLanguageSelector is a HOC which, when applied to a link,
  * turns it into a language toggler.
  *
  * @params useLanguageSelectorProps hook

--- a/packages/bodiless-layouts/__tests__/meta.test.tsx
+++ b/packages/bodiless-layouts/__tests__/meta.test.tsx
@@ -85,7 +85,7 @@ describe('withTerm', () => {
   });
 });
 describe('perserveMeta', () => {
-  it('if a hoc is wrapped in perserve meta the meta from before the hoc will be applied', () => {
+  it('if a HOC is wrapped in perserve meta the meta from before the HOC will be applied', () => {
     const Comp = withTitle('title')(React.Fragment);
     const Hoc = (Component:React.ComponentType) => () => <Component />;
     const perservedHOC = perserveMeta(Hoc as HOC);
@@ -108,7 +108,7 @@ describe('withFacet', () => {
     const hoc = withFacet('cat')('term')();
     expect(hoc(C).description).toBe('title\ncat: term\n');
   });
-  it('should apply any hoc passed in and respect meta data added before it.', () => {
+  it('should apply any HOC passed in and respect meta data added before it.', () => {
     const C = withTitle('title')(React.Fragment);
     const newHoc = <P extends object> (Component:React.ComponentType<P>) => {
       const B = (props:P) => <Component {...props} />;

--- a/packages/bodiless-layouts/doc/FlowContainer.md
+++ b/packages/bodiless-layouts/doc/FlowContainer.md
@@ -133,7 +133,7 @@ const SiteFlowContainer = withDesign(design)(FlowContainer);
 ```
 
 Use the `startWith` HOC to declare the base component and 
-then use any other hoc that will add to this specific version.
+then use any other HOC that will add to this specific version.
 
 > Note that we import the flow container from `@bodiless/layouts-ui`, not
 > directly from `@bodiless/layouts`.  All Bodiless components which

--- a/packages/bodiless-layouts/src/meta/index.tsx
+++ b/packages/bodiless-layouts/src/meta/index.tsx
@@ -29,27 +29,27 @@ function customizer(objValue:any, srcValue:any) {
 }
 const asPassThough = (Component:CTWM) => Component;
 /**
- * Creates an HOC use it to attach meta data in an HOC.
+ * Creates a HOC. Use it to attach metadata in a HOC.
  * @param Component The component to wrap.
  */
 const withOutMeta:HOC = Component => props => <Component {...props} />;
 /**
- * withMeta creates an HOC that will add meta data to a React Component
- * @param meta the data to be side loaded in to the component
+ * withMeta creates a HOC that will add metadata to a React Component.
+ * @param meta the data to be sideloaded into the component
  */
 const withMeta = (meta:Object): HOC => Component => {
   const newMeta = mergeWith({}, Component, meta, customizer);
   return Object.assign(withOutMeta(Component), newMeta) as ComponentWithMeta<any>;
 };
 /**
- * with Title returns an HOC that sideloads a title to a component
+ * withTitle returns a HOC that sideloads a title to a component.
  * @param title The title to be added
  */
 const withTitle = (title: string): HOC => Component => (
   withMeta({ title })(Component)
 );
 /**
- * withAppendTitle returns an HOC that appends to the sideload title of the component
+ * withAppendTitle returns a HOC that appends to the sideload title of the component.
  * Note it appends to the title with a space.
  * @param title The title to be appended
  */
@@ -61,14 +61,14 @@ const withAppendTitle = (newTitle: string): HOC => Component => {
   return withTitle(newTitle)(Component);
 };
 /**
- * withDisplayName returns an HOC that sideloads a displayName to a component
+ * withDisplayName returns a HOC that sideloads a `displayName` to a component.
  * @param displayName The displayName to be added
  */
 const withDisplayName = (displayName: string): HOC => Component => (
   withMeta({ displayName })(Component)
 );
 /**
- * withAppendDisplayName returns a HOC that appends a name to the sideloaded DisplayName
+ * withAppendDisplayName returns a HOC that appends a name to the sideloaded `DisplayName`.
  * @param newDisplayName the Display name to append
  */
 const withAppendDisplayName = (newDisplayName: string): HOC => Component => {
@@ -79,14 +79,14 @@ const withAppendDisplayName = (newDisplayName: string): HOC => Component => {
   return withDisplayName(newDisplayName)(Component);
 };
 /**
- * withDesc returns an HOC that sideloads the provided description to the component.
+ * withDesc returns a HOC that sideloads the provided description to the component.
  * @param description the description to add
  */
 const withDesc = (description: string): HOC => Component => (
   withMeta({ description })(Component)
 );
 /**
- * withAppendDesc returns an HOC that appends a description to the component sideload description.
+ * withAppendDesc returns a HOC that appends a description to the component sideload description.
  * @param newDescription the description to be appended
  */
 const withAppendDesc = (newDescription: string): HOC => Component => {
@@ -95,7 +95,7 @@ const withAppendDesc = (newDescription: string): HOC => Component => {
   return withDesc(description$)(Component);
 };
 /**
- * withTerm returns a function that then takes a term and that returns an HOC that side loads
+ * withTerm returns a function that then takes a term and that returns a HOC that sideloads
  * the category and term on to the component.
  * @param cat that category to use in adding a term
  * @param term the term to add
@@ -104,8 +104,8 @@ const withTerm = (cat: string) => (term: string):HOC => Component => (
   withMeta({ categories: { [cat]: [term] } })(Component)
 );
 /**
- * preserveMeta returns takes an HOC and returns another one that will apply the HOC but preserve
- * theMeta data from the component.
+ * perserveMeta takes a HOC and returns another one that will apply the HOC but preserve the
+ * metadata from the component.
  * @param hoc the HOC to wrap.
  */
 const perserveMeta = (hoc: HOC): HOC => Component => (
@@ -113,11 +113,11 @@ const perserveMeta = (hoc: HOC): HOC => Component => (
 );
 
 /**
- * withFacet is expect to be passed to an on function and takes a term and and HOC (using curring)
- *  and returns a Variant that can be used in the on function
+ * withFacet is expected to be passed to an on function and takes a term and and a HOC (using
+ * currying), and returns a Variant that can be used in the on function.
  * @param cat Category that the Component will be apart
  * @param term the Term in the Category associated with the Component
- * @param hocs the HOC to apply to the Component
+ * @param hocs the HOCs to apply to the Component
  */
 const withFacet = (cat: string) => (term: string) => (...hocs: HOC[]) => flowHoc(
   perserveMeta(flow(...hocs)),

--- a/packages/bodiless-layouts/src/meta/index.tsx
+++ b/packages/bodiless-layouts/src/meta/index.tsx
@@ -29,7 +29,7 @@ function customizer(objValue:any, srcValue:any) {
 }
 const asPassThough = (Component:CTWM) => Component;
 /**
- * Creates an HOC use it to attach meta data in an hoc.
+ * Creates an HOC use it to attach meta data in an HOC.
  * @param Component The component to wrap.
  */
 const withOutMeta:HOC = Component => props => <Component {...props} />;
@@ -104,16 +104,16 @@ const withTerm = (cat: string) => (term: string):HOC => Component => (
   withMeta({ categories: { [cat]: [term] } })(Component)
 );
 /**
- * preserveMeta returns takes an hoc and returns another one that will apply the hoc but preserve
+ * preserveMeta returns takes an HOC and returns another one that will apply the HOC but preserve
  * theMeta data from the component.
- * @param hoc the hoc to wrap.
+ * @param hoc the HOC to wrap.
  */
 const perserveMeta = (hoc: HOC): HOC => Component => (
   withMeta(Component)(hoc(Component) as ComponentType<any>)
 );
 
 /**
- * withFacet is expect to be passed to an on function and takes a term and and hoc (using curring)
+ * withFacet is expect to be passed to an on function and takes a term and and HOC (using curring)
  *  and returns a Variant that can be used in the on function
  * @param cat Category that the Component will be apart
  * @param term the Term in the Category associated with the Component

--- a/packages/bodiless-navigation/doc/Breadcrumbs.md
+++ b/packages/bodiless-navigation/doc/Breadcrumbs.md
@@ -4,7 +4,7 @@
 
  - `withBreadcrumbStore` - HOC that adds breadcrumb store and renders breadcrumbs.
  - `asBreadcrumbs` - HOC that adds breadcrumb props retrieved from breadcrumb store.
- - `AsBreadcrumb` - Creates an HOC which specifies that a wrapped component is a breadcrumb. The HOC will read link and title from the specified nodekeys and will push link and title to the breadcrumb store. Once the wrapped component is unmounted, the corresponding link and title are deleted from the breadcrumb store.
+ - `AsBreadcrumb` - Creates a HOC which specifies that a wrapped component is a breadcrumb. The HOC will read link and title from the specified nodekeys and will push link and title to the breadcrumb store. Once the wrapped component is unmounted, the corresponding link and title are deleted from the breadcrumb store.
  - `withEditableFinalTrail` - Enables rendering of the final trail for a Breadcrumb component with a provided Editors. Uses `withDefaultMenuTitleEditors` by default.
  - `withEditableStartingTrail` - Enables rendering of the starting trail for a Breadcrumb component with a provided Editors. Uses `withDefaultMenuTitleEditors` by default, pre-configured with a link to the home page.
  - `withBreadcrumbItemToken` - Applies supplied tokenDefs to the `StartingTrail`, `FinalTrail`, and `Title` all breadcrumb items.

--- a/packages/bodiless-navigation/doc/BurgerMenu.md
+++ b/packages/bodiless-navigation/doc/BurgerMenu.md
@@ -7,12 +7,12 @@ There are several burger-menu specific HOCs provided by `@bodiless/navigation` t
  - `asBurgerMenu` - Helper, which allows specifying which submenu types are configured by default for the Burger Menu. Transforms selected submenus into accordions.
  - `asBurgerMenuToggler` - HOC that adds an ability to toggle Burger Menu visibility on click. It extends the Component's default onClick handler if it exists. Note that the Component has to be inside a BurgerMenuContext.
  - `withBurgerMenuWrapper` - HOC that wraps the supplied Component in the burger menu chrome.
- - `withBurgerMenuProvider` - An HOC that wraps component with the `BurgerMenuContext` and creates two state variables: `isVisible` and `toggle()`.
+ - `withBurgerMenuProvider` - A HOC that wraps component with the `BurgerMenuContext` and creates two state variables: `isVisible` and `toggle()`.
  - `useBurgerMenuContext` - Hook, which can be used to access `BurgerMenuContext`.
  - `useIsBurgerMenuVisible` - Hook, which can be used to determine if a submenu is visible.
  - `useIsBurgerMenuHidden` - Hook, which can be used to determine if a submenu is hidden.
  - `useIsBurgerTransitionCompleted` - Hook which returns `true` if burger menu transitions are completed. It is almost identical to `useIsBurgerMenuHidden`, but waits untill the Burger Menu animations are completed before returning `true`. Usefull to avoid playing animations on initial component render.
- - `asSlideLeft` - An HOC that adds styles and transitions needed for a slide-in animation for the Burger menu.
+ - `asSlideLeft` - A HOC that adds styles and transitions needed for a slide-in animation for the Burger menu.
 
 ### Burger Menu Structure
 The Burger menu, as well as Bodiless Menu, is based on the List API. Burger menu is, in most cases, an extension of the site top menu. `withBurgerMenuWrapper` is used to wrap top-menu schema in the burger menu chrome.

--- a/packages/bodiless-navigation/src/Breadcrumbs/asBreadcrumb.tsx
+++ b/packages/bodiless-navigation/src/Breadcrumbs/asBreadcrumb.tsx
@@ -55,14 +55,14 @@ export type BreadcrumbSettings = {
 };
 
 /**
- * Creates an HOC which specifies that a wrapped component is a breadcrumb. The HOC
+ * Creates a HOC which specifies that a wrapped component is a breadcrumb. The HOC
  * will read link and title from the specified nodekeys and will push link and title
  * to the breadcrumb store. Once the wrapped component is unmounted, the corresponding link
  * and title are deleted from the breadcrumb store
  *
  * @param settings The title and link nodekeys defining where to locate the link and title nodes.
  *
- * @return An HOC which defines the wrapped component as a breadcrumb.
+ * @return A HOC which defines the wrapped component as a breadcrumb.
  */
 const asBreadcrumb = ({
   linkNodeKey,

--- a/packages/bodiless-next/src/NextImage/asNextImage.tsx
+++ b/packages/bodiless-next/src/NextImage/asNextImage.tsx
@@ -231,7 +231,7 @@ const asNextImage = flowHoc(
 );
 
 /**
- * hoc to remove props configured for NextImage in image data
+ * HOC to remove props configured for NextImage in image data
  *
  * it can be useful for cases when Next Image is not enabled for the image
  */

--- a/packages/bodiless-richtext/doc/RichTextEditor.md
+++ b/packages/bodiless-richtext/doc/RichTextEditor.md
@@ -236,7 +236,7 @@ The RichText Component is built on the [SlateJS](https://docs.slatejs.org/) fram
 (see @bodiless/Design System) that contain HOC to build out the component that are 
 available in the RichText Editor. Those are then presented to the user using both a 
 contextual hover menu as well as the standard menu. These items can be used by using 
-a set of HOC's. 
+a set of HOCs. 
 
 `startWith(Component)` lets us know which component should be part of the item
 

--- a/packages/bodiless-richtext/doc/RichTextEditor.md
+++ b/packages/bodiless-richtext/doc/RichTextEditor.md
@@ -2,7 +2,7 @@
 
 The Rich Text Editor allows you to easily add text content to your site. By
 default there are three options for the Rich Text Editor: Simple, Basic, and
-Full. The Rich Text Editor is also a sub component of many higher order components. 
+Full. The Rich Text Editor is also a sub component of many higher-order components. 
 You can add text to a page on your site via the editor component or you
 can add a component or components that contain text, which make use of the
 editor (e.g. Card, Accordion, etc).

--- a/packages/bodiless-richtext/src/RichTextItemSetters.bl-edit.tsx
+++ b/packages/bodiless-richtext/src/RichTextItemSetters.bl-edit.tsx
@@ -33,7 +33,7 @@ type CTWM = ComponentOrTag<any>;
 
 const withOutMeta = <P extends Object> (Component:CTWM) => (props:P) => (<Component {...props} />);
 /**
- * withMeta creates an HOC that will add meta data to a React Component
+ * withMeta creates a HOC that will add meta data to a React Component
  * @param meta the data to be side loaded in to the component
  */
 const withMeta = (meta:Object) => (Component:CTWM) => {

--- a/packages/bodiless-richtext/src/core/Content.bl-edit.tsx
+++ b/packages/bodiless-richtext/src/core/Content.bl-edit.tsx
@@ -101,7 +101,7 @@ const useIsEmptyEditor = () => {
 const useIsEditableAndEmpty = () => useEditToggle() && useIsEmptyEditor();
 
 /**
- * hoc that can be applied to Editable based component
+ * HOC that can be applied to Editable based component
  * adds styles to slate wrapper in order to solve a placeholder problem
  * described in https://github.com/johnsonandjohnson/Bodiless-JS/issues/481
  */

--- a/packages/bodiless-search/doc/Search.md
+++ b/packages/bodiless-search/doc/Search.md
@@ -282,7 +282,7 @@ You can use a `no-search` HOC around anything you don't want indexed.
 
 **Example:**
 
-Build an HOC component that can be used to wrap any content/components:
+Build a HOC component that can be used to wrap any content/components:
 
 ```tsx
 type Props = DesignableComponentsProps<NoSearchComponents> & HTMLProps<HTMLElement>;

--- a/packages/bodiless-tokens/README.md
+++ b/packages/bodiless-tokens/README.md
@@ -10,7 +10,7 @@ better understand the general patterns at work.
 
 At a high level, this API expresses *Design Tokens* as React higher-order
 components, and provides utilities which allow you to apply them to both simple
-elements and compound components. In most cases, the design token HOC's leverage
+elements and compound components. In most cases, the design token HOCs leverage
 "atomic" or "functional" CSS, defining units of design as collections of utility
 classes.
 
@@ -76,7 +76,7 @@ const withComposedToken = flowHoc(
 However, there are a few key differences:
 
 - Metadata (static properties) attached to a component are prppagated through
-  the chain of HOC's.
+  the chain of HOCs.
 - If you are using Typescript, the type of the parameters is constrained to be an
   HOC (or an object specifying metadata, see below).
 - There is an optional overload to accept a "TokenMeta" object which consists of
@@ -507,7 +507,7 @@ const StandardCard = withDesign({
 
 We can also use the `startWith()` HOC, instead of replacing the whole component, it will only replace the base component but still use any hoc that might have wrapped it.
 
-As with FClasses, HOC's created via `withDesign()` are themselves reusable, so
+As with FClasses, HOCs created via `withDesign()` are themselves reusable, so
 we can write:
 
 ``` js
@@ -519,7 +519,7 @@ const StandardPinkCard = asStandardCard(PinkCard);
 const StandardRedCard = asStandardCard(RedCard);
 ```
 
-And, also as with FClasses, the HOC's can be composed:
+And, also as with FClasses, the HOCs can be composed:
 
 ``` js
 const StandardPinkAndGreenCard = flowRight(

--- a/packages/bodiless-tokens/README.md
+++ b/packages/bodiless-tokens/README.md
@@ -75,9 +75,9 @@ const withComposedToken = flowHoc(
 
 However, there are a few key differences:
 
-- Metadata (static properties) attached to a component are prppagated through
+- Metadata (static properties) attached to a component are propagated through
   the chain of HOCs.
-- If you are using Typescript, the type of the parameters is constrained to be an
+- If you are using TypeScript, the type of the parameters is constrained to be a
   HOC (or an object specifying metadata, see below).
 - There is an optional overload to accept a "TokenMeta" object which consists of
   metadata which should be attached to the token.

--- a/packages/bodiless-tokens/README.md
+++ b/packages/bodiless-tokens/README.md
@@ -505,7 +505,7 @@ const StandardCard = withDesign({
 })(BasicCard);
 ```
 
-We can also use the `startWith()` HOC, instead of replacing the whole component, it will only replace the base component but still use any hoc that might have wrapped it.
+We can also use the `startWith()` HOC, instead of replacing the whole component, it will only replace the base component but still use any HOC that might have wrapped it.
 
 As with FClasses, HOCs created via `withDesign()` are themselves reusable, so
 we can write:

--- a/packages/bodiless-tokens/README.md
+++ b/packages/bodiless-tokens/README.md
@@ -269,7 +269,7 @@ const SpecialGreenCallout = flow(
 )(Callout);
 ```
 
-The higher order components are reusable, so for example:
+The higher-order components are reusable, so for example:
 
 ```
 const withRedCalloutBorder = flow(
@@ -345,7 +345,7 @@ This is usefule when you don't have access to the original, unstyled variant of 
 
 ## The Design API
 
-The Design API provides a mechanism for applying higher order components (including those
+The Design API provides a mechanism for applying higher-order components (including those
 provided by the FClasses API) to individual elements within a compound component.
 
 ### Exposing the Design API

--- a/packages/bodiless-tokens/src/TokenEditor/TokenEditor.tsx
+++ b/packages/bodiless-tokens/src/TokenEditor/TokenEditor.tsx
@@ -58,7 +58,7 @@ const TokenEditorClean = designable<TokenEditorComponents>(
 /**
  * @private
  *
- * Creates an HOC which wraps the target component with the node belonging to
+ * Creates a HOC which wraps the target component with the node belonging to
  * the first item in the flow container whose data is located at the specified
  * node key.
  *

--- a/packages/bodiless-tokens/src/TokenEditor/withTokenEditorComponent.tsx
+++ b/packages/bodiless-tokens/src/TokenEditor/withTokenEditorComponent.tsx
@@ -43,7 +43,7 @@ const useNodeKeyHash = () => {
 };
 
 /**
- * Creates an HOC which sets the target component for a token editor.
+ * Creates a HOC which sets the target component for a token editor.
  * This is the component to which the tokens in the editor will apply.
  *
  * @param def
@@ -53,7 +53,7 @@ const useNodeKeyHash = () => {
  * Optional design to apply to the token panel for this component.
  *
  * @returns
- * An HOC which adds the specifie component
+ * A HOC which adds the specifie component
  */
 const withTokenEditorComponent = (
   def: TokenEditorComponentDef,
@@ -95,7 +95,7 @@ const withTokenEditorComponent = (
 };
 
 /**
- * Creates an HOC which can be used to add a token editor to a flow container.
+ * Creates a HOC which can be used to add a token editor to a flow container.
  *
  * @param def
  * The definition of the component to be added.

--- a/packages/bodiless-tokens/src/TokenPanelPane.tsx
+++ b/packages/bodiless-tokens/src/TokenPanelPane.tsx
@@ -126,7 +126,7 @@ const useMenuOptions = (props: TokenSelectorProps & { tokenPaneTitle?: string })
 };
 
 /**
- * Creates an HOC which enhances a component by supplying a UI for selecting
+ * Creates a HOC which enhances a component by supplying a UI for selecting
  * tokens to apply to that component.
  *
  * The component so enhanced is given an 'availableTokens' prop which is an

--- a/packages/bodiless-tokens/src/withTokenPanelButton.tsx
+++ b/packages/bodiless-tokens/src/withTokenPanelButton.tsx
@@ -25,7 +25,7 @@ export type TokenPanelButtonDefinition = {
 };
 
 /**
- * Creates an HOC which adds a toolbar or context menu button to a component. This will
+ * Creates a HOC which adds a toolbar or context menu button to a component. This will
  * bring up a token panel which will allow editing tokens for any component in the active
  * context trail which has beenwrapped by `withTokenPanelPane`.
  *

--- a/packages/fclasses/README.md
+++ b/packages/fclasses/README.md
@@ -275,7 +275,7 @@ const SpecialGreenCallout = flow(
 )(Callout);
 ```
 
-The higher order components are reusable, so for example:
+The higher-order components are reusable, so for example:
 
 ```
 const withRedCalloutBorder = flow(
@@ -351,7 +351,7 @@ This is useful when you don't have access to the original, unstyled variant of t
 
 ## The Design API
 
-The Design API provides a mechanism for applying higher order components (including those
+The Design API provides a mechanism for applying higher-order components (including those
 provided by the FClasses API) to individual elements within a compound component.
 
 ### Exposing the Design API

--- a/packages/fclasses/README.md
+++ b/packages/fclasses/README.md
@@ -516,7 +516,7 @@ const StandardCard = withDesign({
 ```
 
 We can also use the `startWith()` HOC, instead of replacing the whole component,
-it will only replace the base component but still use any hoc that might have
+it will only replace the base component but still use any HOC that might have
 wrapped it.
 
 As with FClasses, HOCs created via `withDesign()` are themselves reusable, so
@@ -615,7 +615,7 @@ the toggle state from the context, and applies the classes only if toggled on.
 
 ### Modifying props conditionally
 
-You can use the similar `addPropsIf` hoc to add props as well as styles to a
+You can use the similar `addPropsIf` HOC to add props as well as styles to a
 component conditioonally:
 
 ```js

--- a/packages/fclasses/README.md
+++ b/packages/fclasses/README.md
@@ -14,7 +14,7 @@ better understand the general patterns at work.
 
 At a high level, this API expresses *Design Tokens* as React higher-order
 components, and provides utilities which allow you to apply them to both simple
-elements and compound components. In most cases, the design token HOC's leverage
+elements and compound components. In most cases, the design token HOCs leverage
 "atomic" or "functional" CSS, defining units of design as collections of utility
 classes.
 
@@ -82,7 +82,7 @@ const withComposedToken = flowHoc(
 However, there are a few key differences:
 
 - Metadata (static properties) attached to a component are prppagated through
-  the chain of HOC's.
+  the chain of HOCs.
 - If you are using Typescript, the type of the parameters is constrained to be an
   HOC (or an object specifying metadata, see below).
 - There is an optional overload to accept a "TokenMeta" object which consists of
@@ -519,7 +519,7 @@ We can also use the `startWith()` HOC, instead of replacing the whole component,
 it will only replace the base component but still use any hoc that might have
 wrapped it.
 
-As with FClasses, HOC's created via `withDesign()` are themselves reusable, so
+As with FClasses, HOCs created via `withDesign()` are themselves reusable, so
 we can write:
 
 ``` js
@@ -531,7 +531,7 @@ const StandardPinkCard = asStandardCard(PinkCard);
 const StandardRedCard = asStandardCard(RedCard);
 ```
 
-And, also as with FClasses, the HOC's can be composed:
+And, also as with FClasses, the HOCs can be composed:
 
 ``` js
 const StandardPinkAndGreenCard = flowRight(

--- a/packages/fclasses/README.md
+++ b/packages/fclasses/README.md
@@ -81,13 +81,13 @@ const withComposedToken = flowHoc(
 
 However, there are a few key differences:
 
-- Metadata (static properties) attached to a component are prppagated through
+- Metadata (static properties) attached to a component are propagated through
   the chain of HOCs.
-- If you are using Typescript, the type of the parameters is constrained to be an
+- If you are using TypeScript, the type of the parameters is constrained to be a
   HOC (or an object specifying metadata, see below).
 - There is an optional overload to accept a "TokenMeta" object which consists of
   metadata which should be attached to the token.
-- We intruduce a special kind of Token known as a "Filter". See more
+- We introduce a special kind of Token known as a "Filter." See more
   below.
 
 ### Metadata and Filters

--- a/packages/fclasses/__tests__/Design.test.tsx
+++ b/packages/fclasses/__tests__/Design.test.tsx
@@ -123,7 +123,7 @@ describe('withDesign', () => {
     expect(wrapper.find('#bar').last().props().className).toBe('innerB');
     const Test1 = withDesign(outer)(Test);
     const wrapper1 = mount(<Test1 />);
-    // have to use last() because each hoc adds a component that is found
+    // have to use last() because each HOC adds a component that is found
     expect(wrapper1.find('#foo').last().props().className).toBe('outerC innerA');
     expect(wrapper1.find('#bar').last().props().className).toBe('outerD innerB');
     expect(wrapper1.find('#baz').last().props().className).toBe('outerE');
@@ -264,7 +264,7 @@ describe('withShowDesignKeys', () => {
       expect(wrapper.find('section#inner')).toHaveLength(1);
     });
 
-    it('Replaces a component without altering a prior hoc', () => {
+    it('Replaces a component without altering a prior HOC', () => {
       const Test = withDesign({
         Component: flow(
           (C: any) => (props: any) => <C {...props} foo="bar" />,
@@ -303,7 +303,7 @@ describe('replaceWith', () => {
     expect(wrapper.find('span#test')).toHaveLength(1);
   });
 
-  it('erases previous hocs', () => {
+  it('erases previous HOCs', () => {
     const TestBase = withDesign({
       Component: (C: any) => (props: any) => <C {...props} foo="bar" />,
     })(TestDesignable);

--- a/packages/fclasses/__tests__/Tokens.test.tsx
+++ b/packages/fclasses/__tests__/Tokens.test.tsx
@@ -66,7 +66,7 @@ describe('flowHoc', () => {
 
   describe('HOC order', () => {
     const Base = () => <></>;
-    it('Applies hocs left to right', () => {
+    it('Applies HOCs left to right', () => {
       const asTest = flowHoc(
         addProp('foo'),
         addProp('foo', 'bar'),
@@ -76,7 +76,7 @@ describe('flowHoc', () => {
       expect(wrapper.find(Base).prop('foo')).toBe('bar');
     });
 
-    it('Applies hocs left to right including nested tokens', () => {
+    it('Applies HOCs left to right including nested tokens', () => {
       const asFoo = flowHoc(
         addProp('foo'),
       );

--- a/packages/fclasses/__tests__/replaceable.test.tsx
+++ b/packages/fclasses/__tests__/replaceable.test.tsx
@@ -28,7 +28,7 @@ describe('replaceable', () => {
     const wrapper2 = mount(<Sub />);
     expect(wrapper2.text()).toBe('replacement');
   });
-  it('should replace a component and still keep hocs', () => {
+  it('should replace a component and still keep HOCs', () => {
     type Props = {
       text?: string,
     };

--- a/packages/fclasses/doc/Types.md
+++ b/packages/fclasses/doc/Types.md
@@ -1,11 +1,11 @@
-# Tokens and Higher Order Components in Typescript
+# Tokens and Higher-Order Components in Typescript
 
-The Bodiless design system expresses tokens as React higher order components,
+The Bodiless design system expresses tokens as React higher-order components,
 which can be a bit tricky to type correctly. Fortunately, Bodiless exposes
 a number of utility types which simplify the process.
 
 Before proceeding, you should have a solid understanding of
-[higher order components in React](https://reactjs.org/docs/higher-order-components.html)
+[higher-order components in React](https://reactjs.org/docs/higher-order-components.html)
 as well as the basics of how to type them traditionally.
 [This excellent article by James Ravenscroft](https://medium.com/@jrwebdev/react-higher-order-component-patterns-in-typescript-42278f7590fb)
 is a good introduction to the latter. You should also have read and be familiar
@@ -14,9 +14,9 @@ with the BodilessJS documentation on
 
 ## A few terms to begin with:
 
-- **Higher Order Component** A function which takes one component and returns
+- **Higher-Order Component** A function which takes one component and returns
   a new one.
-- **Token** A unit of design or behavior, expressed as a higher order component.
+- **Token** A unit of design or behavior, expressed as a higher-order component.
 - **Base Component** The component to which a token or HOC applies.
 - **Enhanced Component** The component returned by a token or HOC.
 - **Enhancer** A token or HOC which introduces new props in the enhanced

--- a/packages/fclasses/doc/Types.md
+++ b/packages/fclasses/doc/Types.md
@@ -1,40 +1,36 @@
-# Tokens and Higher-Order Components in Typescript
+# Tokens and Higher-Order Components in TypeScript
 
-The Bodiless design system expresses tokens as React higher-order components,
-which can be a bit tricky to type correctly. Fortunately, Bodiless exposes
-a number of utility types which simplify the process.
+The Bodiless design system expresses tokens as React higher-order components, which can be a bit
+tricky to type correctly. Fortunately, Bodiless exposes a number of utility types which simplify the
+process.
 
-Before proceeding, you should have a solid understanding of
-[higher-order components in React](https://reactjs.org/docs/higher-order-components.html)
-as well as the basics of how to type them traditionally.
-[This excellent article by James Ravenscroft](https://medium.com/@jrwebdev/react-higher-order-component-patterns-in-typescript-42278f7590fb)
-is a good introduction to the latter. You should also have read and be familiar
-with the BodilessJS documentation on
-[the FClasses Design API](../Architecture/FClasses).
+Before proceeding, you should have a solid understanding of [higher-order components in
+React](https://legacy.reactjs.org/docs/higher-order-components.html ':target=_blank'), as well as
+the basics of how to type them traditionally. [This excellent article by James
+Ravenscroft](https://medium.com/@jrwebdev/react-higher-order-component-patterns-in-typescript-42278f7590fb
+':target=_blank') is a good introduction to the latter. You should also have read and be familiar
+with the BodilessJS documentation on the [FClasses Design API](../Architecture/FClasses).
 
-## A few terms to begin with:
+## A Few Terms to Get Started
 
-- **Higher-Order Component** A function which takes one component and returns
-  a new one.
-- **Token** A unit of design or behavior, expressed as a higher-order component.
-- **Base Component** The component to which a token or HOC applies.
-- **Enhanced Component** The component returned by a token or HOC.
-- **Enhancer** A token or HOC which introduces new props in the enhanced
-  component.
-- **Injector** A token or HOC which provides a value for one of the base
-  component's props. That prop becomes optional in the enhanced component.
-- **Token Generator** A function which takes some parameters and returns a token
-  or HOC.
+- **Higher-Order Component:** A function which takes one component and returns a new one.
+- **Token:** A unit of design or behavior, expressed as a higher-order component.
+- **Base Component:** The component to which a token or HOC applies.
+- **Enhanced Component:** The component returned by a token or HOC.
+- **Enhancer:** A token or HOC which introduces new props in the enhanced component.
+- **Injector:** A token or HOC which provides a value for one of the base component's props. That
+  prop becomes optional in the enhanced component.
+- **Token Generator:** A function which takes some parameters and returns a token or HOC.
 
-> Note the terms 'injector' and 'enhancer' are borrowed from
-> [this excellent article](https://medium.com/@jrwebdev/react-higher-order-component-patterns-in-typescript-42278f7590fb)
-> by James Ravenscroft.
+?> **Note:** the terms 'enhancer' and 'injector' are borrowed from [this excellent
+article](https://medium.com/@jrwebdev/react-higher-order-component-patterns-in-typescript-42278f7590fb
+':target=_blank') by James Ravenscroft.
 
 ## Generic Tokens
 
-The simplest type of token is one which does not alter the props of the base
-component.  For this we use the `Token` type. For example, if we have the
-following base types:
+The simplest type of token is one which does not alter the props of the base component. For this, we
+use the `Token` type. For example, if we have the following base types:
+
 ```ts
 type BaseProps = {
   foo: string,
@@ -49,39 +45,40 @@ const Base2: FC<Base2Props> = () => null;
 
 const Base3: FC<BaseProps & Base2Props> = () => null;
 ```
-Then we might define a generic token generator producing a token which inserts
-a child as:
+
+Then we might define a generic token generator producing a token which inserts a child as:
+
 ```ts
 const withChild = (Child: ComponentOrTag<any>): Token => C => {
   const WithChild: FC<any> = props => <C {...props}><Child /></C>;
   return WithChild;
 };
 ```
-This will ensure that the enhanced component has the same signature
-as the base component:
+
+This will ensure that the enhanced component has the same signature as the base component:
+
 ```ts
 const A1 = withChild('span')(Base);
 const A1T1 = <A1 foo="foo" bar="bar" />;
-// @ts-expect-error missing prop bar
+// @ts-expect-error Missing prop `bar`.
 const A1T2 = <A1 foo="foo" />;
-// @ts-expect-error prob baz is undefined
+// @ts-expect-error Prop `baz` is undefined.
 const A1T3 = <A1 foo="foo" bar="bar" baz="baz" />;
 ```
+
 Some things to note:
-- We give the enhanced component an explicit name (`WithChild`) so that it is
-  easily identifiable in the React debugger.
-- We do not explicitly type the base component parameter (`C`); this is handled
-  by the `Token` type.
-- We type the enhanced component as `FC<any>`. Again the `Token` type will assure
-  that the actual type of the enhanced component will be correctly inferred when
-  the token is applied.
+
+- We give the enhanced component an explicit name (`WithChild`) so that it is easily identifiable in
+  the React debugger.
+- We do not explicitly type the base component parameter (`C`); this is handled by the `Token` type.
+- We type the enhanced component as `FC<any>`. Again, the `Token` type will assure that the actual
+  type of the enhanced component will be correctly inferred when the token is applied.
 
 ## Constrained Base Components
 
-Sometimes it is useful to constraint the type of component to which a token
-can be applied (for example, if the token modifies a prop which it will then
-pass on to the base component).  This can be accomplished by supplying a
-type parameter to the `Token` type. Consider the following token:
+Sometimes it is useful to constrain the type of component to which a token can be applied (for
+example, if the token modifies a prop that it will then pass on to the base component). This can be
+accomplished by supplying a type parameter to the `Token` type. Consider the following token:
 
 ```ts
 const withLowercaseFoo: Token<BaseProps> = C => {
@@ -92,23 +89,23 @@ const withLowercaseFoo: Token<BaseProps> = C => {
   return WithLowercaseFoo;
 };
 ```
-Now we will get a type error if we try to apply this to a component whose props
-do not match or extend `BaseProps`:
+
+Now we will get a type error if we try to apply this to a component whose props do not match or
+extend `BaseProps`:
+
 ```ts
-// @ts-expect-error Base2 not assignable to Base1
+// @ts-expect-error `Base2` not assignable to `Base1`.
 const B2 = withLowercaseFoo(Base2);
 ```
 
-It is important to note here that we still type the enhanced component as
-`FC<any>`. This is necessary so that its actual type will be inferred
-correctly when it is applied.  However, we know (due to the constraint),
-that its props will at least extend `BaseProps`, so it is safe to cast
-them, or (as here), type them in the function declaration.
+It is important to note here that we still type the enhanced component as `FC<any>`. This is
+necessary so that its actual type will be inferred correctly when it is applied. However, we know
+(due to the constraint), that its props will at least extend `BaseProps`, so it is safe to cast
+them, or (as here) type them in the function declaration.
 
 ## Enhancers
 
-If our token produces a component which requires new props, we can use the
-`Enhancer` type:
+If our token produces a component which requires new props, we can use the `Enhancer` type:
 
 ```ts
 type ToggleProps = { toggle: boolean };
@@ -121,23 +118,24 @@ const withToggle: Enhancer<ToggleProps> = C => {
   return WithToggle;
 };
 ```
-When this is applied, the prop types of the enhanced component will include
-the new prop:
+
+When this is applied, the prop types of the enhanced component will include the new prop:
 
 ```ts
 const C1 = withToggle(Base);
 // The original props and the new prop are all accepted.
 const C1T1 = <C1 toggle foo="foo" bar="bar" />;
-// @ts-expect-error An extraneous prop is not accepted
+// @ts-expect-error An extraneous prop is not accepted.
 const C1T2 = <C1 toggle foo="foo" bar="bar" baz="baz" />;
 // @ts-expect-error And the new prop is now required.
 const C1T3 = <C1 foo="foo" bar="bar" />;
 ```
-As before, it is safe to cast the props to the type we expect, this time because
-they have been added to the signature of the enhanced component.
 
-As with generic tokens, it is possible to constrain the prop types
-of the base component when using an Enhancer:
+As before, it is safe to cast the props to the type we expect; this time because they have been
+added to the signature of the enhanced component.
+
+As with generic tokens, it is possible to constrain the prop types of the base component when using
+an Enhancer:
 
 ```ts
 const withToggledFoo: Enhancer<ToggleProps, BaseProps> = C => {
@@ -148,18 +146,17 @@ const withToggledFoo: Enhancer<ToggleProps, BaseProps> = C => {
   return WithToggledFoo;
 };
 ...
-// @ts-expect-error Base2 is not assignable to Base
+// @ts-expect-error `Base2` is not assignable to `Base`.
 const C2 = withToggledFoo(Base2);
 ```
 
 ## Injectors
 
-The last type of token we consider is one which provides a value for a prop
-of the underlying component. Here we can use the `Injector` utility, which
-will do two things:
+The last type of token we consider is one which provides a value for a prop of the underlying
+component. Here we can use the `Injector` utility, which will do two things:
+
 - Make any injected props optional in the enhanced component.
-- Constrain the token to apply only to components whose prop types include
-  the injected props.
+- Constrain the token to apply only to components whose prop types include the injected props.
 
 ```ts
 type FooProps = Pick<BaseProps, 'foo'>;
@@ -168,6 +165,7 @@ const withFoo = (value: string): Injector<FooProps> => C => {
   return WithFoo;
 };
 ```
+
 Here:
 
 ```ts
@@ -175,24 +173,25 @@ Here:
 const D1T1 = <D1 foo="foo" bar="bar" />;
 // But the injected prop is optional.
 const D1T2 = <D1 bar="bar" />;
-// @ts-expect-error while the non-injected prop is still required.
+// @ts-expect-error While the non-injected prop is still required.
 const D1T3 = <D1 foo="foo" />;
-// @ts-expect-error An undefined prop can't be supplied
+// @ts-expect-error An undefined prop can't be supplied.
 const D1T4 = <D1 baz="baz" />;
-// @ts-expect-error and the token is constrained to a component which accepts injected props
+// @ts-expect-error And the token is constrained to a component which accepts
+// injected props.
 const D2 = withFoo('hello')(Base2);
 const D3 = withFoo('hello')(Base3); // ok
 const Base4: FC<FooProps> = () => null;
 const D4 = withFoo('hello')(Base4); // ok
 ```
 
-## Type inference for composed tokens
+## Type Inference for Composed Tokens
 
 ### `flowHoc`
 
-The Bodiless `flowHoc` composition utility will produce a token which can
-correctly infer the type of an enhanced component based on the signature of the
-base component and the types of the composed tokens.
+The Bodiless `flowHoc` composition utility will produce a token which can correctly infer the type
+of an enhanced component based on the signature of the base component and the types of the composed
+tokens.
 
 Given:
 
@@ -209,26 +208,28 @@ Given:
   );
   const R = composed(Base);
 ```
-then
+
+Then:
+
 ```ts
-// props of the base component and enhanced component are all accepted.
+// Props of the base component and enhanced component are all accepted.
 const T1 = <R foo="foo" bar="bar" baz="baz" />;
 // Injected prop is not required.
 const T2 = <R bar="bar" baz="baz" />;
-// @ts-expect-error Enhanced prop is required
+// @ts-expect-error Enhanced prop is required.
 const T3 = <R foo="foo" bar="bar" />;
-// @ts-expect-error Non-injected base prop is still required
+// @ts-expect-error Non-injected base prop is still required.
 const T4 = <R foo="foo" baz="bar" />;
-// @ts-expect-error Token is constrained by constraint of first token
+// @ts-expect-error Token is constrained by constraint of first token.
 const R2 = composed(Base2);
 ```
 
 ### `flowif`
-The `flowIf` composition utility allows you to apply tokens only if a certain
-condition is met.  It passes received props to the condition hook. If the
-condition requires a prop which does not exist on the base component, we want
-to be sure that the enhanced component requires that prop. `flowIf` will
-correctly infer this from the type of the condition:
+
+The `flowIf` composition utility allows you to apply tokens only if a certain condition is met. It
+passes received props to the condition hook. If the condition requires a prop which does not exist
+on the base component, we want to be sure that the enhanced component requires that prop. `flowIf`
+will correctly infer this from the type of the condition:
 
 ```ts
 type ConditionProps = {
@@ -240,12 +241,13 @@ const composed = flowIf(useCondition)(
 );
 const R = composed(Base);
 ...
-// @ts-expect-error property "test" is missing
+// @ts-expect-error Property `test` is missing.
 const T1 = <R foo="foo" bar="bar" />;
 ```
 
-`flowIf` is generic, so you can explicitly state type of the props which
-should be added to the enhanced component:
+`flowIf` is generic, so you can explicitly state the type of the props which should be added to the
+enhanced component:
+
 ```ts
 const flowIfTest = flowIf<ConditionProps>({ test } => test);
 ```

--- a/packages/fclasses/src/Design.tsx
+++ b/packages/fclasses/src/Design.tsx
@@ -193,13 +193,13 @@ export const extendDesignable = (transformDesign: TransformDesign = identity) =>
 
 /**
  * Makes a component "designable". A designable component defines a set of constituent
- * sub-components which can be modified by applying one or more HOC's.  You specify the
- * HOC's to apply to each sub-component via the `withDesign` HOC.
+ * sub-components which can be modified by applying one or more HOCs.  You specify the
+ * HOCs to apply to each sub-component via the `withDesign` HOC.
  *
  * @param startComponents
  * An object defining the set of constituent subcomponents. Each key
  *   is a string which identifies the component. Each value is the component itself, which
- *   will be modified by any HOC's provided by withDesign.
+ *   will be modified by any HOCs provided by withDesign.
  *
  * @return
  * An HOC which yields a designable version of the component to which it is applied.

--- a/packages/fclasses/src/Design.tsx
+++ b/packages/fclasses/src/Design.tsx
@@ -31,7 +31,7 @@ import { withTransformer } from './Transformer';
 import { as, extendDesign } from './tokenSpec';
 
 /**
- * Creates an HOC that will attach a displayName to an object.
+ * Creates a HOC that will attach a displayName to an object.
  *
  * @param name
  * The displayName to add.
@@ -114,7 +114,7 @@ export const applyDesign = <C extends DesignableComponents> (
  * The design to apply
  *
  * @return
- * An HOC which applies the speciried design to the wrapped component after
+ * A HOC which applies the speciried design to the wrapped component after
  * all other designes.
  *
  * @category Design API

--- a/packages/fclasses/src/Design.tsx
+++ b/packages/fclasses/src/Design.tsx
@@ -202,7 +202,7 @@ export const extendDesignable = (transformDesign: TransformDesign = identity) =>
  *   will be modified by any HOCs provided by withDesign.
  *
  * @return
- * An HOC which yields a designable version of the component to which it is applied.
+ * A HOC which yields a designable version of the component to which it is applied.
  *
  * @category Design API
  */

--- a/packages/fclasses/src/addClasses.tsx
+++ b/packages/fclasses/src/addClasses.tsx
@@ -120,7 +120,7 @@ const addClassesIf = modifyClassesIf('add');
  * A string or array of classes to add.
  *
  * @returns
- * An HOC which adds the specified classes to a [[stylable]] component.
+ * A HOC which adds the specified classes to a [[stylable]] component.
  *
  * @category FClasses API
  */

--- a/packages/fclasses/src/addProps.tsx
+++ b/packages/fclasses/src/addProps.tsx
@@ -47,7 +47,7 @@ export const addPropsIf = <B extends object>(
     };
 
 /**
- * Creates an HOC that injects the specified props to the base component.
+ * Creates a HOC that injects the specified props to the base component.
  *
  * Any props passed to the resulting component will take precedence
  * over those specified here.
@@ -71,11 +71,11 @@ export const addProps = <B extends object, I extends NotAFunction>(
 ) => addPropsIf<B>(() => true)<I>(propsToAdd);
 
 /**
- * Creates an HOC which strips all but the specified props.
+ * Creates a HOC which strips all but the specified props.
  *
  * @param keys A list of the prop-names to keep.
  *
- * @return An HOC which will strip all but the specified props.
+ * @return A HOC which will strip all but the specified props.
  *
  * @category HOC Utility
  */
@@ -106,7 +106,7 @@ export const withoutProps = <A extends object>(
  * ...keys The names of the props to remove.
  *
  * @return
- * An HOC which accepts a component and returns another which accepts the
+ * A HOC which accepts a component and returns another which accepts the
  * specified props and removes them before rendering.
  *
  * Note this expects a type parameter specifying the props which will be

--- a/packages/fclasses/src/addProps.tsx
+++ b/packages/fclasses/src/addProps.tsx
@@ -26,7 +26,7 @@ type NotAFunction = { [key: string]: any, bind?: never, call?: never };
  * A custom React hook which will be invoked to determine whether the props should be added.
  *
  * @returns
- * A function with the same signature as `addProps`
+ * A function with the same signature as `addProps`.
  *
  * @see addProps
  *
@@ -54,7 +54,7 @@ export const addPropsIf = <B extends object>(
  *
  * @param propsToAdd
  * Object containing props and values which will be passed to the base component,
- * or a function which recevies the original props and returns such an object.
+ * or a function which receives the original props and returns such an object.
  *
  * @return
  * A component which renders the base component with the added props.
@@ -87,7 +87,7 @@ export const withOnlyProps = <Q extends object>(...keys: string[]) => (
 );
 
 /**
- * Alias for [[removeProps]]
+ * Alias for [[removeProps]].
  *
  * @category HOC Utility
  */
@@ -110,7 +110,7 @@ export const withoutProps = <A extends object>(
  * specified props and removes them before rendering.
  *
  * Note this expects a type parameter specifying the props which will be
- * removed. For example
+ * removed. For example:
  * ```
  * type Foo = {
  *   A: string,
@@ -132,14 +132,14 @@ export const withoutProps = <A extends object>(
 export const removeProps = withoutProps;
 
 /**
- * Alias for [[addProps]]
+ * Alias for [[addProps]].
  *
  * @category HOC Utility
  */
 export const withProps = addProps;
 
 /**
- * Alias for [[addPropsIf]]
+ * Alias for [[addPropsIf]].
  *
  * @category HOC Utility
  */
@@ -148,7 +148,7 @@ export const withPropsIf = addPropsIf;
 /**
  * A React `Fragment` which ensures that all invalid props are removed.
  * This is useful in conjunction with [[replaceWith]], [[startWith]]
- * or [[remove]], so that any props added by otehr HOCs will be discarded.
+ * or [[remove]], so that any props added by other HOCs will be discarded.
  *
  * @example
  * ```

--- a/packages/fclasses/src/addProps.tsx
+++ b/packages/fclasses/src/addProps.tsx
@@ -148,7 +148,7 @@ export const withPropsIf = addPropsIf;
 /**
  * A React `Fragment` which ensures that all invalid props are removed.
  * This is useful in conjunction with [[replaceWith]], [[startWith]]
- * or [[remove]], so that any props added by otehr HOC's will be discarded.
+ * or [[remove]], so that any props added by otehr HOCs will be discarded.
  *
  * @example
  * ```

--- a/packages/fclasses/src/flowHoc.tsx
+++ b/packages/fclasses/src/flowHoc.tsx
@@ -34,7 +34,7 @@ function mergeMeta(objValue:any, srcValue:any) {
 }
 
 /**
- * Enhances an HOC so as to reserve metadata attached to the component it wraps.
+ * Enhances a HOC so as to reserve metadata attached to the component it wraps.
  */
 const preserveMeta = (hoc: HOC): HOC => <P extends object, Q extends object = P>(
   Component: ComponentOrTag<P>,
@@ -51,13 +51,13 @@ const preserveMeta = (hoc: HOC): HOC => <P extends object, Q extends object = P>
 };
 
 /**
- * Creates an HOC which attaches metadata to a component.
+ * Creates a HOC which attaches metadata to a component.
  *
  * @param meta
  * The metadata to attach.
  *
  * @returns
- * An HOC which attaches the supplied metadata as properties of the component.
+ * A HOC which attaches the supplied metadata as properties of the component.
  *
  * @category Token API
  */

--- a/packages/fclasses/src/flowIf.tsx
+++ b/packages/fclasses/src/flowIf.tsx
@@ -17,14 +17,14 @@ import { FlowHoc, Condition } from './types';
 import { flowHoc } from './flowHoc';
 
 /**
- * Applies a set of HOC's if a condition is true.
+ * Applies a set of HOCs if a condition is true.
  *
  * @param useCondition
- * A custom react hook which returns true if the HOC's should be applied.  Will receive
+ * A custom react hook which returns true if the HOCs should be applied.  Will receive
  * the components props as an argument.
  *
  * @returns
- * A function which accepts a list of HOC's and returns a new HOC which will be applied
+ * A function which accepts a list of HOCs and returns a new HOC which will be applied
  * to the target component only if the specified condition evaluates to true.
  *
  * @category HOC Utility

--- a/packages/fclasses/src/replaceable.tsx
+++ b/packages/fclasses/src/replaceable.tsx
@@ -73,7 +73,7 @@ export const replaceable: HOC = Component => {
 };
 
 /**
- * Creates an HOC which replaces a base component with a specified replacement.
+ * Creates a HOC which replaces a base component with a specified replacement.
  * Unlike [[replaceWith]], this function replaces the base component but leaves
  * any previously applied tokens intact.
  *
@@ -125,7 +125,7 @@ export const startWith = (ReplacementComponent: ComponentType<any>): HOC => Comp
  * The component or tag to use as a replacement.
  *
  * @returns
- * An HOC which renders the replacement in place of the target.
+ * A HOC which renders the replacement in place of the target.
  *
  * @see `startWith`
  *

--- a/packages/fclasses/src/replaceable.tsx
+++ b/packages/fclasses/src/replaceable.tsx
@@ -118,7 +118,7 @@ export const startWith = (ReplacementComponent: ComponentType<any>): HOC => Comp
 };
 /**
  * Returns a HOC which replaces the component to which it is applied with another.
- * Unlike `startWith`, this replaces the component along with any hoc's which
+ * Unlike `startWith`, this replaces the component along with any HOCs which
  * had previously been applied.
  *
  * @param Replacement

--- a/packages/fclasses/src/tokenSpec.ts
+++ b/packages/fclasses/src/tokenSpec.ts
@@ -109,7 +109,7 @@ function as(
  * The design to apply.
  *
  * @returns
- * An hoc which applies the design.
+ * An HOC which applies the design.
  *
  * @category Design API
  */

--- a/packages/fclasses/src/tokenSpec.ts
+++ b/packages/fclasses/src/tokenSpec.ts
@@ -51,7 +51,7 @@ function getHocForDomain<C extends DesignableComponents, D extends object = any>
 
 /**
  * Converts a list of token into an HOC which can be applied to
- * a component. Tokens to apply may be expressed in token object notation, as HOC's
+ * a component. Tokens to apply may be expressed in token object notation, as HOCs
  * or as className strings.
  *
  * @param specs
@@ -232,9 +232,9 @@ const on = (
 /**
  * Used to create a token specification.
  *
- * A token specification is an object which organizes Token HOC's into "domains" which
+ * A token specification is an object which organizes Token HOCs into "domains" which
  * can then be selectively overridden. With the exception of certain [[ReservedDomains]],
- * each domain is a [[Design]], defining a set of HOC's which should be applied to
+ * each domain is a [[Design]], defining a set of HOCs which should be applied to
  * the individual design keys (or slots) in the target component.
  *
  * Normally, each component will use this create its own `as...Token` function in order
@@ -254,7 +254,7 @@ const on = (
  *   allowed domains.  Keys will be re-ordered to match the canonoical order, and missing keys
  *   will be supplied.
  * - a string, which will be treated as a set of classes to be applied to the `_` key of the
- *   `Core` domain.  The `_` key in a design applies HOC's or classes to the component as a
+ *   `Core` domain.  The `_` key in a design applies HOCs or classes to the component as a
  *   whole rather than one of its slots.
  * - a function, which will be treated as an HOC to be applied to the `_` key of the `Core`
  *   domain.

--- a/packages/fclasses/src/tokenSpec.ts
+++ b/packages/fclasses/src/tokenSpec.ts
@@ -27,7 +27,7 @@ import { addClasses } from './addClasses';
 import { withHocDesign } from './withHocDesign';
 
 /**
- * Converts a domain into an HOC which applies the extended design defined
+ * Converts a domain into a HOC which applies the extended design defined
  * by that domain.  Properly handles special domain names ('Flow',
  * 'Compose' and 'Meta').
  *
@@ -50,7 +50,7 @@ function getHocForDomain<C extends DesignableComponents, D extends object = any>
 }
 
 /**
- * Converts a list of token into an HOC which can be applied to
+ * Converts a list of token into a HOC which can be applied to
  * a component. Tokens to apply may be expressed in token object notation, as HOCs
  * or as className strings.
  *
@@ -58,7 +58,7 @@ function getHocForDomain<C extends DesignableComponents, D extends object = any>
  * A list of token to be composed.
  *
  * @returns
- * An HOC which can be applied to a component.
+ * A HOC which can be applied to a component.
  *
  * @category Token API
  */

--- a/packages/fclasses/src/tokenSpec.ts
+++ b/packages/fclasses/src/tokenSpec.ts
@@ -68,7 +68,7 @@ function as(
 ): HOC<any, any, any> {
   const args = args$.filter(Boolean);
 
-  // Ensure that all token specs have been passed through `asTokenSpec`
+  // Ensure that all token specs have been passed through `asTokenSpec`.
   args.forEach(a => {
     if (typeof a !== 'function' && typeof a !== 'string' && !a![$TokenSpec]) {
       // @todo add some debugging info here - token domains names, token meta if any, etc.
@@ -153,7 +153,7 @@ const tokenMergeCustomizer = (...args: any) => {
 };
 
 /**
- * Alias for extendDomain.
+ * Alias for `extendDomain`.
  *
  * @see `extendDomain`
  * @category Design API
@@ -185,7 +185,7 @@ const extendDomain = extendDesign;
  * list will be converted to designs by invoking them on an empty design.
  *
  * @param dx
- * List of designs or HODs which will be used as extensons
+ * List of designs or HODs which will be used as extensions.
  *
  * @returns
  * An HOD which will extend the base design with the supplied designs.
@@ -248,10 +248,10 @@ const on = (
  * in this parameter.
  *
  * @returns
- * Function which receives a set of partial token speciications and returns a normalized token
+ * Function which receives a set of partial token specifications and returns a normalized token
  * specification created by merging those partials.  Each parameter may be:
  * - a partial tokens specification object, in which case the keys must belong to the set of
- *   allowed domains.  Keys will be re-ordered to match the canonoical order, and missing keys
+ *   allowed domains.  Keys will be re-ordered to match the canonical order, and missing keys
  *   will be supplied.
  * - a string, which will be treated as a set of classes to be applied to the `_` key of the
  *   `Core` domain.  The `_` key in a design applies HOCs or classes to the component as a
@@ -271,9 +271,9 @@ const on = (
  *   C extends DesignableComponents
  * >() => asTokenSpec<C, DefaultDomains>(domains);
  * ```
- * And use it to create an `as...Token` utiity which restricts domains.
+ * And use it to create an `as...Token` utility which restricts domains.
  * ```
- * type FooComponens = {
+ * type FooComponents = {
  *   Wrapper: ComponentOrTag<any>,
  *   Title: ComponentOrTag<any>,
  *   Body: ComponentOrTag<any>,
@@ -315,7 +315,7 @@ export {
 };
 
 /**
- * Type guard to ensure that a Token is a TokenSpec.
+ * Type guard to ensure that a `Token` is a `TokenSpec`.
  *
  * @param a
  * The Token to test.

--- a/packages/fclasses/src/tokenSpec.ts
+++ b/packages/fclasses/src/tokenSpec.ts
@@ -109,7 +109,7 @@ function as(
  * The design to apply.
  *
  * @returns
- * An HOC which applies the design.
+ * A HOC which applies the design.
  *
  * @category Design API
  */
@@ -188,7 +188,7 @@ const extendDomain = extendDesign;
  * List of designs or HODs which will be used as extensions.
  *
  * @returns
- * An HOD which will extend the base design with the supplied designs.
+ * A HOD which will extend the base design with the supplied designs.
  *
  * @category Design API
  */
@@ -256,7 +256,7 @@ const on = (
  * - a string, which will be treated as a set of classes to be applied to the `_` key of the
  *   `Core` domain.  The `_` key in a design applies HOCs or classes to the component as a
  *   whole rather than one of its slots.
- * - a function, which will be treated as an HOC to be applied to the `_` key of the `Core`
+ * - a function, which will be treated as a HOC to be applied to the `_` key of the `Core`
  *   domain.
  *
  * @example

--- a/packages/fclasses/src/types.ts
+++ b/packages/fclasses/src/types.ts
@@ -159,7 +159,7 @@ export type Enhancer<A, B = {}> = HOC<B, A>;
 export type Injector<R, B = {}> = HOC<B & Partial<R>, {}, R>;
 
 /**
- * Type of the filter function which should be passed to `withTokenFilter`
+ * Type of the filter function which should be passed to `withTokenFilter`.
  *
  * @see withTokenFilter
  * @hidden
@@ -167,7 +167,7 @@ export type Injector<R, B = {}> = HOC<B & Partial<R>, {}, R>;
 export type TokenFilterTest = (token: HOCWithMeta) => boolean;
 
 /**
- * Type of the parameters to flowHoc  Overloaded to accept metadata
+ * Type of the parameters to `flowHoc`. Overloaded to accept metadata
  * objects (or undefined) in addition to HOCs.
  *
  * @category HOC Utility
@@ -229,7 +229,7 @@ export type HocDesign<C extends DesignableComponents = DesignableComponents> = {
  * This is the type of the props for a designable component.
  *
  * @param C
- * The components or "sots" accepted by this designable component.
+ * The components or "slots" accepted by this designable component.
  *
  * @category Design API
  */
@@ -238,10 +238,10 @@ export type DesignableProps<C extends DesignableComponents = DesignableComponent
 };
 
 /**
- * TYpe of the props of a base component which can be made designable.
+ * Type of the props of a base component which can be made designable.
  *
  * @param C
- * The components or "sots" accepted by this designable component.
+ * The components or "slots" accepted by this designable component.
  *
  *
  * @example
@@ -272,14 +272,14 @@ export type HOD<
 > = (design?:Design<C, D>) => Design<C, D>;
 
 /**
- * This is a HOD that accepts any DesignableComponents
+ * This is a HOD that accepts any `DesignableComponents`.
  *
  * @category Design API
  */
 export type FluidHOD = HOD<DesignableComponents>;
 
 /**
- * [[Design]] that accepts any DesignableComponents
+ * [[Design]] that accepts any `DesignableComponents`.
  *
  * @category Design API
  */
@@ -307,30 +307,30 @@ export type ReservedDomains<
   D extends object,
 > = {
   /**
-     * A list of other tokens which should be applied.
-     */
+   * A list of other tokens which should be applied.
+   */
   Compose?: {
     [key: string]: ComposedToken<C, D>,
   },
   /**
-     * If specified, the entire token will be wrapped in a flow toggle using
-     * this condition hook. Note, the condition is applied to the whole token,
-     * so it will not have access to any contexts or content nodes provided by
-     * the token itself.
-     */
+   * If specified, the entire token will be wrapped in a flow toggle using
+   * this condition hook. Note, the condition is applied to the whole token,
+   * so it will not have access to any contexts or content nodes provided by
+   * the token itself.
+   */
   Flow?: FlowHoc | undefined,
   /**
-     * Metadata which should be attached to this token (and to any components
-     * to which the token is applied).
-     */
+   * Metadata which should be attached to this token (and to any components
+   * to which the token is applied).
+   */
   Meta?: TokenMeta,
 };
 
 /**
  * Type of an argument to `as` and/or the value of a key in an Extended Design.
  * May be:
- * - A token specified in token object notation
- * - A token specified as an HOC
+ * - A token specified in token object notation;
+ * - A token specified as an HOC;
  * - A token specified as a string of classes.
  *
  * @category Token API
@@ -376,8 +376,8 @@ export type FinalDesign<
 
 /**
    * A Design is a keyed set of tokens which can apply to a designable
-   * component. The keys correspond to the design elements
-   * - includes a special key which contains tokens to be applied to the
+   * component. The keys correspond to the design elements.
+   * - Includes a special key which contains tokens to be applied to the
    *   component as a whole.
    * - Allows each value to be specified as a VitalDS extended token definition.
    *
@@ -411,7 +411,7 @@ export type Design<
 export type Condition<P = any> = (props: P) => boolean;
 
 /**
- * Type of a set of domains uses in a [[TokenSpec]]
+ * Type of a set of domains uses in a [[TokenSpec]].
  *
  * @category Token API
  */
@@ -467,7 +467,7 @@ export type TokenSpec<
  *
  * @param specs
  * A list of partial token specifications.  These may be objects, in which case
- * their keys should be a subset of the alloed domains.  They may also be strings
+ * their keys should be a subset of the allowed domains.  They may also be strings
  * or HOCs, which will be converted to partial token specifications, applying
  * the classes or HOC to the `_` key of the `Core` domain.
  *

--- a/packages/fclasses/src/types.ts
+++ b/packages/fclasses/src/types.ts
@@ -119,7 +119,7 @@ export type TokenProps = {
 };
 
 /**
- * Type of a "Token", which is an HOC with optional metadata and filtering.
+ * Type of a "Token", which is a HOC with optional metadata and filtering.
  *
  * Tokens may be composed of other tokens using the `flowHoc` utility.
  *

--- a/packages/fclasses/src/types.ts
+++ b/packages/fclasses/src/types.ts
@@ -330,7 +330,7 @@ export type ReservedDomains<
  * Type of an argument to `as` and/or the value of a key in an Extended Design.
  * May be:
  * - A token specified in token object notation;
- * - A token specified as an HOC;
+ * - A token specified as a HOC;
  * - A token specified as a string of classes.
  *
  * @category Token API

--- a/packages/fclasses/src/types.ts
+++ b/packages/fclasses/src/types.ts
@@ -168,7 +168,7 @@ export type TokenFilterTest = (token: HOCWithMeta) => boolean;
 
 /**
  * Type of the parameters to flowHoc  Overloaded to accept metadata
- * objects (or undefined) in addition to HOC's.
+ * objects (or undefined) in addition to HOCs.
  *
  * @category HOC Utility
  */

--- a/packages/fclasses/src/types.ts
+++ b/packages/fclasses/src/types.ts
@@ -71,7 +71,7 @@ export type Tag<T = HTMLElement> = ComponentOrTag<HTMLProps<T>>;
 export type PP<P, A, R> = Omit<P & A, keyof R> & Partial<R>;
 
 /**
- * Type of a higher order component.
+ * Type of a higher-order component.
  *
  * This is a generic type which allows you to specify how the props of the target
  * component will be treated. It accepts 3 type parameters:
@@ -261,7 +261,7 @@ export type DesignableComponentsProps<C extends DesignableComponents = Designabl
 };
 
 /**
- * This is the type of a  Higher order design which can be applied to a component which accepts
+ * This is the type of a higher-order design which can be applied to a component which accepts
  * a components prop of type "C".
  *
  * @category Design API

--- a/packages/fclasses/src/withHocDesign.tsx
+++ b/packages/fclasses/src/withHocDesign.tsx
@@ -23,10 +23,10 @@ import { flowHoc } from './flowHoc';
  * @hidden
  * Creates an HOC which applies a specified design to the wrapped component.
  *
- * A design is a keyed set of HOC's which should be applied to constituent elements
+ * A design is a keyed set of HOCs which should be applied to constituent elements
  * of the wrapped component. The wrapped component itself should accept a components
  * prop, and be wrapped in the `designable` HOC to define a set of base components
- * to which the HOC's should apply.
+ * to which the HOCs should apply.
  *
  * @param design
  * The design to apply

--- a/packages/fclasses/src/withHocDesign.tsx
+++ b/packages/fclasses/src/withHocDesign.tsx
@@ -21,7 +21,7 @@ import { flowHoc } from './flowHoc';
 
 /**
  * @hidden
- * Creates an HOC which applies a specified design to the wrapped component.
+ * Creates a HOC which applies a specified design to the wrapped component.
  *
  * A design is a keyed set of HOCs which should be applied to constituent elements
  * of the wrapped component. The wrapped component itself should accept a components

--- a/packages/vital-accordion/src/components/AccordionTitle/AccordionTitleClean.tsx
+++ b/packages/vital-accordion/src/components/AccordionTitle/AccordionTitleClean.tsx
@@ -69,7 +69,7 @@ const AccordionTitleBase: FC<PropsWithChildren<AccordionTitleBaseProps>> = ({
 };
 
 /**
- * An HOC that handles toggling the current accordion when pressing Enter or Space on the keyboard.
+ * A HOC that handles toggling the current accordion when pressing Enter or Space on the keyboard.
  * On Edit, the keyboard won't toggle the accordion, but this will prevent the user from placing
  * a carriage return (Enter) in the title, forcing it to be one line.
  */

--- a/packages/vital-editors/src/withEditor/withEditor.tsx
+++ b/packages/vital-editors/src/withEditor/withEditor.tsx
@@ -34,7 +34,7 @@ export type WithEditor = (
 /**
  * Use `withEditor` to make a given text element editable.
  *
- * Creates an "asBodiless" HOC factory which returns an HOC adding
+ * Creates an "asBodiless" HOC factory which returns a HOC adding
  * specified editor as a designable child of the target component.  The design key
  * of the child is 'Editor'.
  *
@@ -68,7 +68,7 @@ const withEditor = (Editor:CT<any>): WithEditor => (
 // ********** EditorPlain
 
 /**
- * Bodiless HOC factory creates an HOC which adds a VitalDS Plain Text
+ * Bodiless HOC factory creates a HOC which adds a VitalDS Plain Text
  * editor as a designable child of the target component.
  *
  * @see withEditor
@@ -76,7 +76,7 @@ const withEditor = (Editor:CT<any>): WithEditor => (
 const withEditorPlain = withEditor(as(vitalEditorPlain.Default)(EditorPlainClean));
 
 /**
- * Bodiless HOC factory creates an HOC which adds a Clean Plain Text
+ * Bodiless HOC factory creates a HOC which adds a Clean Plain Text
  * editor (basically a Bodiless "Editable" as a designable child of the
  * target component.
  *
@@ -85,7 +85,7 @@ const withEditorPlain = withEditor(as(vitalEditorPlain.Default)(EditorPlainClean
 const withEditorPlainClean = withEditor(EditorPlainClean);
 
 /**
- * Bodiless HOC factory creates an HOC which adds a Clean Rich Text
+ * Bodiless HOC factory creates a HOC which adds a Clean Rich Text
  * editor (basically a Bodiless "RichText" as a designable child of the
  * target component.
  *
@@ -94,7 +94,7 @@ const withEditorPlainClean = withEditor(EditorPlainClean);
 const withEditorRichClean = withEditor(RichTextClean);
 
 /**
- * Bodiless HOC factory creates an HOC which adds a VitalDS Full Rich Text
+ * Bodiless HOC factory creates a HOC which adds a VitalDS Full Rich Text
  * editor as a designable child of the target component.
  *
  * @see withEditor

--- a/packages/vital-elements/doc/README.md
+++ b/packages/vital-elements/doc/README.md
@@ -21,7 +21,7 @@ To get the most out of this document, you should have a basic familiarity with:
 * Atomic Design, Design Systems and Design Tokens
 * "Functional" or "Atomic" CSS
 * Fundamental principles of functional programming
-* React Higher Order Components.
+* React Higher-Order Components.
 
 There are many excellent web resources on these topics, and we encourage you to
 read a few articles if any of these concepts are foreign to you.

--- a/packages/vital-elements/doc/TokenDomains.md
+++ b/packages/vital-elements/doc/TokenDomains.md
@@ -128,7 +128,7 @@ following differences:
 
 - The value of each key can by any of the following:
   - A normal Bodiless token HOC (as in a normal design object).
-  - A token specification object (which will be converted to an HOC by being wrapped in `as`).
+  - A token specification object (which will be converted to a HOC by being wrapped in `as`).
   - A string (which will be interpreted as a set of CSS classes to be added to the component via
    `addClasses`).
 - There is a special `_` key which defines tokens/HOCs which should be applied to the component as a

--- a/packages/vital-elements/doc/Tokens.md
+++ b/packages/vital-elements/doc/Tokens.md
@@ -317,7 +317,7 @@ import { LinkClean, brandLink } from '@bodiless/brand';
 const DefaultLink = as(brandLink.Default)(LinkClean);
 ```
 
-Defining and exporting our token as an object rather than an HOC allows an individual brand or site
+Defining and exporting our token as an object rather than a HOC allows an individual brand or site
 to customize part of the token's behavior while retaining the rest. For example, let's imagine that
 our site's design system calls for links to be purple and not underlined. We could retain the edit
 behavior of the brand link and change its styling:

--- a/packages/vital-examples/doc/Curriculum/Lessons/ReusableTokens.md
+++ b/packages/vital-examples/doc/Curriculum/Lessons/ReusableTokens.md
@@ -86,7 +86,7 @@ const Hero = asCardToken({
   Theme: {
     ...vitalCardBase.Hero.Theme,
 /* Note the use of 'as' here. This is a composition utility provided 
-* by BodilessJS that converts a list of tokens into an HOC. When applying
+* by BodilessJS that converts a list of tokens into a HOC. When applying
 * multiple tokens to a component, 'as' must be used to properly combine them.
 *
 * In the 'Default' token example above, you'll notice that because only one * token is being applied to the 'ContentWrapper' slot, 'as' is not needed.

--- a/packages/vital-examples/src/intro/functional-classes/components/Dialog/Dialog.tsx
+++ b/packages/vital-examples/src/intro/functional-classes/components/Dialog/Dialog.tsx
@@ -49,7 +49,7 @@ const DialogCleanBase: FC<DialogBaseProps> = ({ components: C, ...rest }) => (
  * a `design` prop. This is an object with the same keys as the
  * `components` prop received by the base component. Each value is
  * a Higher-Order Component composing all the Vital tokens which have
- * been applied to that slot.  `designable` will apply the HOC's to
+ * been applied to that slot.  `designable` will apply the HOCs to
  * the starting component in each slot, and pass the resulting sub-component
  * through to the `DialogCleanBase` in the `components` prop.
  *

--- a/packages/vital-examples/src/intro/functional-classes/components/Dialog/Dialog.tsx
+++ b/packages/vital-examples/src/intro/functional-classes/components/Dialog/Dialog.tsx
@@ -53,8 +53,8 @@ const DialogCleanBase: FC<DialogBaseProps> = ({ components: C, ...rest }) => (
  * the starting component in each slot, and pass the resulting sub-component
  * through to the `DialogCleanBase` in the `components` prop.
  *
- * The second paramter to `designable` is a string which will be used
- * to identify slots in the rendered parkup.  This makes it easier
+ * The second parameter to `designable` is a string which will be used
+ * to identify slots in the rendered markup.  This makes it easier
  * to understand which slot to target in order to modify a particular
  * DOM element.
  */

--- a/packages/vital-examples/src/intro/functional-classes/components/Dialog/Dialog.tsx
+++ b/packages/vital-examples/src/intro/functional-classes/components/Dialog/Dialog.tsx
@@ -48,7 +48,7 @@ const DialogCleanBase: FC<DialogBaseProps> = ({ components: C, ...rest }) => (
  * By making our clean component `designable`, we allow it to receive
  * a `design` prop. This is an object with the same keys as the
  * `components` prop received by the base component. Each value is
- * a Higher Order Component composing all the Vital tokens which have
+ * a Higher-Order Component composing all the Vital tokens which have
  * been applied to that slot.  `designable` will apply the HOC's to
  * the starting component in each slot, and pass the resulting sub-component
  * through to the `DialogCleanBase` in the `components` prop.

--- a/packages/vital-examples/src/intro/reaching-inside/components/Dialog/Dialog.tsx
+++ b/packages/vital-examples/src/intro/reaching-inside/components/Dialog/Dialog.tsx
@@ -31,7 +31,7 @@ const dialogComponents: DialogComponents = {
 };
 
 /**
- * The actual clean compnoent base is defined next.
+ * The actual clean component base is defined next.
  *
  * Note that it will receive a `components` prop which contains all the
  * starting elements defined above, already modified by any Vital tokens
@@ -59,8 +59,8 @@ const DialogCleanBase: FC<DialogBaseProps> = ({ components: C, ...rest }) => (
  * the starting component in each slot, and pass the resulting sub-component
  * through to the `DialogCleanBase` in the `components` prop.
  *
- * The second paramter to `designable` is a string which will be used
- * to identify slots in the rendered parkup.  This makes it easier
+ * The second parameter to `designable` is a string which will be used
+ * to identify slots in the rendered markup.  This makes it easier
  * to understand which slot to target in order to modify a particular
  * DOM element.
  */

--- a/packages/vital-examples/src/intro/reaching-inside/components/Dialog/Dialog.tsx
+++ b/packages/vital-examples/src/intro/reaching-inside/components/Dialog/Dialog.tsx
@@ -54,7 +54,7 @@ const DialogCleanBase: FC<DialogBaseProps> = ({ components: C, ...rest }) => (
  * By making our clean component `designable`, we allow it to receive
  * a `design` prop. This is an object with the same keys as the
  * `components` prop received by the base component. Each value is
- * a Higher Order Component composing all the Vital tokens which have
+ * a Higher-Order Component composing all the Vital tokens which have
  * been applied to that slot.  `designable` will apply the HOC's to
  * the starting component in each slot, and pass the resulting sub-component
  * through to the `DialogCleanBase` in the `components` prop.

--- a/packages/vital-examples/src/intro/reaching-inside/components/Dialog/Dialog.tsx
+++ b/packages/vital-examples/src/intro/reaching-inside/components/Dialog/Dialog.tsx
@@ -55,7 +55,7 @@ const DialogCleanBase: FC<DialogBaseProps> = ({ components: C, ...rest }) => (
  * a `design` prop. This is an object with the same keys as the
  * `components` prop received by the base component. Each value is
  * a Higher-Order Component composing all the Vital tokens which have
- * been applied to that slot.  `designable` will apply the HOC's to
+ * been applied to that slot.  `designable` will apply the HOCs to
  * the starting component in each slot, and pass the resulting sub-component
  * through to the `DialogCleanBase` in the `components` prop.
  *

--- a/packages/vital-image/src/components/Image/util.ts
+++ b/packages/vital-image/src/components/Image/util.ts
@@ -18,7 +18,7 @@ import { ContentNodePath, withDefaultContent } from '@bodiless/data';
 import { getImageContentFrom } from '@bodiless/gatsby-theme-bodiless';
 
 /**
-* Util function generating an HOC which adds default content from
+* Util function generating a HOC which adds default content from
 * the specified node path.
 *
 * @param nodePath

--- a/packages/vital-link/src/components/Link/util.ts
+++ b/packages/vital-link/src/components/Link/util.ts
@@ -16,7 +16,7 @@ import { asBodilessLink } from '@bodiless/components-ui';
 import type { AsBodilessLink } from '@bodiless/components';
 
 /**
- * Produces an HOC which creates an editable link.
+ * Produces a HOC which creates an editable link.
  *
  * @see asBodilessLink.
  */

--- a/sites/test-site/src/components/Image/index.ts
+++ b/sites/test-site/src/components/Image/index.ts
@@ -56,7 +56,7 @@ export const asBaseEditableImagePlain: AsBodilessImage = (
 );
 
 /**
- * util function to build a hoc for rendering a non-responsive image.
+ * util function to build a HOC for rendering a non-responsive image.
  */
 export const asEditableImagePlain: AsBodilessImage = (
   nodeKey?, placeholder?, useOverrides?,
@@ -67,7 +67,7 @@ export const asEditableImagePlain: AsBodilessImage = (
 );
 
 /**
- * util function to build a hoc for rendering a responsive image.
+ * util function to build a HOC for rendering a responsive image.
  */
 const asEditableImage = withGatsbyImagePreset(GatsbyImagePresets.FluidWithWebp)(asBaseEditableImagePlain);
 

--- a/sites/test-site/src/data/pages/cards/index.jsx
+++ b/sites/test-site/src/data/pages/cards/index.jsx
@@ -34,7 +34,7 @@ import {
 } from '../../../components/Card/token';
 
 /**
- * hoc to disable gatsby image for a card
+ * HOC to disable gatsby image for a card
  */
 const withDisabledGatsbyImage = flow(
   withDesign({


### PR DESCRIPTION
## Changes

- Hyphenate "higher order" when referring to "higher-order components."
- Remove apostrophe from pluralized form of HOC (HOCs), as it's unnecessary.
- Change instances of "hoc" to "HOC".
- Fix miscellaneous code comments.
  - Fix typos, formatting, etc. in code comments of miscellaneous files.
- Fix a few broken/empty links.
- Clean up "Tokens and Higher-Order Components in TypeScript" page.
  - Fix typos, formatting, etc.