### PR TITLE
feat(page): Add page navigation button

### DIFF
--- a/packages/bodiless-core-ui/src/GlobalContextMenu.tsx
+++ b/packages/bodiless-core-ui/src/GlobalContextMenu.tsx
@@ -29,6 +29,7 @@ import {
   ComponentFormFieldTitle, ComponentFormCheckBox, ComponentFormRadio, ComponentFormRadioGroup,
   ComponentFormSelect, ComponentFormOption, ComponentFormTextArea, ContextSubMenu,
   ToolbarButtonLabel, HorizontalToolbarButton, ComponentFormSpinner, ToolbarVertical,
+  ComponentFormNotification,
 } from '@bodiless/ui';
 import ReactTagsField from './ReactTags';
 
@@ -91,6 +92,7 @@ const ui: ContextMenuUI = {
   ComponentFormLink,
   ComponentFormList,
   ComponentFormListItem,
+  ComponentFormNotification,
   Icon: ToolbarIcon,
   ContextSubMenu,
   Toolbar,

--- a/packages/bodiless-core/src/Types/ContextMenuTypes.tsx
+++ b/packages/bodiless-core/src/Types/ContextMenuTypes.tsx
@@ -197,6 +197,7 @@ export type ContextMenuUI = {
   ReactTags?: ComponentType<ReactTagsFieldProps>;
   ComponentFormList?: ComponentType<HTMLProps<HTMLUListElement>> | string;
   ComponentFormListItem?: ComponentType<HTMLProps<HTMLLIElement>> | string;
+  ComponentFormNotification?: ComponentType<HTMLProps<HTMLLIElement>> | string;
   ContextSubMenu?: ComponentType<HTMLProps<HTMLDivElement>> | string;
   ContextMenuGroup?: ComponentType<IContextMenuItemProps>;
   Spinner?: ComponentType<any>;

--- a/packages/bodiless-core/src/components/ContextMenuContext.bl-edit.tsx
+++ b/packages/bodiless-core/src/components/ContextMenuContext.bl-edit.tsx
@@ -56,6 +56,7 @@ const defaultUI: Required<ContextMenuUI> = {
   ReactTags: ReactTagsField,
   ComponentFormList: 'ul',
   ComponentFormListItem: 'li',
+  ComponentFormNotification: 'li',
   ComponentFormDescription: 'div',
   ContextSubMenu: React.Fragment,
   HorizontalToolbarButton: DefaultToolbarButton,

--- a/packages/bodiless-core/src/withNotificationButton.tsx
+++ b/packages/bodiless-core/src/withNotificationButton.tsx
@@ -20,15 +20,15 @@ import { useMenuOptionUI } from './components/ContextMenuContext.bl-edit';
 import type { ContextMenuFormProps } from './Types/ContextMenuTypes';
 
 const NotificationList = () => {
-  const { ComponentFormList, ComponentFormListItem } = useMenuOptionUI();
+  const { ComponentFormList, ComponentFormNotification } = useMenuOptionUI();
   const { notifications } = useNotifications();
   if (notifications.length === 0) return (<p>There are no alerts.</p>);
   return (
     <ComponentFormList>
       {notifications.map(n => (
-        <ComponentFormListItem key={n.id}>
+        <ComponentFormNotification key={n.id}>
           {n.message}
-        </ComponentFormListItem>
+        </ComponentFormNotification>
       ))}
     </ComponentFormList>
   );

--- a/packages/bodiless-next/src/Page.bl-edit.tsx
+++ b/packages/bodiless-next/src/Page.bl-edit.tsx
@@ -39,6 +39,7 @@ import {
   withNewPageButton,
   withRedirectAliasButton,
 } from '@bodiless/page';
+import withPageTreeButton from './withPageTreeButton';
 import NextNodeProvider from './NextNodeProvider.bl-edit';
 import { FinalUI, UI, PageProps } from './types';
 import ShowDesignKeys from './ShowDesignKeys';
@@ -74,6 +75,8 @@ const EditButtons: FC = () => {
   return <></>;
 };
 
+const PageTreeButton = withPageTreeButton(Fragment);
+
 const EditPage: FC<PropsWithChildren<PageProps>> = observer(({ children, ui, ...rest }) => {
   const { PageEditor: Editor, ContextWrapper: Wrapper } = getUI(ui);
   const { pageContext } = rest;
@@ -100,6 +103,7 @@ const EditPage: FC<PropsWithChildren<PageProps>> = observer(({ children, ui, ...
               <NotificationButton />
               <Editor>
                 <EditButtons />
+                <PageTreeButton />
                 <OnNodeErrorNotification />
                 <NewPageButton />
                 <MovePageButton />

--- a/packages/bodiless-next/src/getStaticProps.ts
+++ b/packages/bodiless-next/src/getStaticProps.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /**
  * Copyright © 2023 Johnson & Johnson
  *
@@ -166,6 +167,7 @@ const getStaticProps = async ({ params }: getServerSideProps) => {
   try {
     const indexPath = findComponentPath(...pagesBasePath, ...realSlug.split('/').filter(Boolean));
     if (indexPath === null) {
+      // eslint-disable-next-line no-console
       console.log('Skip folder ', realSlug, pageData.path, ' index file not found.');
     } else {
       const basePath = path.resolve(...pagesBasePath);
@@ -195,6 +197,15 @@ const getStaticProps = async ({ params }: getServerSideProps) => {
           path.join(...siteDataBasePath),
           path.join(...publicBasePath)
         );
+        const pages = await getPages();
+
+        // Get the list of all pages and put in site collection.
+        pageData.data.Site.push({
+          node: {
+            name: '_pages',
+            content: JSON.stringify(pages.filter(Boolean)),
+          }
+        });
         propsCache.set('pageDataSite', pageData.data.Site);
       }
 

--- a/packages/bodiless-next/src/withPageTreeButton.tsx
+++ b/packages/bodiless-next/src/withPageTreeButton.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { HOC } from '@bodiless/fclasses';
+import { withPageTreeButton as withPageTreeButtonBase } from '@bodiless/page';
+import { useNode } from '@bodiless/data';
+
+const withPageTreeButton: HOC = Component => {
+  const WithPageTreeButton = withPageTreeButtonBase(Component);
+  return (props: any) => {
+    const { node } = useNode();
+    const { data } = node.peer('Site$_pages');
+    return <WithPageTreeButton {...props} pages={data} />;
+  };
+};
+
+export default withPageTreeButton;

--- a/packages/bodiless-page/src/MenuOptionUI/usePageMenuOptionUI.ts
+++ b/packages/bodiless-page/src/MenuOptionUI/usePageMenuOptionUI.ts
@@ -22,6 +22,7 @@ import {
   flowHoc,
   removeClasses,
   StylableProps,
+  A,
 } from '@bodiless/fclasses';
 
 const usePageMenuOptionUI = () => {
@@ -52,6 +53,10 @@ const usePageMenuOptionUI = () => {
     addClasses('bl-italic'),
   )(ComponentFormLink as ComponentType<StylableProps>);
 
+  const PageTreeLink = addClasses(
+    'bl-cursor-pointer bl-text-xs bl-block hover:bl-underline hover:bl-text-yellow-500'
+  )(A);
+
   const Warning = flowHoc(
     removeClasses('bl-float-left'),
   )(ComponentFormWarning as ComponentType<StylableProps>);
@@ -63,6 +68,7 @@ const usePageMenuOptionUI = () => {
     ComponentFormLabelSmall: LabelSmall as ComponentType<HTMLProps<HTMLLabelElement>>,
     ComponentFormLinkEdit: Link as ComponentType<HTMLProps<HTMLAnchorElement>>,
     ComponentFormWarning: Warning as ComponentType<HTMLProps<HTMLDivElement>>,
+    PageTreeLink,
   };
 
   return ui;

--- a/packages/bodiless-page/src/NodeApi/getPages.ts
+++ b/packages/bodiless-page/src/NodeApi/getPages.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /**
  * Copyright © 2023 Johnson & Johnson
  *

--- a/packages/bodiless-page/src/withPageTreeButton/index.ts
+++ b/packages/bodiless-page/src/withPageTreeButton/index.ts
@@ -11,13 +11,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-export * from './Forms';
-export * from './MenuOptions';
-export * from './MenuOptionUI';
-export * from './Operations';
-export * from './Provider';
-export * from './RedirectAlias';
-export * from './types';
-export * from './utils';
-export * from './withPageTreeButton';
+export * from './withPageTreeButton.bl-edit';

--- a/packages/bodiless-page/src/withPageTreeButton/pathsToTree.ts
+++ b/packages/bodiless-page/src/withPageTreeButton/pathsToTree.ts
@@ -1,0 +1,28 @@
+export type TreeNode = {
+  name: string,
+  children: TreeNode[],
+  url?: string,
+};
+
+export function pathsToTree(paths: string[] = []) {
+  const map: Record<string, string[]> = {};
+  function addToMap(rawPath: string) {
+    const path = rawPath.replace(/^\//, '').replace(/\/$/, '');
+    const segments = path.split('/');
+    const parent = segments.slice(0, -1).join('/');
+    if (!map[parent]) map[parent] = [];
+    if (!map[parent].includes(path)) map[parent] = [...map[parent], path];
+    if (parent) addToMap(parent);
+  }
+  function buildTree(path: string): TreeNode {
+    const name = path.split('/').pop() || 'Home';
+    const url = path ? `/${path}/` : '/';
+    return {
+      name,
+      url,
+      children: map[path] ? map[path].map(buildTree) : [],
+    };
+  }
+  paths.forEach(addToMap);
+  return buildTree('');
+}

--- a/packages/bodiless-page/src/withPageTreeButton/withPageTreeButton.bl-edit.tsx
+++ b/packages/bodiless-page/src/withPageTreeButton/withPageTreeButton.bl-edit.tsx
@@ -2,12 +2,10 @@ import React, {
   useMemo, FC, useState, useRef, useLayoutEffect,
 } from 'react';
 import {
-  withMenuOptions, ContextMenuFormProps, ContextMenuForm, useMenuOptionUI
+  withMenuOptions, ContextMenuFormProps, ContextMenuForm,
 } from '@bodiless/core';
-import {
-  addClasses, flowHoc, removeClasses, ComponentOrTag,
-} from '@bodiless/fclasses';
 import { pathsToTree, TreeNode } from './pathsToTree';
+import { usePageMenuOptionUI } from '../MenuOptionUI';
 
 type FolderTreeProps = {
   data: TreeNode,
@@ -27,18 +25,13 @@ const isNodeVisible = (data: TreeNode, testVisible: (data: TreeNode) => boolean)
 
 const FolderTreeNode: FC<FolderTreeNodeProps>= ({ data, test }) => {
   if (!isNodeVisible(data, test)) return null;
-  const { ComponentFormLink, ComponentFormList, ComponentFormListItem } = useMenuOptionUI();
-  const Link = flowHoc(
-    addClasses('bl-block hover:bl-text-yellow-500'),
-    // addClasses('block hover:text-interactive-tertiary-hover'),
-    removeClasses('bl-underline'),
-  )(ComponentFormLink as ComponentOrTag<any>);
-  // const ComponentFormList = 'ul';
-  // const ComponentFormListItem = 'li';
+  const {
+    ComponentFormList, ComponentFormListItem, PageTreeLink,
+  } = usePageMenuOptionUI();
   return (
     // @todo should use bl classes
     <ComponentFormListItem>
-      <Link href={data.url}>{data.name}</Link>
+      <PageTreeLink href={data.url}>{data.name}</PageTreeLink>
       {data.children.length > 0 && (
       <ComponentFormList>
         {data.children.map(c => <FolderTreeNode data={c} test={test} />)}
@@ -49,9 +42,9 @@ const FolderTreeNode: FC<FolderTreeNodeProps>= ({ data, test }) => {
 };
 
 const FolderTree: FC<FolderTreeProps> = props => {
-  const { ComponentFormList } = useMenuOptionUI();
+  const { ComponentFormList } = usePageMenuOptionUI();
   // const ComponentFormList = 'ul';
-  const { ComponentFormText } = useMenuOptionUI();
+  const { ComponentFormText } = usePageMenuOptionUI();
 
   // Track the text in the filter input field
   const [match, setMatch] = useState<string|undefined>();
@@ -95,7 +88,7 @@ const useForm = ({ pages }: withPageTreeButtonProps) => useMemo(() => (
     const {
       ComponentFormTitle,
       ComponentFormDescription,
-    } = useMenuOptionUI();
+    } = usePageMenuOptionUI();
     const tree = pathsToTree(pages);
     return (
       <ContextMenuForm {...props} hasSubmit={false}>

--- a/packages/bodiless-page/src/withPageTreeButton/withPageTreeButton.bl-edit.tsx
+++ b/packages/bodiless-page/src/withPageTreeButton/withPageTreeButton.bl-edit.tsx
@@ -1,0 +1,132 @@
+import React, {
+  useMemo, FC, useState, useRef, useLayoutEffect,
+} from 'react';
+import {
+  withMenuOptions, ContextMenuFormProps, ContextMenuForm, useMenuOptionUI
+} from '@bodiless/core';
+import {
+  addClasses, flowHoc, removeClasses, ComponentOrTag,
+} from '@bodiless/fclasses';
+import { pathsToTree, TreeNode } from './pathsToTree';
+
+type FolderTreeProps = {
+  data: TreeNode,
+};
+
+type FolderTreeNodeProps = {
+  test: (data: TreeNode) => boolean,
+} & FolderTreeProps;
+
+const isNodeVisible = (data: TreeNode, testVisible: (data: TreeNode) => boolean): boolean => {
+  const isVisible = data.children.reduce(
+    (acc, next) => acc || isNodeVisible(next, testVisible),
+    testVisible(data),
+  );
+  return isVisible;
+};
+
+const FolderTreeNode: FC<FolderTreeNodeProps>= ({ data, test }) => {
+  if (!isNodeVisible(data, test)) return null;
+  const { ComponentFormLink, ComponentFormList, ComponentFormListItem } = useMenuOptionUI();
+  const Link = flowHoc(
+    addClasses('bl-block hover:bl-text-yellow-500'),
+    // addClasses('block hover:text-interactive-tertiary-hover'),
+    removeClasses('bl-underline'),
+  )(ComponentFormLink as ComponentOrTag<any>);
+  // const ComponentFormList = 'ul';
+  // const ComponentFormListItem = 'li';
+  return (
+    // @todo should use bl classes
+    <ComponentFormListItem>
+      <Link href={data.url}>{data.name}</Link>
+      {data.children.length > 0 && (
+      <ComponentFormList>
+        {data.children.map(c => <FolderTreeNode data={c} test={test} />)}
+      </ComponentFormList>
+      )}
+    </ComponentFormListItem>
+  );
+};
+
+const FolderTree: FC<FolderTreeProps> = props => {
+  const { ComponentFormList } = useMenuOptionUI();
+  // const ComponentFormList = 'ul';
+  const { ComponentFormText } = useMenuOptionUI();
+
+  // Track the text in the filter input field
+  const [match, setMatch] = useState<string|undefined>();
+  const test = (data: TreeNode) => !match || new RegExp(match).test(data.name);
+
+  // Ensure the height of the list div remains constent even when items are filtered
+  const [height, setHeight] = useState<number|undefined>();
+  const listDivRef = useRef<HTMLDivElement>(null);
+  useLayoutEffect(() => {
+    setHeight(listDivRef.current?.offsetHeight);
+  });
+
+  return (
+    <>
+      <ComponentFormText
+        onChange={fieldState => {
+          setMatch(fieldState.value as string);
+        }}
+        placeholder="Path..."
+        name="match"
+        autoFocus
+      />
+      <ComponentFormList>
+        <div
+          style={height ? { height } : undefined}
+          ref={listDivRef}
+        >
+          <FolderTreeNode {...props} test={test} />
+        </div>
+      </ComponentFormList>
+    </>
+  );
+};
+
+export type withPageTreeButtonProps = {
+  pages: string[],
+};
+
+const useForm = ({ pages }: withPageTreeButtonProps) => useMemo(() => (
+  (props: ContextMenuFormProps) => {
+    const {
+      ComponentFormTitle,
+      ComponentFormDescription,
+    } = useMenuOptionUI();
+    const tree = pathsToTree(pages);
+    return (
+      <ContextMenuForm {...props} hasSubmit={false}>
+        <ComponentFormTitle>Navigate to Page</ComponentFormTitle>
+        <ComponentFormDescription>
+          <FolderTree
+            data={tree}
+          />
+        </ComponentFormDescription>
+      </ContextMenuForm>
+    );
+  }),
+[pages]);
+/**
+ * Provide a menu Button to show the sitemap as a tree of links.
+ *
+ * @param children
+ * @constructor
+ */
+const useMenuOptions = (props: withPageTreeButtonProps) => {
+  const Form = useForm(props);
+  return [{
+    name: 'page-tree',
+    label: 'Nav',
+    icon: 'account_tree',
+    handler: () => Form,
+  }];
+};
+
+export const withPageTreeButton = withMenuOptions({
+  useMenuOptions,
+  name: 'Page Tree',
+  root: true,
+});

--- a/packages/bodiless-page/src/withPageTreeButton/withPageTreeButton.static.tsx
+++ b/packages/bodiless-page/src/withPageTreeButton/withPageTreeButton.static.tsx
@@ -1,0 +1,1 @@
+export const withPageTreeButton = (C: any) => C;

--- a/packages/bodiless-ui/src/elements.tsx
+++ b/packages/bodiless-ui/src/elements.tsx
@@ -91,6 +91,10 @@ export const ComponentFormDescription = addClasses(
 )(Div);
 
 export const ComponentFormListItem = addClasses(
+  'bl-px-grid-4 bl-max-w-xl-grid-1',
+)(Li);
+
+export const ComponentFormNotification = addClasses(
   'first:bl-border-t-0 bl-border-t bl-py-grid-1 bl-px-grid-1 bl-max-w-xl-grid-1',
 )(Li);
 

--- a/packages/bodiless-ui/src/elements.tsx
+++ b/packages/bodiless-ui/src/elements.tsx
@@ -232,7 +232,7 @@ const isDisabled = (props: any) => hasProp('disabled')(props);
 export const ComponentFormLink = flow(
   addClasses('bl-cursor-pointer bl-text-xs bl-block bl-underline'),
   addClassesIf(isDisabled)('bl-text-gray-600'),
-  removeClassesIf(isDisabled)('bl-cursor-pointer bl-text-gray-100 '),
+  removeClassesIf(isDisabled)('bl-cursor-pointer bl-text-gray-100 hover:bl-text-primary'),
 )(Anchor);
 
 export const ComponentFormDefaultPanelWidth = addClasses('bl-w-xl-grid-2');

--- a/packages/gatsby-theme-bodiless/src/dist/Page.bl-edit.tsx
+++ b/packages/gatsby-theme-bodiless/src/dist/Page.bl-edit.tsx
@@ -43,6 +43,7 @@ import GatsbyNodeProvider from './GatsbyNodeProvider.bl-edit';
 import { FinalUI, UI, PageProps } from './types';
 import ShowDesignKeys from './ShowDesignKeys';
 import StaticPage from './Page.static';
+import withPageTreeButton from './withPageTreeButton';
 
 const defaultUI: FinalUI = {
   ContextWrapper,
@@ -70,6 +71,7 @@ const EditButtons: FC = () => {
   useEditButton();
   return <></>;
 };
+const PageTreeButton = withPageTreeButton(Fragment);
 
 const EditPage: FC<PropsWithChildren<PageProps>> = observer(({ children, ui, ...rest }) => {
   const { PageEditor: Editor, ContextWrapper: Wrapper } = getUI(ui);
@@ -95,6 +97,7 @@ const EditPage: FC<PropsWithChildren<PageProps>> = observer(({ children, ui, ...
               <NotificationButton />
               <Editor>
                 <EditButtons />
+                <PageTreeButton />
                 <OnNodeErrorNotification />
                 <NewPageButton />
                 <MovePageButton />


### PR DESCRIPTION
## Changes
- Adds a 'Nav' button to the main menu which allows editor to navigate from one page to another.

## Test Instructions
- Test on both vital-demo and vital-demo-next
- Launch edit environment
- Click 'nav' button
  - Use filter to fitler list of pages
  - click on a page to navigate there

## Known Issues
- in NextJS, when you create a new page it does not appear in nav until you refresh.
- In Gatsby, when you create a new page, the dialog closes immediately without offering the "go to new page" button.