### PR TITLE
chore: Add markdown extensions to recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,10 @@
     "esbenp.prettier-vscode",
     "msjsdiag.debugger-for-chrome",
     "PKief.material-icon-theme",
-    "eamodio.gitlens"
+    "eamodio.gitlens",
+    "streetsidesoftware.code-spell-checker",
+    "davidanson.vscode-markdownlint",
+    "stkb.rewrap",
+    "shardulm94.trailing-spaces",
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,7 +34,9 @@
   "editor.rulers": [
     100
   ],
+  "rewrap.wrappingColumn": 100,
   "cSpell.words": [
+    "fclasses",
     "tsbuildinfo",
     "typedoc"
   ],


### PR DESCRIPTION
## Changes

- Add the following markdown-related extensions to the list of VS Code extension recommendations:
  - [Code Spell Checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) (`streetsidesoftware.code-spell-checker`)
    - Oddly, this extension already had a config section in the `.vscode/settings.json` file (`"cSpell.words"`), but wasn't listed in the recommendations.
    - Add "fclasses" to ignored spell-checker words.
  - [markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint) (`DavidAnson.vscode-markdownlint`)
  - [Rewrap](https://marketplace.visualstudio.com/items?itemName=stkb.rewrap) (`stkb.rewrap`)
  - [Trailing Spaces](https://marketplace.visualstudio.com/items?itemName=shardulm94.trailing-spaces) (`shardulm94.trailing-spaces`)
- Add configuration for Rewrap extension to wrap lines at 100 columns.