### PR TITLE
docs: Restore API docs

### DIFF
--- a/packages/bodiless-i18n/package.json
+++ b/packages/bodiless-i18n/package.json
@@ -20,7 +20,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "npm run build:lib",
+    "build": "npm run build:lib && npm run build:api-doc",
     "build:lib": "tsc -p ./tsconfig.json",
     "build:watch": "npm run build:lib -- --watch",
     "dev": "npm run build:watch",

--- a/packages/bodiless-layouts/package.json
+++ b/packages/bodiless-layouts/package.json
@@ -27,7 +27,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "run-p build:lib",
+    "build": "run-p build:lib && npm run build:api-doc",
     "build:lib": "tsc -p ./tsconfig.json",
     "build:watch": "npm run build:lib -- --watch",
     "dev": "npm run build:watch",

--- a/packages/bodiless-schema-org/package.json
+++ b/packages/bodiless-schema-org/package.json
@@ -28,7 +28,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "npm run build:lib",
+    "build": "npm run build:lib && npm run build:api-doc",
     "build:lib": "tsc -p ./tsconfig.json",
     "build:watch": "npm run build:lib -- --watch",
     "dev": "npm run build:watch",

--- a/packages/gatsby-theme-bodiless/package.json
+++ b/packages/gatsby-theme-bodiless/package.json
@@ -44,7 +44,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "npm run copy && npm run build:lib",
+    "build": "npm run copy && npm run build:lib && npm run build:api-doc",
     "build:lib": "tsc -b ./tsconfig.json ./tsconfig.cjs.json",
     "build:watch": "tsc -b ./tsconfig.json ./tsconfig.cjs.json --watch",
     "build:api-doc": "typedoc --options ../../typedoc.js --out doc/api --tsconfig ./tsconfig.json ./src",

--- a/packages/vital-accordion/package.json
+++ b/packages/vital-accordion/package.json
@@ -22,7 +22,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsc -p ./tsconfig.json && npm run copy",
+    "build": "tsc -p ./tsconfig.json && npm run copy && npm run build:api-doc",
     "build:lib": "tsc -p ./tsconfig.json",
     "build:watch": "npm run build:lib -- --watch",
     "dev": "npm run build:watch",

--- a/packages/vital-button/package.json
+++ b/packages/vital-button/package.json
@@ -23,7 +23,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "npm run build:lib",
+    "build": "npm run build:lib && npm run build:api-doc",
     "build:lib": "tsc -p ./tsconfig.json",
     "build:watch": "npm run build:lib -- --watch",
     "dev": "npm run build:watch",

--- a/packages/vital-card/package.json
+++ b/packages/vital-card/package.json
@@ -22,7 +22,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "run-s build:lib copy",
+    "build": "run-s build:lib copy build:api-doc",
     "build:api-doc": "typedoc --options ../../typedoc.js --out doc/api src",
     "build:lib": "tsc -p ./tsconfig.json",
     "build:watch": "npm run build:lib -- --watch && npm run copy",

--- a/packages/vital-content-listing/package.json
+++ b/packages/vital-content-listing/package.json
@@ -22,7 +22,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "run-p build:lib",
+    "build": "run-p build:lib build:api-doc",
     "build:api-doc": "typedoc --out doc/api src",
     "build:lib": "tsc -p ./tsconfig.json",
     "build:watch": "npm run build:lib -- --watch",

--- a/packages/vital-demo/package.json
+++ b/packages/vital-demo/package.json
@@ -24,7 +24,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "npm run build:lib && npm run copy",
+    "build": "npm run build:lib && npm run copy && npm run build:api-doc",
     "build:lib": "tsc -p ./tsconfig.json",
     "build:watch": "npm run build:lib -- --watch",
     "dev": "npm run build:watch",

--- a/packages/vital-flowcontainer/package.json
+++ b/packages/vital-flowcontainer/package.json
@@ -22,7 +22,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "run-s build:lib",
+    "build": "run-s build:lib build:api-doc",
     "build:api-doc": "typedoc --options ../../typedoc.js --out doc/api src",
     "build:lib": "tsc -p ./tsconfig.json",
     "build:watch": "npm run build:lib -- --watch",

--- a/packages/vital-image/package.json
+++ b/packages/vital-image/package.json
@@ -22,7 +22,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "run-s build:lib copy",
+    "build": "run-s build:lib copy build:api-doc",
     "build:lib": "tsc -p ./tsconfig.json",
     "build:watch": "npm run build:lib -- --watch",
     "dev": "npm run build:watch",

--- a/packages/vital-layout/package.json
+++ b/packages/vital-layout/package.json
@@ -22,7 +22,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "run-s build:lib copy",
+    "build": "run-s build:lib copy build:api-doc",
     "build:api-doc": "typedoc --options ../../typedoc.js --out doc/api src",
     "build:lib": "tsc -p ./tsconfig.json",
     "build:watch": "npm run build:lib -- --watch",

--- a/packages/vital-list/package.json
+++ b/packages/vital-list/package.json
@@ -22,7 +22,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "run-p build:lib",
+    "build": "run-p build:lib build:api-doc",
     "build:api-doc": "typedoc --options ../../typedoc.js --out doc/api src",
     "build:lib": "tsc -p ./tsconfig.json",
     "build:watch": "npm run build:lib -- --watch",

--- a/packages/vital-meta/package.json
+++ b/packages/vital-meta/package.json
@@ -21,7 +21,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "run-p build:lib",
+    "build": "run-p build:lib build:api-doc",
     "build:api-doc": "typedoc --options ../../typedoc.js --out doc/api src",
     "build:lib": "tsc -p ./tsconfig.json",
     "build:watch": "npm run build:lib -- --watch",

--- a/packages/vital-search/package.json
+++ b/packages/vital-search/package.json
@@ -22,7 +22,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc -p ./tsconfig.json && npm run build:api-doc",
     "build:required": "npm run build",
     "build:watch": "npm run build -- --watch",
     "dev": "npm run build:watch",

--- a/packages/vital-section/package.json
+++ b/packages/vital-section/package.json
@@ -22,7 +22,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "npm run build:lib",
+    "build": "npm run build:lib && npm run build:api-doc",
     "build:lib": "tsc -p ./tsconfig.json",
     "build:watch": "npm run build:lib -- --watch",
     "dev": "npm run build:watch",

--- a/packages/vital-table/package.json
+++ b/packages/vital-table/package.json
@@ -23,7 +23,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "run-p build:lib",
+    "build": "run-p build:lib build:api-doc",
     "build:api-doc": "typedoc --options ../../typedoc.js --out doc/api src",
     "build:lib": "tsc -p ./tsconfig.json",
     "build:watch": "npm run build:lib -- --watch",

--- a/packages/vital-templates/package.json
+++ b/packages/vital-templates/package.json
@@ -22,7 +22,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "run-p build:lib",
+    "build": "run-p build:lib build:api-doc",
     "build:api-doc": "typedoc --options ../../typedoc.js --out doc/api ./src",
     "build:lib": "tsc -p ./tsconfig.json",
     "build:watch": "npm run build:lib -- --watch",

--- a/packages/vital-youtube/package.json
+++ b/packages/vital-youtube/package.json
@@ -21,7 +21,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "npm run build:lib",
+    "build": "npm run build:lib && npm run build:api-doc",
     "build:lib": "tsc -p ./tsconfig.json",
     "build:watch": "npm run build:lib -- --watch",
     "dev": "npm run build:watch",


### PR DESCRIPTION
## Changes

- Restore Bodiless/Vital API docs in the Bodiless documentation.
  - This commit reverses commit 3e97fa59da599c5ad08873a5e89c77c2897d0590.
    - See: <https://github.com/johnsonandjohnson/Bodiless-JS/pull/2110/commits/3e97fa59da599c5ad08873a5e89c77c2897d0590>

## Test Instructions

01. Run `test-site` docs.
    ```
    cd sites/test-site
    npm run docs
    ```
02. Go to http://localhost:3000/#/Development/API/.
03. See that a number of packages (12) are listed.